### PR TITLE
refactor: migrate appearance/security OS branching to platform abstraction

### DIFF
--- a/scripts/dot/commands/appearance.sh
+++ b/scripts/dot/commands/appearance.sh
@@ -24,13 +24,15 @@ cmd_fonts() {
 
 cmd_tune() {
   local src_dir
+  local platform
   src_dir="$(require_source_dir)"
+  platform="$(dot_platform_id)"
 
-  case "$(uname -s)" in
-    Darwin)
+  case "$platform" in
+    macos)
       exec bash "$src_dir/scripts/tuning/macos.sh" "$@"
       ;;
-    Linux)
+    linux | wsl)
       exec bash "$src_dir/scripts/tuning/linux.sh" "$@"
       ;;
     *)

--- a/scripts/security/dns-doh.sh
+++ b/scripts/security/dns-doh.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../dot/lib/ui.sh
 source "$SCRIPT_DIR/../dot/lib/ui.sh"
+# shellcheck source=../dot/lib/platform.sh
+source "$SCRIPT_DIR/../dot/lib/platform.sh"
 
 ui_init
 ui_header "DNS-over-HTTPS"
@@ -14,8 +16,8 @@ if [ "${DOTFILES_DOH:-}" != "1" ]; then
   exit 1
 fi
 
-case "$(uname -s)" in
-  Linux)
+case "$(dot_platform_id)" in
+  linux | wsl)
     if command -v resolvectl >/dev/null; then
       ui_info "Enabling" "systemd-resolved DoH (Cloudflare)"
       sudo resolvectl dns-over-https on
@@ -25,7 +27,7 @@ case "$(uname -s)" in
       exit 1
     fi
     ;;
-  Darwin)
+  macos)
     ui_info "Configure" "DoH in your browser"
     exit 0
     ;;

--- a/scripts/security/encryption-check.sh
+++ b/scripts/security/encryption-check.sh
@@ -4,12 +4,14 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../dot/lib/ui.sh
 source "$SCRIPT_DIR/../dot/lib/ui.sh"
+# shellcheck source=../dot/lib/platform.sh
+source "$SCRIPT_DIR/../dot/lib/platform.sh"
 
 ui_init
 ui_header "Encryption Check"
 
-case "$(uname -s)" in
-  Darwin)
+case "$(dot_platform_id)" in
+  macos)
     if command -v fdesetup >/dev/null; then
       status=$(fdesetup status || true)
       echo "$status"
@@ -24,7 +26,7 @@ case "$(uname -s)" in
       exit 1
     fi
     ;;
-  Linux)
+  linux | wsl)
     if command -v lsblk >/dev/null; then
       lsblk_output=$(lsblk -f)
       if command -v rg >/dev/null; then

--- a/scripts/security/firewall.sh
+++ b/scripts/security/firewall.sh
@@ -38,6 +38,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../dot/lib/ui.sh
 source "$SCRIPT_DIR/../dot/lib/ui.sh"
+# shellcheck source=../dot/lib/platform.sh
+source "$SCRIPT_DIR/../dot/lib/platform.sh"
 
 ui_init
 ui_header "Firewall"
@@ -48,15 +50,15 @@ if [ "${DOTFILES_FIREWALL:-}" != "1" ]; then
   exit 1
 fi
 
-case "$(uname -s)" in
-  Darwin)
+case "$(dot_platform_id)" in
+  macos)
     ui_info "Enabling" "macOS firewall"
     sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setglobalstate on
     sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setallowsigned on
     sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setallowsignedapp on
     sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setstealthmode on
     ;;
-  Linux)
+  linux | wsl)
     if command -v ufw >/dev/null; then
       ui_info "Enabling" "UFW"
       sudo ufw default deny incoming

--- a/scripts/security/lock-screen.sh
+++ b/scripts/security/lock-screen.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../dot/lib/ui.sh
 source "$SCRIPT_DIR/../dot/lib/ui.sh"
+# shellcheck source=../dot/lib/platform.sh
+source "$SCRIPT_DIR/../dot/lib/platform.sh"
 
 ui_init
 ui_header "Lock Screen"
@@ -14,8 +16,8 @@ if [ "${DOTFILES_LOCK:-}" != "1" ]; then
   exit 1
 fi
 
