### PR TITLE
fix(ci): least-privilege workflow tokens + Dockerfile base pinning

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,12 @@
 # Dotfiles Dev Container
 # Provides a full development environment with chezmoi-managed dotfiles
-FROM mcr.microsoft.com/devcontainers/base:ubuntu
+#
+# Base image pinned by sha256 digest per Scorecard's Pinned-Dependencies
+# check. Refresh with:
+#   docker pull mcr.microsoft.com/devcontainers/base:ubuntu
+#   docker inspect --format '{{index .RepoDigests 0}}' \
+#     mcr.microsoft.com/devcontainers/base:ubuntu
+FROM mcr.microsoft.com/devcontainers/base:ubuntu@sha256:7ee7da33a68d997971660d91ecc8372e55a38a777c3c6bd6808daf91928052db
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/.github/workflows/ci-enforced.yml
+++ b/.github/workflows/ci-enforced.yml
@@ -9,10 +9,13 @@ on:
   # Manual trigger for full CI
   workflow_dispatch:
 
+# Least-privilege top-level — Scorecard's Token-Permissions check
+# flags any non-`read` token at workflow level. The only job that
+# needs write is `security-infrastructure` (upload-sarif). The
+# `pull-requests:write` was leftover from an earlier reusable
+# workflow and no job in this pipeline uses it.
 permissions:
   contents: read
-  security-events: write
-  pull-requests: write
 
 # Cancel in-progress runs for the same branch
 concurrency:
@@ -124,6 +127,9 @@ jobs:
     name: Security / Infrastructure Scan
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
+      security-events: write   # upload-sarif (Checkov)
     steps:
       - name: Harden runner (audit mode)
         uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,16 +28,22 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Least-privilege top-level — Scorecard's Token-Permissions check
+# flags any non-`read` token granted at the workflow level. The
+# write scope CodeQL needs (`security-events: write` to upload the
+# SARIF) is granted on the analyze job only.
 permissions:
   contents: read
-  security-events: write
-  actions: read
 
 jobs:
   analyze:
     name: Security / CodeQL
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
+      security-events: write   # upload-sarif
+      actions: read
     steps:
       - name: Harden runner (audit mode)
         uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1

--- a/.github/workflows/deps-dev-validation.yml
+++ b/.github/workflows/deps-dev-validation.yml
@@ -28,10 +28,10 @@ on:
     - cron: '0 4 * * 2'   # Tuesday 04:00 UTC — after Dependabot
   workflow_dispatch:
 
+# Least-privilege top-level — write scopes are granted on the
+# validate job only (Scorecard's Token-Permissions check).
 permissions:
   contents: read
-  security-events: write
-  issues: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -42,6 +42,10 @@ jobs:
     name: deps.dev / direct deps
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
+      security-events: write   # upload deps.dev SARIF
+      issues: write            # open advisory tracking issue
     steps:
       - name: Harden runner (audit mode)
         uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1

--- a/.github/workflows/devcontainer-prebuild.yml
+++ b/.github/workflows/devcontainer-prebuild.yml
@@ -16,9 +16,11 @@ on:
     - cron: '0 3 * * 1'
   workflow_dispatch:
 
+# Least-privilege top-level — `packages: write` is needed only by
+# the build job (to push to ghcr.io). Scorecard's Token-Permissions
+# check flags top-level write scopes.
 permissions:
   contents: read
-  packages: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -29,6 +31,9 @@ jobs:
     name: Build Devcontainer Image
     runs-on: ubuntu-latest
     timeout-minutes: 30  # Increased — apt mirror congestion can extend builds
+    permissions:
+      contents: read
+      packages: write   # push image to ghcr.io
     steps:
       - name: Harden runner (audit mode)
         uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -10,6 +10,12 @@ on:
         required: false
         type: string
 
+# Least-privilege top-level — write scopes are granted on jobs
+# that actually need them. Scorecard's Token-Permissions check
+# requires an explicit `permissions:` block at top-level.
+permissions:
+  contents: read
+
 jobs:
   publish-npm:
     runs-on: ubuntu-latest

--- a/.github/workflows/security-enhanced.yml
+++ b/.github/workflows/security-enhanced.yml
@@ -33,10 +33,13 @@ on:
     - cron: '0 2 * * 0'
   workflow_dispatch:
 
