### PR TITLE
fix(cli): wire up missing diagnostic commands

### DIFF
--- a/dot_local/bin/executable_dot
+++ b/dot_local/bin/executable_dot
@@ -45,6 +45,9 @@ show_help() {
     echo "  doctor      Check system health and configuration"
     echo "  heal        Auto-repair common dotfiles issues"
     echo "  health      Run comprehensive health check"
+    echo "  verify      Run security and integrity verification"
+    echo "  scorecard   System health and security scorecard"
+    echo "  snapshot    Capture baseline system snapshot"
     echo "  smoke-test  Run automated toolchain verification"
     echo "  chaos       Simulate config corruption to test self-healing"
     echo "  bundle      Create offline archive of dotfiles environment"
@@ -292,6 +295,9 @@ case "$COMMAND" in
     heal) run_script "scripts/ops/heal.sh" "Heal script" "$@" ;;
     health|health-check) run_script "scripts/ops/health-check.sh" "Health check script" "$@" ;;
     smoke-test) run_script "scripts/diagnostics/smoke-test.sh" "Smoke test script" "$@" ;;
+    verify) run_script "scripts/diagnostics/verify.sh" "Verification script" "$@" ;;
+    scorecard) run_script "scripts/diagnostics/scorecard.sh" "Scorecard script" "$@" ;;
+    snapshot) run_script "scripts/diagnostics/snapshot.sh" "Snapshot script" "$@" ;;
     chaos) run_script "scripts/ops/chaos.sh" "Chaos engineering script" "$@" ;;
     bundle) run_script "scripts/ops/bundle.sh" "Offline bundle script" "$@" ;;
     rollback) run_script "scripts/ops/rollback.sh" "Rollback script" "$@" ;;

--- a/scripts/tests/unit/test_dot_cli_new_commands.sh
+++ b/scripts/tests/unit/test_dot_cli_new_commands.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Copyright (c) 2015-2026 Sebastien Rousseau. All rights reserved.
+# shellcheck disable=SC1090,SC1091,SC2034
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+source "$SCRIPT_DIR/../framework/assertions.sh"
+
+DOT_CLI="$REPO_ROOT/dot_local/bin/executable_dot"
+
+test_start "dot_cli_has_verify"
+assert_file_contains "$DOT_CLI" "verify)" "dot CLI should handle verify command"
+
+test_start "dot_cli_has_scorecard"
+assert_file_contains "$DOT_CLI" "scorecard)" "dot CLI should handle scorecard command"
+
+test_start "dot_cli_has_snapshot"
+assert_file_contains "$DOT_CLI" "snapshot)" "dot CLI should handle snapshot command"
+
+test_start "dot_help_shows_verify"
+output=$("$DOT_CLI" help)
+if echo "$output" | grep -q "verify"; then
+  ((TESTS_PASSED++))
+  printf '%b
+' "  ${GREEN}✓${NC} $CURRENT_TEST: verify in help"
+else
+  ((TESTS_FAILED++))
+  printf '%b
+' "  ${RED}✗${NC} $CURRENT_TEST: verify NOT in help"
+fi
+
+echo "RESULTS:$TESTS_RUN:$TESTS_PASSED:$TESTS_FAILED"


### PR DESCRIPTION
Restores missing command dispatchers for verify, scorecard, and snapshot that were documented but not wired into the CLI case block.