### PR TITLE
fix(ci): restore NPM_TOKEN auth in npm-publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -34,9 +34,15 @@ jobs:
           fi
           cat package.json
 
-      # Trusted Publishing with OIDC (no token required)
-      # Configure at: npmjs.com → Packages → @sebastienrousseau/dotfiles → Settings → Trusted publishing
-      - name: Publish to npm (OIDC Trusted Publishing)
+      # Publish with NPM_TOKEN auth + --provenance (SLSA Level 3 attestation).
+      # Trusted Publishing (OIDC) is the eventual target, but it requires the
+      # package's "Trusted publishing" settings to be configured on npmjs.com
+      # first; until that's done, token auth is the working path.
+      # id-token: write (job permissions above) still lets npm attach a
+      # GitHub-signed provenance statement to the published tarball.
+      - name: Publish to npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --access public --provenance
 
   publish-gpr:


### PR DESCRIPTION
## Context

Every npm publish since v0.2.497 has failed with:

```
404 Not Found - PUT https://registry.npmjs.org/@sebastienrousseau%2fdotfiles
404 '@sebastienrousseau/dotfiles@<version>' is not in this registry.
```

Root cause: the workflow was switched to OIDC Trusted Publishing (`npm publish --provenance` without auth) in an earlier release, but the corresponding **Trusted publishing** settings were never configured on npmjs.com for this package. Without either a token or a TP config, the PUT can't resolve the scoped package and npm returns 404.

`NPM_TOKEN` has been in org secrets since 2026-02-14 and was what drove successful publishes up through v0.2.481 (currently the latest on the registry).

## Change

- Add `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` to the `npm publish` step.
- Keep `--provenance` for SLSA Level 3 attestation (works with token auth as long as the job has `id-token: write`, which it already does).
- Update the comment above the step to describe the intent.

## After merge

- Trigger the workflow via `workflow_dispatch` to publish `@sebastienrousseau/dotfiles@0.2.500`.
- Once that succeeds, configure Trusted Publishing at **npmjs.com → Packages → @sebastienrousseau/dotfiles → Settings → Trusted publishing** so future releases can revert to the tokenless form.

## Test plan

- [x] `actionlint .github/workflows/npm-publish.yml` — clean
- [ ] After merge: `gh workflow run "Publish to npm" --ref master` completes successfully
- [ ] `npm view @sebastienrousseau/dotfiles version` returns `0.2.500`
- [ ] Published tarball carries a valid provenance statement (visible on the npmjs.com package page)

---

THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co