### PR TITLE
fix(ci): unblock SLSA Release Attestation (6 broken releases → green)

### DIFF
--- a/.github/workflows/security-release.yml
+++ b/.github/workflows/security-release.yml
@@ -92,14 +92,21 @@ jobs:
             dotfiles-sbom.spdx.json.sig
             dotfiles-sbom.spdx.json.pem
 
-      - name: Attach Cosign artefacts to the release
-        if: github.event_name == 'release'
+      - name: Attach SBOM + Cosign artefacts to the release
+        # Under workflow_dispatch we also re-upload the SBOM itself —
+        # the freshly-generated file will have a different hash than
+        # whatever was attached when the release first published, so
+        # the .sig / .pem must match the new SBOM bytes. The release-
+        # event path uploads only the sig+cert (the SBOM is added by
+        # the sbom-action step's `upload-release-assets` elsewhere).
+        if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
         env:
           GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.release_tag }}
         run: |
           set -euo pipefail
           gh release upload "$RELEASE_TAG" \
+            dotfiles-sbom.spdx.json \
             dotfiles-sbom.spdx.json.sig \
             dotfiles-sbom.spdx.json.pem \
             --clobber

--- a/.github/workflows/security-release.yml
+++ b/.github/workflows/security-release.yml
@@ -125,6 +125,14 @@ jobs:
     with:
       base64-subjects: "${{ needs.sbom.outputs.hash }}"
       upload-assets: true
+      # SLSA `upload-assets` job is gated on
+      #   startsWith(github.ref, 'refs/tags/') || inputs.upload-tag-name != ''
+      # A `workflow_dispatch` re-run carries `github.ref = refs/heads/<branch>`,
+      # which would skip the upload. Pass the dispatch-provided tag through so
+      # operators can retroactively attach provenance to an existing release.
+      # Release-event runs leave this empty (the first arm of the condition
+      # above already matches the tag ref).
+      upload-tag-name: ${{ inputs.release_tag || '' }}
 
   verify-release-integrity:
     name: Release / Verify Integrity

--- a/.github/workflows/security-release.yml
+++ b/.github/workflows/security-release.yml
@@ -111,7 +111,17 @@ jobs:
       actions: read
       id-token: write
       contents: write
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
+    # NOTE: The SLSA generator's `builder-fetch.sh` requires `BUILDER_REF`
+    # to be `refs/tags/vX.Y.Z` (regex-checked at start of fetch). A SHA-
+    # pinned `@<sha>` makes the ref a bare hash and the script exits 2
+    # — see slsa-framework/slsa-github-generator#1163. The SLSA team's
+    # documented recommendation is to pin by tag, which is what we do
+    # here. v2.1.0 = f7dd8c54c2067bafc12ca7a55595d5ee9b75204a (verify
+    # before each bump). This single tag-pinned reusable workflow is the
+    # documented exception to the repo's otherwise-strict SHA-pinning
+    # convention; Scorecard's Pinned-Dependencies check explicitly
+    # exempts SLSA-generator from SHA pinning for this reason.
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
     with:
       base64-subjects: "${{ needs.sbom.outputs.hash }}"
       upload-assets: true

--- a/.github/workflows/security-release.yml
+++ b/.github/workflows/security-release.yml
@@ -189,20 +189,37 @@ jobs:
           fi
           echo "Release provenance asset verified"
 
-      - name: Install verification dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y jq
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2
+        with:
+          cosign-release: v2.4.1
 
-      - name: Verify SBOM attestation cryptographically
+      - name: Download cosign signature + certificate from the release
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.release_tag || github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          gh release download "$RELEASE_TAG" \
+            --pattern dotfiles-sbom.spdx.json.sig \
+            --pattern dotfiles-sbom.spdx.json.pem \
+            --clobber
+
+      - name: Verify SBOM signature with Cosign
+        # `gh attestation verify` only finds attestations from
+        # `actions/attest-*`. Our SBOM is signed via Cosign keyless
+        # (Fulcio + Rekor) in the sbom job above, so verify with the
+        # same tool against the same artefacts. Identity binds to the
+        # repo that produced the signature — any rebuild from a fork
+        # would fail this check.
+        env:
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          gh attestation verify dotfiles-sbom.spdx.json --repo "${REPO}" --format json >"$RUNNER_TEMP/attestation-verify.json"
-          if ! jq -e 'length > 0' "$RUNNER_TEMP/attestation-verify.json" >/dev/null; then
-            echo "::error::No valid attestations were returned for dotfiles-sbom.spdx.json"
-            exit 1
-          fi
-          echo "SBOM attestation verified"
+          cosign verify-blob \
+            --certificate dotfiles-sbom.spdx.json.pem \
+            --signature dotfiles-sbom.spdx.json.sig \
+            --certificate-identity-regexp "^https://github.com/${REPO}/" \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+            dotfiles-sbom.spdx.json
+          echo "SBOM Cosign signature verified"


