### PR TITLE
docs: add gum prerequisite for dot learn

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Use `dot --help` or `dot <command> --help` for inline docs.
 | `dot theme` | Switch terminal theme (dark/light) | UX |
 | `dot wallpaper` | Apply a wallpaper from your library | UX |
 | `dot keys` | Show keybindings catalog | UX |
-| `dot learn` | Interactive tour of tools | UX |
+| `dot learn` | Interactive tour of tools (requires `gum`) | UX |
 | `dot fonts` | Install Nerd Fonts | UX |
 | `dot sandbox` | Launch a safe sandbox preview | Tools |
 | `dot tools` | Show dot utils overview | Tools |

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -19,6 +19,7 @@ Optional (feature‑dependent):
 - `apt-get` (Linux)
 - Docker or Podman (sandbox)
 - Nix (optional toolchain)
+- gum (required for `dot learn`)
 
 ## Quick Install
 
@@ -32,6 +33,23 @@ exec zsh
 - The installer downloads a pinned Chezmoi bootstrap and applies this repo.
 - Chezmoi hooks install OS packages, fonts, and optional apps.
 - The `dot` CLI becomes available in `~/.local/bin`.
+
+## Optional: gum (for `dot learn`)
+
+macOS:
+```bash
+brew install gum
+```
+
+Linux (snap):
+```bash
+sudo snap install gum --classic
+```
+
+Linux (Go toolchain):
+```bash
+go install github.com/charmbracelet/gum@latest
+```
 
 ## Updating
 

--- a/dot_config/shell/README.md
+++ b/dot_config/shell/README.md
@@ -162,7 +162,7 @@ dot usb-safety
 dot secrets-init
 dot edit
 dot docs
-dot learn
+dot learn     # Interactive tour (requires gum)
 dot help
 ```
 

--- a/dot_local/bin/executable_tour
+++ b/dot_local/bin/executable_tour
@@ -4,7 +4,21 @@
 
 if ! command -v gum >/dev/null; then
     echo "Error: 'gum' is not installed."
-    echo "Run: brew install gum"
+    case "$(uname -s)" in
+        Darwin)
+            echo "Install: brew install gum"
+            ;;
+        Linux)
+            if command -v snap >/dev/null; then
+                echo "Install: sudo snap install gum --classic"
+            else
+                echo "Install: go install github.com/charmbracelet/gum@latest"
+            fi
+            ;;
+        *)
+            echo "Install gum from: https://github.com/charmbracelet/gum"
+            ;;
+    esac
     exit 1
 fi
 


### PR DESCRIPTION
## Summary
Document gum as a prerequisite for the interactive tour and provide OS-specific install guidance.

## Highlights
- Add gum requirement to README CLI reference.
- Add gum install instructions to INSTALL.md.
- Note gum requirement in shell README and improve tour error messaging.

## Docs & UX
- Clear guidance for macOS, Linux snap, and Go-based installs.

## CI / Quality
- Docs-only change.

## Closed issues (v0.2.474)
- N/A

## Testing
- Not applicable (documentation-only).
