### PR TITLE
fix(ci): split Scorecard workflow to satisfy webapp's uses:-only rule

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -10,6 +10,20 @@ name: OpenSSF Scorecard
 #   3. An auto-opened tracking issue if the aggregate score drops
 #      below the 7.0 threshold, so regressions are visible without
 #      manual log-trawling.
+#
+# Workflow structure — two jobs:
+#
+#   - `analysis` runs the scorecard-action and uploads SARIF.
+#     scorecard.dev's signature verifier requires this job to
+#     contain ONLY `uses:` steps (no `run:` steps). Otherwise the
+#     publish step 400s with `scorecard job must only have steps
+#     with 'uses'`. The Pages SARIF upload + the run-id artifact are
+#     fine because they are also `uses:` steps.
+#
+#   - `track-regression` downloads the SARIF artifact, extracts the
+#     aggregate score, and opens / comments a tracking issue when
+#     the score regresses past the 7.0 floor. This job carries the
+#     `run:` steps and runs only if `analysis` succeeds.
 
 on:
   branch_protection_rule: {}
@@ -35,7 +49,6 @@ jobs:
       id-token: write          # publish results to OpenSSF API
       contents: read
       actions: read
-      issues: write            # open the auto-tracking issue
     steps:
       - name: Harden runner (audit mode)
         uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
@@ -48,13 +61,10 @@ jobs:
           persist-credentials: false
 
       - name: Run analysis
-        # The v2.4.3 tag is an annotated tag pointing at commit
-        # 4eaacf0543bb3f2c246792bd56e8cdeffafb205a. Pinning by the
-        # tag-object SHA (99c09fe9…) made GitHub Actions happy but
-        # the scorecard.dev webapp's signature verifier flagged
-        # it as an "imposter commit" (the tag SHA isn't a real
-        # commit in ossf/scorecard-action), so the publish step
-        # 400'd with status 400 every run. Pin the commit SHA.
+        # v2.4.3 → 4eaacf0543bb3f2c246792bd56e8cdeffafb205a (commit).
+        # Pinning the v2.4.3 tag-object SHA (99c09fe9…) instead made
+        # scorecard.dev flag this run as an "imposter commit": the
+        # tag SHA isn't a commit in ossf/scorecard-action's history.
         uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: results.sarif
@@ -74,6 +84,24 @@ jobs:
           name: scorecard-results-${{ github.run_number }}
           path: results.sarif
           retention-days: 30
+
+  track-regression:
+    name: Scorecard / Regression Tracker
+    needs: analysis
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write            # open the auto-tracking issue
+    steps:
+      - name: Harden runner (audit mode)
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
+
+      - name: Download SARIF artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: scorecard-results-${{ github.run_number }}
 
       - name: Extract aggregate score
         id: score


### PR DESCRIPTION
## Summary

The OpenSSF Scorecard gate has been red on every master push since #884 landed, with a new error one layer below the imposter-commit issue that fix addressed:

```
workflow verification failed: scorecard job must only have steps
with `uses`, see https://github.com/ossf/scorecard-action#workflow-restrictions
```

scorecard.dev's signature verifier requires the job that runs `ossf/scorecard-action` to contain only `uses:` steps when `publish_results: true`. Our job had two trailing `run:` steps:
1. "Extract aggregate score" (jq the SARIF for `aggregateScore`).
2. "Auto-open tracking issue on regression" (gh issue create/comment).

The publish step had been 401-ing earlier on imposter-commit verification before reaching this restriction check — so fixing the SHA pin in #884 surfaced the second restriction. Both are latent. Scorecard runs only on `push: master` + Monday cron — never on PRs — which is why neither showed up in the v0.2.501 audit.

## What changed

Restructured into two jobs:

- **`analysis`** — only `uses:` steps (harden-runner, checkout, scorecard-action, codeql upload-sarif, upload-artifact). This is the job scorecard.dev verifies.
- **`track-regression`** (`needs: analysis`) — downloads the SARIF artifact, extracts the aggregate score, opens/comments the tracking issue if the score regresses past 7.0. Carries the `run:` steps without contaminating the verified job.

SARIF still uploads to Code Scanning (Security tab) and the artifact is still retained 30 days — both behaviours unchanged.

Issue-creation permissions moved off the analysis job (it no longer needs `issues: write`) onto `track-regression` (only it does).

## Test plan

- [x] `python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/scorecard.yml"))'` parses clean.
- [x] `actions/download-artifact` SHA matches the one already pinned by `manual-publish.yml` and `security-release.yml` (`3e5f45b…` @ v8.0.1).
- [x] Confirmed `ossf/scorecard-action#workflow-restrictions` documents the uses:-only rule.
- [ ] Master push after merge: `OpenSSF Scorecard / Analysis` green, publish to scorecard.dev succeeds.

---
THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co