### PR TITLE
fix(ci): cross-repo TAP_PUSH_TOKEN for Homebrew/Scoop distribution

### DIFF
--- a/.github/workflows/release-distribute-homebrew.yml
+++ b/.github/workflows/release-distribute-homebrew.yml
@@ -159,7 +159,7 @@ jobs:
         run: |
           set -euo pipefail
           TAP_REPO="sebastienrousseau/homebrew-tap"
-          git clone "https://${{ secrets.GITHUB_TOKEN }}@github.com/${TAP_REPO}.git" homebrew-tap
+          git clone "https://${{ secrets.TAP_PUSH_TOKEN || secrets.GITHUB_TOKEN }}@github.com/${TAP_REPO}.git" homebrew-tap
           # Detect the default branch (main vs master) so the PR targets
           # the right base regardless of how the tap is initialised.
           cd homebrew-tap
@@ -209,7 +209,7 @@ jobs:
 
       - name: Open Pull Request to homebrew-tap
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.TAP_PUSH_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           VERSION="${{ steps.resolve-tag.outputs.version }}"

--- a/.github/workflows/release-distribute-scoop.yml
+++ b/.github/workflows/release-distribute-scoop.yml
@@ -156,7 +156,7 @@ jobs:
         run: |
           set -euo pipefail
           BUCKET_REPO="sebastienrousseau/scoop-bucket"
-          git clone "https://${{ secrets.GITHUB_TOKEN }}@github.com/${BUCKET_REPO}.git" scoop-bucket
+          git clone "https://${{ secrets.TAP_PUSH_TOKEN || secrets.GITHUB_TOKEN }}@github.com/${BUCKET_REPO}.git" scoop-bucket
           # Detect the default branch (main vs master) so the PR targets
           # the right base regardless of how the bucket is initialised.
           cd scoop-bucket
@@ -206,7 +206,7 @@ jobs:
 
       - name: Open Pull Request to scoop-bucket
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.TAP_PUSH_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           VERSION="${{ steps.resolve-tag.outputs.version }}"


### PR DESCRIPTION
Homebrew + Scoop push to the separate `homebrew-tap`/`scoop-bucket`
repos with the repo-scoped `GITHUB_TOKEN`, which can't write cross-repo.
Swap exactly the cross-repo clone + PR-create to
`secrets.TAP_PUSH_TOKEN || secrets.GITHUB_TOKEN`. No-op until the secret
exists, then auto-activates. CI-only.

---

THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co
