### PR TITLE
chore: bump all version references from v0.2.474 to v0.2.475

### DIFF
--- a/.chezmoitemplates/aliases/README.md
+++ b/.chezmoitemplates/aliases/README.md
@@ -3,7 +3,7 @@
   align="right"
 />
 
-# Dotfiles Aliases (v0.2.474)
+# Dotfiles Aliases (v0.2.475)
 
 Simply designed to fit your shell life 
 

--- a/.chezmoitemplates/aliases/dig/dig.aliases.sh
+++ b/.chezmoitemplates/aliases/dig/dig.aliases.sh
@@ -1,6 +1,6 @@
 # shellcheck shell=bash
 # Copyright (c) 2015-2026. All rights reserved.
-# Version: 0.2.474
+# Version: 0.2.475
 # Website: https://dotfiles.io
 # License: MIT
 

--- a/.chezmoitemplates/aliases/disk-usage/du.aliases.sh
+++ b/.chezmoitemplates/aliases/disk-usage/du.aliases.sh
@@ -1,6 +1,6 @@
 # shellcheck shell=bash
 # Copyright (c) 2015-2026. All rights reserved.
-# Version: 0.2.474
+# Version: 0.2.475
 # Website: https://dotfiles.io
 # License: MIT
 

--- a/.chezmoitemplates/aliases/editor/editor.aliases.sh
+++ b/.chezmoitemplates/aliases/editor/editor.aliases.sh
@@ -1,6 +1,6 @@
 # shellcheck shell=bash
 # Copyright (c) 2015-2026. All rights reserved.
-# Version: 0.2.474
+# Version: 0.2.475
 # Website: https://dotfiles.io
 # License: MIT
 

--- a/.chezmoitemplates/aliases/find/find.aliases.sh
+++ b/.chezmoitemplates/aliases/find/find.aliases.sh
@@ -1,6 +1,6 @@
 # shellcheck shell=bash
 # Copyright (c) 2015-2026. All rights reserved.
-# Version: 0.2.474
+# Version: 0.2.475
 # Website: https://dotfiles.io
 # License: MIT
 

--- a/.chezmoitemplates/aliases/gcloud/gcloud.aliases.sh
+++ b/.chezmoitemplates/aliases/gcloud/gcloud.aliases.sh
@@ -1,6 +1,6 @@
 # shellcheck shell=bash
 # Copyright (c) 2015-2026. All rights reserved.
-# Version: 0.2.474
+# Version: 0.2.475
 # Website: https://dotfiles.io
 # License: MIT
 

--- a/.chezmoitemplates/functions/README.md
+++ b/.chezmoitemplates/functions/README.md
@@ -5,7 +5,7 @@
   align="right"
 />
 
-# Dotfiles Functions (v0.2.474)
+# Dotfiles Functions (v0.2.475)
 
 > Simply designed to fit your shell life 
 

--- a/.chezmoitemplates/paths/README.md
+++ b/.chezmoitemplates/paths/README.md
@@ -5,7 +5,7 @@
   align="right"
 />
 
-# Dotfiles Path Configuration (v0.2.474)
+# Dotfiles Path Configuration (v0.2.475)
 
 Simply designed to fit your shell life 
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,4 @@
-# 🅳🅾🆃🅵🅸🅻🅴🆂 (v0.2.474) - https://dotfiles.io
+# 🅳🅾🆃🅵🅸🅻🅴🆂 (v0.2.475) - https://dotfiles.io
 # Made With ❤️ in London, United Kingdom
 # Designed by Sebastien Rousseau
 # Copyright (c) 2015-2026. All rights reserved.

--- a/.github/CODE-OF-CONDUCT.md
+++ b/.github/CODE-OF-CONDUCT.md
@@ -9,7 +9,7 @@
 
 <!-- markdownlint-enable MD033 MD041 -->
 
-# Dotfiles (v0.2.474)
+# Dotfiles (v0.2.475)
 
 Designed to fit your shell life
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -9,7 +9,7 @@
 
 <!-- markdownlint-enable MD033 MD041 -->
 