+# Least-privilege top-level — Scorecard's Token-Permissions check
+# flags any non-`read` token granted at the workflow level. The
+# write scopes are granted on jobs that actually need them
+# (security-events: write for SARIF upload, attestations: write
+# on the attestation job).
 permissions:
   contents: read
-  security-events: write
-  actions: read
 
 # Cancel in-progress runs for the same branch
 concurrency:
@@ -95,6 +98,9 @@ jobs:
     name: Security / Dependencies
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
+      security-events: write   # upload Grype SARIF
     steps:
       - name: Harden runner (audit mode)
         uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
@@ -135,6 +141,9 @@ jobs:
     name: Security / Infrastructure
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
+      security-events: write   # upload Checkov SARIF
     steps:
       - name: Harden runner (audit mode)
         uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
@@ -170,6 +179,9 @@ jobs:
     timeout-minutes: 15
     # Only run container scans manually or with explicit tag
     if: contains(github.event.head_commit.message, '[container]') || github.event_name == 'workflow_dispatch'
+    permissions:
+      contents: read
+      security-events: write   # upload Trivy SARIF
     steps:
       - name: Harden runner (audit mode)
         uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1

--- a/.github/workflows/security-release.yml
+++ b/.github/workflows/security-release.yml
@@ -10,15 +10,18 @@ on:
         required: true
         type: string
 
+# Least-privilege top-level — Scorecard's Token-Permissions check
+# flags top-level write scopes. The release-attaching jobs below
+# carry their own `contents: write` declarations.
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   sbom:
     name: Release / SBOM
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: write   # upload SBOM as release asset
     outputs:
       hash: ${{ steps.hash.outputs.hash }}
     steps:

--- a/.github/workflows/sync-versions.yml
+++ b/.github/workflows/sync-versions.yml
@@ -22,8 +22,11 @@ on:
         required: false
         type: string
 
+# Least-privilege top-level — write is granted on the sync job
+# only (it commits/pushes the version bump). Read-only verify jobs
+# keep top-level read.
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -77,6 +80,8 @@ jobs:
     if: github.event_name != 'pull_request' && github.ref_name != 'master'
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: write   # commit + push version-bump diff
     steps:
       - name: Harden runner (audit mode)
         uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -11,9 +11,11 @@ on:
         default: 'false'
         type: boolean
 
+# Least-privilege top-level — the update-dependencies job pushes
+# branches and opens PRs; its `contents:write` + `pull-requests:write`
+# are scoped to the job rather than granted workflow-wide.
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 env:
   BRANCH_NAME: deps/auto-update-${{ github.run_number }}
@@ -23,6 +25,9 @@ jobs:
     name: Update Dependencies
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: write           # push update branch
+      pull-requests: write      # open PR
     steps:
       - name: Harden runner (audit mode)
         uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -6,7 +6,10 @@
 # =============================================================================
 # Ubuntu 26.04 (LTS) - Tests Debian/Ubuntu prerequisites + install.sh
 # =============================================================================
-FROM ubuntu:26.04 AS ubuntu-test
+# Base images pinned by sha256 digest per Scorecard's Pinned-
+# Dependencies check. Refresh with `docker pull <image> && docker
+# inspect --format '{{index .RepoDigests 0}}' <image>`.
+FROM ubuntu:26.04@sha256:f3d28607ddd78734bb7f71f117f3c6706c666b8b76cbff7c9ff6e5718d46ff64 AS ubuntu-test
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV HOME=/root
@@ -71,7 +74,7 @@ RUN bash -n "$HOME/.dotfiles/install.sh" && echo "=== Ubuntu 24.04: ALL TESTS PA
 # =============================================================================
 # Debian 12 (Bookworm) - Tests Debian prerequisites + install.sh
 # =============================================================================
-FROM debian:12 AS debian-test
+FROM debian:12@sha256:85019db29298555fd1a5f4bb57673ae989414a9884117c75d7a3e1a6cce21688 AS debian-test
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV HOME=/root
@@ -123,7 +126,7 @@ USER testuser
 # Arch Linux - Tests Arch prerequisites
 # =============================================================================
 # Using base-devel tag for stable builds (CKV_DOCKER_7)
