### PR TITLE
Remove `--include` flag from `.curlrc` to prevent corruption of downloaded files using `curl`

### DIFF
--- a/lib/configurations/curl/curlrc
+++ b/lib/configurations/curl/curlrc
@@ -20,9 +20,6 @@
 # (HTTP) Request a compressed response using one of the algorithms curl supports, and save the uncompressed document.
 --compressed
 
-# Include HTTP headers in the output.
---include
-
 # Resolve names to IPV4 addresses only.
 --ipv4
 


### PR DESCRIPTION
The --include flag in .curlrc was causing downloaded files to become corrupted due to the inclusion of HTTP headers in the output. Removing this flag resolves the issue and ensures that downloaded files remain intact.