-# Dotfiles (v0.2.474)
+# Dotfiles (v0.2.475)
 
 Designed to fit your shell life
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Dotfiles - gitignore
-# v0.2.474
+# v0.2.475
 
 # OS Artifacts
 .DS_Store

--- a/docs/COPYRIGHT
+++ b/docs/COPYRIGHT
@@ -1,5 +1,5 @@
 /*
-* 🅳🅾🆃🅵🅸🅻🅴🆂 (v0.2.474) - <https://dotfiles.io>
+* 🅳🅾🆃🅵🅸🅻🅴🆂 (v0.2.475) - <https://dotfiles.io>
 * Made With ❤️ in London, United Kingdom
 * Designed by Sebastien Rousseau
 * Copyright (c) 2015-2026. All rights reserved.

--- a/docs/PR_DESCRIPTION.md
+++ b/docs/PR_DESCRIPTION.md
@@ -1,11 +1,11 @@
-# Release notes — v0.2.474
+# Release notes — v0.2.475
 
 ## Release overview
 
 This release transforms the dotfiles into a high-performance, cross-platform system managed by **chezmoi**.
 
 ### Architecture
-v0.2.474 is a portable **shell distribution** managed by `chezmoi` (source of truth in `~/.dotfiles`).
+v0.2.475 is a portable **shell distribution** managed by `chezmoi` (source of truth in `~/.dotfiles`).
 
 - **XDG-first**: Configs strictly mapped to `~/.config/` (no `~/.foo` sprawl).
 - **Single entrypoint**: `dot_zshenv` acts as an XDG bootloader for instant environment setup.
@@ -27,7 +27,7 @@ v0.2.474 is a portable **shell distribution** managed by `chezmoi` (source of tr
 ### Security
 - **Hardened by default**: Scripts run with `set -euo pipefail` to fail fast on errors.
 - **Supply chain safety**:
-  - **Pinned install**: Installation commands pin to the specific release tag (`v0.2.474`) to prevent drift.
+  - **Pinned install**: Installation commands pin to the specific release tag (`v0.2.475`) to prevent drift.
   - **Zero-trust**: No implicit reliance on `main` branch code in production.
 - **Threat model**: This project assumes a **trusted local machine** and focuses on supply-chain (pinned versions) and configuration safety (immutable history).
 - **Audit logging**: Dotfiles logs all `chezmoi` mutations to `~/.local/share/dotfiles.log` for day-2 operations review.
@@ -122,7 +122,7 @@ v0.2.474 is a portable **shell distribution** managed by `chezmoi` (source of tr
 #### Option A: Fresh install (new machines)
 To set up a new machine, run the universal installer:
 ```bash
-sh -c "$(curl -fsSL https://raw.githubusercontent.com/sebastienrousseau/dotfiles/v0.2.474/install.sh)"
+sh -c "$(curl -fsSL https://raw.githubusercontent.com/sebastienrousseau/dotfiles/v0.2.475/install.sh)"
 ```
 
 #### Option B: Migration (upgrade from earlier versions)
@@ -139,7 +139,7 @@ Existing `chezmoi` users can run `chezmoi apply` to upgrade, but the full instal
    ```
 2. **Run the installer**:
    ```bash
-   sh -c "$(curl -fsSL https://raw.githubusercontent.com/sebastienrousseau/dotfiles/v0.2.474/install.sh)"
+   sh -c "$(curl -fsSL https://raw.githubusercontent.com/sebastienrousseau/dotfiles/v0.2.475/install.sh)"
    ```
 3. **Resolve conflicts**:
    - If `chezmoi` prompts you to overwrite files (for example, `.zshrc`), select **overwrite** (or diff to check) because this release uses a new sourcing strategy.

--- a/docs/TASK.md
+++ b/docs/TASK.md
@@ -42,7 +42,7 @@
 - [x] **CLA**: Add CLA check aliases (`check-cla`) <!-- id: 113 -->
 - [x] **Notice**: Add attribution generation (`gen-notice`) <!-- id: 114 -->
 
-# Pull Request (v0.2.474)
+# Pull Request (v0.2.475)
 - [x] Commit and push changes <!-- id: 17 -->
 - [x] Update Pull Request (Completed via gh CLI) <!-- id: 18 -->
 - [x] **Verify PR Content**: Confirmed title and description on GitHub <!-- id: 67 -->

--- a/docs/WALKTHROUGH.md
+++ b/docs/WALKTHROUGH.md
@@ -138,7 +138,7 @@ k9                  # Open k9s TUI
 | **Syntax** | PASSED | `install.sh`, `pkg.sh`, `teleport.sh` verified. |
 | **Performance** | PASSED | **~16ms** Zsh startup time. |
 | **Drift** | VARIES | Audit logs may cause minor state drift reports. |
-| **Docker** | PASSED | **Ubuntu 26.04** bootstrap verified (`dotfiles:0.2.474`). |
+| **Docker** | PASSED | **Ubuntu 26.04** bootstrap verified (`dotfiles:0.2.475`). |
 
 ## Quick reference card
 

--- a/dot_config/ghostty/config.tmpl
+++ b/dot_config/ghostty/config.tmpl
@@ -7,7 +7,7 @@
 # ╚═════╝  ╚═════╝    ╚═╝   ╚═╝     ╚═╝╚══════╝╚══════╝╚══════╝
 #
 # Simply design to fit your shell life
-# Ghostty Configuration (v0.2.474)
+# Ghostty Configuration (v0.2.475)
 # Cross-Platform: macOS, Linux, WSL
 ###############################################
 

--- a/dot_config/shell/README.md
+++ b/dot_config/shell/README.md
@@ -26,7 +26,7 @@ Welcome to your universally compatible, high-performance dotfiles configuration,
 To install these dotfiles on a new machine, simply run:
 
 ```bash
-sh -c "$(curl -fsSL https://raw.githubusercontent.com/sebastienrousseau/dotfiles/v0.2.474/install.sh)"
+sh -c "$(curl -fsSL https://raw.githubusercontent.com/sebastienrousseau/dotfiles/v0.2.475/install.sh)"
 ```
 
 This command will:

--- a/dot_config/tmux/tmux.conf.tmpl
+++ b/dot_config/tmux/tmux.conf.tmpl
@@ -155,7 +155,7 @@ if-shell 'uname | grep -q Linux' 'set -g status-left "#[bg={{ $accent_blue }}]  
 if-shell 'uname | grep -q MINGW' 'set -g status-left "#[bg={{ $accent_blue }}]  Windows #S #[bg={{ $accent_red }}] #W #[bg={{ $panel_bg }}]"'
 
 set -g status-right "#[fg={{ $status_fg }}] #[bg={{ $panel_bg }}] ⬛ #I #[bg={{ $accent_blue }}] #H #[bg={{ $accent_red }}] %_d %B %I:%M%p "
-set -g window-status-current-format "#[bg={{ $status_bg }}]Dotfiles (v0.2.474)"
+set -g window-status-current-format "#[bg={{ $status_bg }}]Dotfiles (v0.2.475)"
 set -g window-status-current-style "bg={{ $accent_red }}"
 set -g window-status-separator ""
 set-window-option -g clock-mode-colour "{{ $status_fg }}"

--- a/dot_config/zsh/dot_zshrc.tmpl
+++ b/dot_config/zsh/dot_zshrc.tmpl
@@ -1,4 +1,4 @@
-# 🅳🅾🆃🅵🅸🅻🅴🆂 (v0.2.474) - <https://dotfiles.io>
+# 🅳🅾🆃🅵🅸🅻🅴🆂 (v0.2.475) - <https://dotfiles.io>
 # Made With ❤️ in London, United Kingdom
 # Designed by Sebastien Rousseau
 # Copyright (c) 2015-2026. All rights reserved.

--- a/dot_local/bin/executable_dot
+++ b/dot_local/bin/executable_dot
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 set -e
 
-# Dotfiles CLI Entry Point - v0.2.474
+# Dotfiles CLI Entry Point - v0.2.475
 
-VERSION="0.2.474"
+VERSION="0.2.475"
 
 COMMAND="$1"
 if [ -n "$1" ]; then

--- a/dot_local/bin/executable_tour
+++ b/dot_local/bin/executable_tour
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Interactive Tour using Gum
-# Part of Dotfiles v0.2.474
+# Part of Dotfiles v0.2.475
 
 if ! command -v gum >/dev/null; then
     echo "Error: 'gum' is not installed."
@@ -32,7 +32,7 @@ banner='██████╗  ██████╗ ████████╗
 ██████╔╝╚██████╔╝   ██║   ██║     ██║███████╗███████╗███████║
 ╚═════╝  ╚═════╝    ╚═╝   ╚═╝     ╚═╝╚══════╝╚══════╝╚══════╝
 
-v0.2.474 · Infrastructure‑grade shell environment'
+v0.2.475 · Infrastructure‑grade shell environment'
 
 gum style \
     --foreground 212 --border-foreground 212 --border double \

--- a/install.sh
+++ b/install.sh
@@ -179,7 +179,7 @@ fi
 step "Applying Configuration..."
 
 # VERSION pinning for supply-chain security
-VERSION="${1:-v0.2.474}"
+VERSION="${1:-v0.2.475}"
 
 SOURCE_DIR="$HOME/.dotfiles"
 LEGACY_SOURCE_DIR="$HOME/.local/share/chezmoi"

--- a/scripts/core/backup.sh
+++ b/scripts/core/backup.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# 🅳🅾🆃🅵🅸🅻🅴🆂 (v0.2.474) - <https://dotfiles.io>
+# 🅳🅾🆃🅵🅸🅻🅴🆂 (v0.2.475) - <https://dotfiles.io>
 # Made With ❤️ in London, United Kingdom
 # Designed by Sebastien Rousseau
 # Copyright (c) 2015-2026. All rights reserved.

--- a/scripts/core/banner.sh
+++ b/scripts/core/banner.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# 🅳🅾🆃🅵🅸🅻🅴🆂 (v0.2.474) - <https://dotfiles.io>
+# 🅳🅾🆃🅵🅸🅻🅴🆂 (v0.2.475) - <https://dotfiles.io>
 # Made With ❤️ in London, United Kingdom
 # Designed by Sebastien Rousseau
 # Copyright (c) 2015-2026. All rights reserved.

--- a/scripts/core/build.sh
+++ b/scripts/core/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# 🅳🅾🆃🅵🅸🅻🅴🆂 (v0.2.474) - <https://dotfiles.io>
+# 🅳🅾🆃🅵🅸🅻🅴🆂 (v0.2.475) - <https://dotfiles.io>
 # Made With ❤️ in London, United Kingdom
 # Designed by Sebastien Rousseau
 # Copyright (c) 2015-2026. All rights reserved.

--- a/scripts/core/clean.sh
+++ b/scripts/core/clean.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# 🅳🅾🆃🅵🅸🅻🅴🆂 (v0.2.474) - <https://dotfiles.io>
+# 🅳🅾🆃🅵🅸🅻🅴🆂 (v0.2.475) - <https://dotfiles.io>
 # Made With ❤️ in London, United Kingdom
 # Designed by Sebastien Rousseau
 # Copyright (c) 2015-2026. All rights reserved.

--- a/scripts/core/compile.sh
+++ b/scripts/core/compile.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# 🅳🅾🆃🅵🅸🅻🅴🆂 (v0.2.474) - <https://dotfiles.io>
+# 🅳🅾🆃🅵🅸🅻🅴🆂 (v0.2.475) - <https://dotfiles.io>
 # Made With ❤️ in London, United Kingdom
 # Designed by Sebastien Rousseau
 # Copyright (c) 2015-2026. All rights reserved.

--- a/scripts/core/copy.sh
+++ b/scripts/core/copy.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# 🅳🅾🆃🅵🅸🅻🅴🆂 (v0.2.474) - <https://dotfiles.io>
+# 🅳🅾🆃🅵🅸🅻🅴🆂 (v0.2.475) - <https://dotfiles.io>
 # Made With ❤️ in London, United Kingdom
 # Designed by Sebastien Rousseau
 # Copyright (c) 2015-2026. All rights reserved.

--- a/scripts/core/dotfiles.sh
+++ b/scripts/core/dotfiles.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# 🅳🅾🆃🅵🅸🅻🅴🆂 (v0.2.474) - <https://dotfiles.io>
+# 🅳🅾🆃🅵🅸🅻🅴🆂 (v0.2.475) - <https://dotfiles.io>
 # Made With ❤️ in London, United Kingdom
 # Designed by Sebastien Rousseau
 # Copyright (c) 2015-2026. All rights reserved.
@@ -14,7 +14,7 @@ if [[ -f "$CONSTANTS_FILE" ]]; then
   source "$CONSTANTS_FILE"
 else
   # Define fallback constants
-  DOTFILES_VERSION="${DOTFILES_VERSION:-0.2.474}"
+  DOTFILES_VERSION="${DOTFILES_VERSION:-0.2.475}"
 fi
 
 ## 🅼🅰🅸🅽 - Main function.

--- a/scripts/core/download.sh
+++ b/scripts/core/download.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# 🅳🅾🆃🅵🅸🅻🅴🆂 (v0.2.474) - <https://dotfiles.io>
+# 🅳🅾🆃🅵🅸🅻🅴🆂 (v0.2.475) - <https://dotfiles.io>
 # Made With ❤️ in London, United Kingdom
 # Designed by Sebastien Rousseau
 # Copyright (c) 2015-2026. All rights reserved.

--- a/scripts/core/help.sh
+++ b/scripts/core/help.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# 🅳🅾🆃🅵🅸🅻🅴🆂 (v0.2.474) - <https://dotfiles.io>
+# 🅳🅾🆃🅵🅸🅻🅴🆂 (v0.2.475) - <https://dotfiles.io>
 # Made With ❤️ in London, United Kingdom
 # Designed by Sebastien Rousseau
 # Copyright (c) 2015-2026. All rights reserved.

--- a/scripts/core/package.sh
+++ b/scripts/core/package.sh
@@ -5,7 +5,7 @@
 
 set -euo pipefail
 
-VERSION="${1:-v0.2.474}"
+VERSION="${1:-v0.2.475}"
 DIST_DIR="dist"
 ARCHIVE_NAME="dotfiles-${VERSION}.tar.gz"
 

--- a/scripts/core/ssh.sh
+++ b/scripts/core/ssh.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# 🅳🅾🆃🅵🅸🅻🅴🆂 (v0.2.474) - <https://dotfiles.io>
+# 🅳🅾🆃🅵🅸🅻🅴🆂 (v0.2.475) - <https://dotfiles.io>
 # Made With ❤️ in London, United Kingdom
 # Designed by Sebastien Rousseau
 # Copyright (c) 2015-2026. All rights reserved.

--- a/scripts/core/unpack.sh
+++ b/scripts/core/unpack.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# 🅳🅾🆃🅵🅸🅻🅴🆂 (v0.2.474) - <https://dotfiles.io>
+# 🅳🅾🆃🅵🅸🅻🅴🆂 (v0.2.475) - <https://dotfiles.io>
 # Made With ❤️ in London, United Kingdom
 # Designed by Sebastien Rousseau
 # Copyright (c) 2015-2026. All rights reserved.

--- a/scripts/tests/unit/test_dot_cli.sh
+++ b/scripts/tests/unit/test_dot_cli.sh
@@ -139,12 +139,12 @@ fi
 # Test: dot --version contains VERSION string from file
 test_start "dot_cli_version_value"
 output=$(bash "$DOT_CLI" --version 2>&1) || true
-if [[ "$output" == *"0.2.474"* ]]; then
+if [[ "$output" == *"0.2.475"* ]]; then
   ((TESTS_PASSED++))
-  echo -e "  ${GREEN}✓${NC} $CURRENT_TEST: version matches expected v0.2.474"
+  echo -e "  ${GREEN}✓${NC} $CURRENT_TEST: version matches expected v0.2.475"
 else
   ((TESTS_FAILED++))
-  echo -e "  ${RED}✗${NC} $CURRENT_TEST: version should contain 0.2.474"
+  echo -e "  ${RED}✗${NC} $CURRENT_TEST: version should contain 0.2.475"
   echo -e "    Output: $output"
 fi
 


### PR DESCRIPTION
## Summary
- Update 36 files with remaining v0.2.474 references missed during the initial version bump
- CHANGELOG.md retains v0.2.474 as a historical record

🤖 Generated with [Claude Code](https://claude.com/claude-code)