-FROM archlinux:base-devel AS arch-test
+FROM archlinux:base-devel@sha256:6ec1f5073a94d877ae97ebf68e507f709b395c7a90005fe92d9db1c21f933077 AS arch-test
 
 ENV HOME=/root
 
@@ -177,7 +180,7 @@ USER testuser
 # =============================================================================
 # Ubuntu 26.04 + eza - Tests modern aliases with eza installed
 # =============================================================================
-FROM ubuntu:26.04 AS ubuntu-eza-test
+FROM ubuntu:26.04@sha256:f3d28607ddd78734bb7f71f117f3c6706c666b8b76cbff7c9ff6e5718d46ff64 AS ubuntu-eza-test
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV HOME=/root

--- a/tests/Dockerfile.sandbox
+++ b/tests/Dockerfile.sandbox
@@ -3,7 +3,10 @@
 # Run:   docker run --rm -it dotfiles-sandbox
 # Security: DS-0029 fix included
 
-FROM ubuntu:24.04
+# Base pinned by sha256 digest per Scorecard's Pinned-Dependencies
+# check. Refresh with `docker pull ubuntu:24.04 && docker inspect
+# --format '{{index .RepoDigests 0}}' ubuntu:24.04`.
+FROM ubuntu:24.04@sha256:c4a8d5503dfb2a3eb8ab5f807da5bc69a85730fb49b5cfca2330194ebcc41c7b
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV HOME=/root


### PR DESCRIPTION
## Summary

Resolves the **10 high-severity `TokenPermissionsID` alerts** from Scorecard at github.com/sebastienrousseau/dotfiles/security/code-scanning. These surfaced after #885 fixed the Scorecard publish step — the alerts existed all along but were hidden by the publish failure.

Scorecard's `Token-Permissions` check (high severity) flags any non-`read` scope granted at workflow top-level. Least-privilege wants those scopes to live on the job that actually needs them.

## Per-workflow rationale

| Workflow | Top-level | Job-level write scope (where) |
|---|---|---|
| `ci-enforced.yml` | `contents: read` | `security-events:write` on `security-infrastructure` (upload-sarif). `pull-requests:write` dropped — no job uses it. |
| `codeql.yml` | `contents: read` | `security-events:write` + `actions:read` on `analyze`. |
| `deps-dev-validation.yml` | `contents: read` | `security-events:write` + `issues:write` on `validate`. |
| `devcontainer-prebuild.yml` | `contents: read` | `packages:write` on `build` (ghcr push). |
| `manual-publish.yml` | already correct (`contents:read`, `attach-release` job has `contents:write`) — no change |
| `npm-publish.yml` | added `contents: read` (had no top-level) | jobs already declared `id-token:write`, `packages:write` |
| `security-enhanced.yml` | `contents: read` | `security-events:write` on `dependency-scan`, `infrastructure-scan`, `container-scan` |
| `security-release.yml` | `contents: read` | `contents:write` on `sbom` + `provenance` (attach release assets) |
| `sync-versions.yml` | `contents: read` | `contents:write` on `sync` job (non-PR, non-master only — commits version-bump diff) |
| `update-deps.yml` | `contents: read` | `contents:write` + `pull-requests:write` on `update-dependencies` (pushes branch, opens PR) |

## Score impact

Should restore the `Token-Permissions` Scorecard check from **0/10 → ~9/10** (residual warnings from inevitable job-level writes are acceptable per the [Scorecard docs](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions)).

## Test plan

- [x] All 9 modified workflows parse clean (`python3 -c 'import yaml; yaml.safe_load(...)'`).
- [x] No `write` scope removed without re-granting at the job that uses it (manually audited each `upload-sarif`, `gh issue`, `gh pr`, release-asset call).
- [ ] After merge, next master push: TokenPermissions alerts drop from 10 → 0.


## Scope addition (commit 271dfdcf)

Also pins 6 Dockerfile base images by sha256 digest, resolving the medium-severity `PinnedDependenciesID` findings on container images. After this PR, the remaining Pinned-Dependencies alerts are limited to npm/go/pip command invocations (handled in a follow-up).

---
THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co
