### PR TITLE
fix(ci): restore aur-pkg ownership after .SRCINFO container

### DIFF
--- a/.github/workflows/release-distribute-aur.yml
+++ b/.github/workflows/release-distribute-aur.yml
@@ -128,6 +128,10 @@ jobs:
             -w /work \
             archlinux/archlinux:base-devel \
             bash -c "useradd -m builder && chown -R builder:builder /work && su builder -c 'cd /work && makepkg --printsrcinfo > .SRCINFO'"
+          # The container chowned the bind-mount (including aur-pkg/.git) to
+          # its builder UID; restore runner ownership so the host git steps
+          # below can lock .git/config and commit/push.
+          sudo chown -R "$(id -u):$(id -g)" aur-pkg
 
       - name: Commit and push to AUR
         run: |


### PR DESCRIPTION
Fixes the AUR distribution failure: the `.SRCINFO` container chowns the
bind-mounted `aur-pkg` (incl. `.git`) to its builder UID, so the host
commit step hits `could not lock .git/config: Permission denied`. Restore
runner ownership after the container. CI-only.

---

THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co
