### PR TITLE
fix(ci): pin go/npm/pip in CI-scope shell commands

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -204,9 +204,11 @@ jobs:
         run: |
           echo "Testing with Go-built shfmt..."
 
-          # Install Go and build latest shfmt
+          # Install Go and build a pinned shfmt. Scorecard's
+          # Pinned-Dependencies check flags `@latest`; refresh
+          # this tag with each shfmt release.
           sudo apt-get update && sudo apt-get install -y golang-go
-          go install mvdan.cc/sh/v3/cmd/shfmt@latest
+          go install mvdan.cc/sh/v3/cmd/shfmt@v3.13.1
 
           echo "Running development shfmt..."
           ~/go/bin/shfmt -version

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -40,7 +40,9 @@ jobs:
       # Trusted Publishing (OIDC) requires npm >= 11.5.1. Node 20 ships
       # with npm 10.x, so upgrade explicitly. Pinned to a known-good major.
       - name: Upgrade npm for Trusted Publishing
-        run: npm install -g npm@^11.5.1
+        # Pinned to an exact version per Scorecard's Pinned-
+        # Dependencies check. Bump on the next npm major.
+        run: npm install -g npm@11.5.1
 
       - name: Verify package.json
         run: |

--- a/install/provision/run_onchange_10-linux-packages.sh.tmpl
+++ b/install/provision/run_onchange_10-linux-packages.sh.tmpl
@@ -359,10 +359,14 @@ fi
 # Aider (Python-based)
 if ! command -v aider >/dev/null; then
   log_info "Installing Aider..."
+  # Pinned per Scorecard's Pinned-Dependencies check. Refresh on
+  # each aider-chat release. The pin uses `==`, not `>=`, so a
+  # yanked version is a hard fail rather than a silent upgrade.
+  AIDER_PIN="aider-chat==0.86.2"
   if command -v uv >/dev/null; then
-    uv tool install aider-chat || log_warn "Aider install via uv failed. Install manually with: pip install aider-chat"
+    uv tool install "$AIDER_PIN" || log_warn "Aider install via uv failed. Install manually with: pip install $AIDER_PIN"
   elif command -v pip3 >/dev/null; then
-    python3 -m pip install --user aider-chat || log_warn "Aider install via pip failed."
+    python3 -m pip install --user "$AIDER_PIN" || log_warn "Aider install via pip failed."
   else
     log_info "Skipping Aider install: neither uv nor pip found."
   fi


### PR DESCRIPTION
## Summary

Resolves the 3 medium-severity `PinnedDependenciesID` findings in the supply-chain-relevant scope. User-facing convenience commands stay unpinned where pinning would defeat their purpose.

| Site | Change |
|---|---|
| `nightly.yml:209` | `go install …/shfmt@latest` → `@v3.13.1` |
| `npm-publish.yml:43` | `npm install -g npm@^11.5.1` → `npm@11.5.1` (exact) |
| `run_onchange_10-linux-packages.sh.tmpl:365` | `pip/uv install aider-chat` → `aider-chat==0.86.2` (shared `AIDER_PIN` env so the uv + pip3 branches stay aligned) |

## Out of scope (deliberate)

| Site | Why unpinned |
|---|---|
| `aliases/legal/*` | user-facing convenience alias |
| `aliases/update/*` | user-facing convenience alias |
| `executable_update:99` | the script's purpose is `npm update -g` — pinning defeats it |
| `tools.sh:121` | `npm install --package-lock-only` generates a lockfile, doesn't fetch packages |

## Test plan

- [x] `python3 -c 'import yaml; yaml.safe_load(open(...))'` on both workflows.
- [x] `chezmoi execute-template --init=false < … sh.tmpl | bash -n` parses clean.
- [ ] After merge: Scorecard's open alert count drops from 12 → ~9 (3 shell-command alerts closed; 4 user-alias alerts intentionally remain).

---
THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co