### PR TITLE
ci: fix SBOM release attach permission error on tag runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,6 +191,9 @@ jobs:
         with:
           format: cyclonedx-json
           output-file: sbom.cyclonedx.json
+          # CI only needs artifact upload; release attachment is handled in
+          # security-release.yml where permissions are elevated intentionally.
+          upload-release-assets: false
       - name: Upload SBOM
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:


### PR DESCRIPTION
## Fix
- disable `upload-release-assets` in CI SBOM job (`.github/workflows/ci.yml`)

## Why
CI runs with read-only `contents` permissions and the Anchore SBOM action attempted to attach assets to release tags, causing:
`Resource not accessible by integration`.

Release asset publication is already handled by `.github/workflows/security-release.yml` with explicit write permissions.

## Result
- CI SBOM generation still runs
- artifact upload still works
- no release-attachment attempt from CI, so tag workflows stop failing on permission errors