-case "$(uname -s)" in
-  Linux)
+case "$(dot_platform_id)" in
+  linux | wsl)
     if command -v gsettings >/dev/null; then
       ui_info "Enabling" "screen lock and idle timeout"
       gsettings set org.gnome.desktop.screensaver lock-enabled true || true
@@ -26,7 +28,7 @@ case "$(uname -s)" in
       exit 1
     fi
     ;;
-  Darwin)
+  macos)
     ui_info "Enabling" "lock on sleep and screensaver (macOS)"
     defaults write com.apple.screensaver askForPassword -int 1 || true
     defaults write com.apple.screensaver askForPasswordDelay -int 0 || true

--- a/scripts/security/telemetry-kill.sh
+++ b/scripts/security/telemetry-kill.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../dot/lib/ui.sh
 source "$SCRIPT_DIR/../dot/lib/ui.sh"
+# shellcheck source=../dot/lib/platform.sh
+source "$SCRIPT_DIR/../dot/lib/platform.sh"
 
 ui_init
 ui_header "Telemetry"
@@ -14,8 +16,8 @@ if [ "${DOTFILES_TELEMETRY:-}" != "1" ]; then
   exit 1
 fi
 
-case "$(uname -s)" in
-  Linux)
+case "$(dot_platform_id)" in
+  linux | wsl)
     ui_info "Disabling" "Ubuntu crash reporting (whoopsie/apport)"
     sudo systemctl disable --now whoopsie 2>/dev/null || true
     sudo systemctl disable --now apport 2>/dev/null || true
@@ -23,7 +25,7 @@ case "$(uname -s)" in
     ui_info "Disabling" "popularity-contest"
     sudo systemctl disable --now popularity-contest 2>/dev/null || true
     ;;
-  Darwin)
+  macos)
     ui_info "Disabling" "macOS analytics"
     sudo defaults write /Library/Application\ Support/CrashReporter/DiagnosticMessagesHistory.plist AutoSubmit -bool false || true
     sudo defaults write /Library/Application\ Support/CrashReporter/DiagnosticMessagesHistory.plist ThirdPartyDataSubmit -bool false || true

--- a/scripts/security/usb-safety.sh
+++ b/scripts/security/usb-safety.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../dot/lib/ui.sh
 source "$SCRIPT_DIR/../dot/lib/ui.sh"
+# shellcheck source=../dot/lib/platform.sh
+source "$SCRIPT_DIR/../dot/lib/platform.sh"
 
 ui_init
 ui_header "USB Safety"
@@ -14,8 +16,8 @@ if [ "${DOTFILES_USB_SAFETY:-}" != "1" ]; then
   exit 1
 fi
 
-case "$(uname -s)" in
-  Linux)
+case "$(dot_platform_id)" in
+  linux | wsl)
     if command -v gsettings >/dev/null; then
       ui_info "Disabling" "GNOME automount for removable media"
       gsettings set org.gnome.desktop.media-handling automount false || true
@@ -25,7 +27,7 @@ case "$(uname -s)" in
       exit 1
     fi
     ;;
-  Darwin)
+  macos)
     ui_info "macOS" "no CLI toggle for USB automount"
     ui_info "Use" "System Settings > General > Login Items > External disks"
     ;;


### PR DESCRIPTION
## Summary
- migrate `dot tune` and core security scripts from direct `uname` branching to shared `dot_platform_id`
- source `scripts/dot/lib/platform.sh` in security modules
- treat `wsl` as Linux execution path where applicable

## Files
- `scripts/dot/commands/appearance.sh`
- `scripts/security/firewall.sh`
- `scripts/security/encryption-check.sh`
- `scripts/security/lock-screen.sh`
- `scripts/security/dns-doh.sh`
- `scripts/security/telemetry-kill.sh`
- `scripts/security/usb-safety.sh`

## Validation
- `bash -n` on all touched scripts
- `bash scripts/tests/unit/test_dot_commands_appearance.sh`
- `bash scripts/tests/unit/test_security_firewall.sh`
- `bash scripts/tests/unit/test_security_encryption.sh`
- `bash scripts/tests/unit/test_security_lock_screen.sh`
- `bash scripts/tests/unit/test_security_dns_doh.sh`
- `bash scripts/tests/unit/test_security_telemetry.sh`
- `bash scripts/tests/unit/test_security_usb_safety.sh`
