### PR TITLE
fix(aur): publish to dot-cli-git, not dotfiles-git

### DIFF
--- a/.github/workflows/release-distribute-aur.yml
+++ b/.github/workflows/release-distribute-aur.yml
@@ -102,7 +102,7 @@ jobs:
         id: clone-aur
         run: |
           set -euo pipefail
-          if ! git clone ssh://aur@aur.archlinux.org/dotfiles-git.git aur-pkg 2>&1; then
+          if ! git clone ssh://aur@aur.archlinux.org/dot-cli-git.git aur-pkg 2>&1; then
             echo "::error::First publication: the user must create the AUR package entry via the web UI at https://aur.archlinux.org/packages first"
             exit 1
           fi
@@ -148,4 +148,4 @@ jobs:
 
       - name: Print AUR URL
         run: |
-          echo "AUR package updated: https://aur.archlinux.org/packages/dotfiles-git"
+          echo "AUR package updated: https://aur.archlinux.org/packages/dot-cli-git"

--- a/docs/operations/RELEASE_PIPELINE.md
+++ b/docs/operations/RELEASE_PIPELINE.md
@@ -59,7 +59,7 @@ where dependencies allow.
 | `security-release.yml` (manifest job) | `release.published`, dispatch | Build `ALL_SHA256SUMS` over every release asset, Cosign-sign it. | `ALL_SHA256SUMS` + `.sig` + `.pem`. |
 | `release-distribute-homebrew.yml` | `release.published`, dispatch | Hash `dot-VERSION.tar.gz`, regenerate `install/homebrew/dot.rb`, push branch + PR to `sebastienrousseau/homebrew-tap`. | One PR on the tap repo. |
 | `release-distribute-scoop.yml` | `release.published`, dispatch | Hash `dot-VERSION.zip`, rewrite `install/scoop/dot.json` via jq (both 64bit + arm64 point at same zip), PR to `sebastienrousseau/scoop-bucket`. | One PR on the bucket repo. |
-| `release-distribute-aur.yml` | `release.published`, dispatch | Hash `dot-VERSION.tar.gz`, rewrite `pkgver` + `sha256sums` in `install/aur/PKGBUILD`, regenerate `.SRCINFO` via dockerised `makepkg`, push to `ssh://aur@aur.archlinux.org/dotfiles-git.git`. | One commit on AUR. |
+| `release-distribute-aur.yml` | `release.published`, dispatch | Hash `dot-VERSION.tar.gz`, rewrite `pkgver` + `sha256sums` in `install/aur/PKGBUILD`, regenerate `.SRCINFO` via dockerised `makepkg`, push to `ssh://aur@aur.archlinux.org/dot-cli-git.git`. | One commit on AUR. |
 | `release-attestation-check.yml` | weekly cron + dispatch | Verify the latest release carries the full attestation bundle (SBOM + sig + cert + intoto + manifest + sig + cert). | Opens or comments on a tracking issue. |
 
 ## Why `created` vs `published`
@@ -93,7 +93,7 @@ manifest job after late asset uploads picks up the new state and the
 |---|---|---|
 | Homebrew | `sebastienrousseau/homebrew-tap` | Tap repo exists (currently bare README + LICENSE). Workflow creates the `Formula/dot.rb` path on first publish. |
 | Scoop | `sebastienrousseau/scoop-bucket` | Bucket repo exists (currently bare). Workflow creates `bucket/dot.json` on first publish. |
-| AUR | `ssh://aur@aur.archlinux.org/dotfiles-git.git` | **Manual one-time step**: the maintainer must create the package entry via the AUR web UI before the workflow's `git clone` can succeed. The workflow exits with a clear error message on the first run if the repo doesn't exist. |
+| AUR | `ssh://aur@aur.archlinux.org/dot-cli-git.git` | **Manual one-time step**: the maintainer must create the package entry via the AUR web UI before the workflow's `git clone` can succeed. The workflow exits with a clear error message on the first run if the repo doesn't exist. |
 
 ## Verifying a release
 
@@ -105,7 +105,7 @@ independently.
 
 ## Known caveats
 
-- **AUR `pkgname=dotfiles-git`**: AUR's `-git` convention means
+- **AUR `pkgname=dot-cli-git`**: AUR's `-git` convention means
   "tracks git HEAD", but the workflow publishes tagged stable
   releases. Either rename to plain `dotfiles` in
   `install/aur/PKGBUILD` and register that package, or accept the

--- a/install/README.md
+++ b/install/README.md
@@ -14,7 +14,7 @@ managers.
 | `run_before_cleanup.sh` | active | Pre-apply cleanup hook (chezmoi `run_before_` convention). |
 | `homebrew/dot.rb` | template | Homebrew formula for the `dot` CLI. Bumped per release by `.github/workflows/release-distribute-homebrew.yml` (PR to `sebastienrousseau/homebrew-tap`). |
 | `scoop/dot.json` | template | Scoop manifest for Windows. Bumped per release by `.github/workflows/release-distribute-scoop.yml` (PR to `sebastienrousseau/scoop-bucket`). |
-| `aur/PKGBUILD` | template | Arch User Repository package definition. Bumped per release by `.github/workflows/release-distribute-aur.yml` (push to `ssh://aur@aur.archlinux.org/dotfiles-git.git`). First-time publication requires the AUR package entry to exist (manual web-UI step). |
+| `aur/PKGBUILD` | template | Arch User Repository package definition. Bumped per release by `.github/workflows/release-distribute-aur.yml` (push to `ssh://aur@aur.archlinux.org/dot-cli-git.git`). First-time publication requires the AUR package entry to exist (manual web-UI step). |
 
 ## Bootstrap entrypoint
 
@@ -50,7 +50,7 @@ re-test a specific channel out-of-band.
 4. **`release-distribute-*.yml`** fan out:
    - Homebrew: PR to `sebastienrousseau/homebrew-tap` with the regenerated `dot.rb`.
    - Scoop: PR to `sebastienrousseau/scoop-bucket` with the regenerated `dot.json` (both 64bit + arm64 point at the same zip).
-   - AUR: direct push to `ssh://aur@aur.archlinux.org/dotfiles-git.git` (requires `AUR_SSH_KEY` secret and a pre-existing AUR package entry).
+   - AUR: direct push to `ssh://aur@aur.archlinux.org/dot-cli-git.git` (requires `AUR_SSH_KEY` secret and a pre-existing AUR package entry).
 5. **Verify locally** before announcing:
 
    ```sh

--- a/install/aur/PKGBUILD
+++ b/install/aur/PKGBUILD
@@ -10,10 +10,10 @@
 # `sha256sums` is SKIP and source uses the master branch as a
 # placeholder.
 #
-# Publication target: aur.archlinux.org/packages/dotfiles-git
-# Validate via:  paru -S dotfiles-git
+# Publication target: aur.archlinux.org/packages/dot-cli-git
+# Validate via:  paru -S dot-cli-git
 
-pkgname=dotfiles-git
+pkgname=dot-cli-git
 pkgver=0.2.503.r0
 pkgrel=1
 pkgdesc='Declarative dotfiles CLI for macOS, Linux, WSL, and PowerShell (git head)'


### PR DESCRIPTION
The AUR distribute workflow + PKGBUILD pushed to `dotfiles-git`, which is
not the maintainer's package (`permission denied: srousseau`). The real
package is `dot-cli-git`. Repoint the clone/push URL, `pkgname`, and the
current docs. Historical refs left as-is.

---

THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co
