### PR TITLE
fix(ci): bump npm-publish to Node 24 → npm 11 bundled

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -32,17 +32,15 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Node.js
+        # Node 24 LTS bundles npm >= 11, which is the minimum
+        # OIDC Trusted Publishing requires. With this we no longer
+        # need a follow-up `npm install -g npm@…` step; removing
+        # that step also closes the matching Scorecard
+        # `Pinned-Dependencies` finding on this workflow.
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: '20'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
-
-      # Trusted Publishing (OIDC) requires npm >= 11.5.1. Node 20 ships
-      # with npm 10.x, so upgrade explicitly. Pinned to a known-good major.
-      - name: Upgrade npm for Trusted Publishing
-        # Pinned to an exact version per Scorecard's Pinned-
-        # Dependencies check. Bump on the next npm major.
-        run: npm install -g npm@11.5.1
 
       - name: Verify package.json
         run: |
@@ -82,7 +80,10 @@ jobs:
       - name: Setup Node.js for GPR
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: '20'
+          # Match the publish-npm job's Node 24; keeps both pipelines
+          # on the same npm major and avoids surprise behavioural diffs
+          # between npm 10 and npm 11.
+          node-version: '24'
           registry-url: 'https://npm.pkg.github.com'
           scope: '@sebastienrousseau'
 


### PR DESCRIPTION
## Summary

Resolves the `Pinned-Dependencies` Scorecard finding on `npm-publish.yml:46`:

```
npm install -g npm@11.5.1   ← flagged as unpinned npmCommand
```

Node 24 LTS (runners serve v24.15) ships with **npm 11.6 bundled** — over the 11.5.1 floor that OIDC Trusted Publishing requires. With that, the explicit upgrade step is unnecessary and the matching Scorecard alert closes.

## Changes

| Job | `node-version` | Other |
|---|---|---|
| `publish-npm` | `20` → `24` | Removed the `npm install -g npm@11.5.1` step entirely |
| `publish-gpr` | `20` → `24` | Keep both jobs on the same npm major (avoid behavioural diffs between npm 10 and npm 11) |

## LTS runway

Per the Node release schedule: v24 entered Active LTS on 2025-10-28 (codename "Krypton"), maintenance starts 2026-10-20, EOL 2028-04-30. Comfortable headroom.

## On the remaining pip alert

The `pip install aider-chat==0.86.2` finding at `run_onchange_10-linux-packages.sh.tmpl:369` is technically fixable with `pip install --require-hashes`, but doing it properly requires a hashed lockfile covering all transitive deps — `uv pip compile --generate-hashes` against aider-chat produces a **2,697-line file with 108 packages** that would need re-pinning on every aider release. Not landing that in this PR — recommend dismissing the alert in the Security tab as `Used in tests` / `Won't fix` with the rationale "exact version pin is the practical maximum for an optional provisioning install."

After merge: 9 → 8 open Scorecard alerts.

## Test plan

- [x] YAML parses.
- [ ] After merge: `publish-npm` and `publish-gpr` succeed using Node 24's bundled npm (no extra upgrade step).
- [ ] After next master push: Scorecard alert count drops from 9 → 8.

---
THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co