### PR DESCRIPTION
Closes a 6-release-old pipeline failure (v0.2.497 → v0.2.502 all failed Security Attestation identically). Four sequential commits:

1. **`26638847` — Tag-pin the SLSA reusable workflow.** SHA-pinning made `BUILDER_REF` a bare 40-char hash; `builder-fetch.sh:30` regex-checks for `refs/tags/` prefix and exits 2. Generator never built, downstream steps failed silently under `continue-on-error`. The misleading "Repository is private" line in logs was just the input parameter being echoed — privacy-check never ran. Pin to `@v2.1.0` per the SLSA team's documented exception ([slsa-framework/slsa-github-generator#1163](https://github.com/slsa-framework/slsa-github-generator/issues/1163)).
2. **`f18ae27d` — Pass `upload-tag-name` through under workflow_dispatch.** SLSA upload-assets is gated on `startsWith(github.ref, 'refs/tags/') || inputs.upload-tag-name != ''`. A `workflow_dispatch` re-run carries a branch ref, so the upload was skipped. Pass the dispatch-provided `release_tag` so operators can retroactively attach provenance.
3. **`d5e3a9c1` — Verify SBOM via Cosign, not `gh attestation`.** Our SBOM is signed via Cosign keyless (Fulcio + Rekor) in the sbom job; `gh attestation verify` queries GitHub's attestations API, which we don't populate (we'd need `actions/attest-*` for that). HTTP 404 → fail. Replaced with `cosign verify-blob` using the same `.sig` + `.pem` we just attached, identity-bound to this repo.
4. **`e079b720` — Re-upload SBOM+sig under workflow_dispatch.** First successful re-run downloaded stale `.sig`+`.pem` from the original (broken) release-event run; freshly-generated SBOM had a different hash → signature mismatch. Now upload step runs under both event types and atomically re-attaches all three files via `--clobber`.

## Verification

Ran `gh workflow run security-release.yml -f release_tag=v0.2.502` four times across this PR. The fourth run is fully green:

```
success	Release / SBOM
success	Release / SLSA Provenance / detect-env
success	Release / SLSA Provenance / generator
success	Release / SLSA Provenance / upload-assets
success	Release / SLSA Provenance / final
success	Release / Verify Integrity
```

And the v0.2.502 GitHub release now carries the full attestation triplet:

```
dotfiles-sbom.spdx.json
dotfiles-sbom.spdx.json.intoto.jsonl   ← SLSA provenance (was missing for 6 releases)
dotfiles-sbom.spdx.json.pem            ← Cosign certificate
dotfiles-sbom.spdx.json.sig            ← Cosign signature
```

## Verification recipes (now actually work)

```sh
# Cosign verification (uses the .sig + .pem on the release)
cosign verify-blob \
  --certificate dotfiles-sbom.spdx.json.pem \
  --signature dotfiles-sbom.spdx.json.sig \
  --certificate-identity-regexp '^https://github.com/sebastienrousseau/dotfiles/' \
  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
  dotfiles-sbom.spdx.json

# SLSA verification (uses the .intoto.jsonl on the release)
slsa-verifier verify-artifact dotfiles-sbom.spdx.json \
  --provenance-path dotfiles-sbom.spdx.json.intoto.jsonl \
  --source-uri github.com/sebastienrousseau/dotfiles \
  --source-tag v0.2.502
```

Closes the R3-N3 deferred item from `HARD_AUDIT_2026.md` Part 7.

## Test plan

- [x] `gh workflow run security-release.yml -f release_tag=v0.2.502` → all 6 jobs success
- [x] `gh release view v0.2.502 --json assets` → `.intoto.jsonl` + `.sig` + `.pem` all present
- [x] Cosign signature freshly re-attached (matches re-generated SBOM hash)
- [x] All commits SSH-signed
- [x] No pre-commit bypass used

---
THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co