### PR TITLE
fix(ai): install Claude Code via native installer; drop redundant codex/opencode npm pins

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ See the [Migration Guide](docs/operations/MIGRATION.md) for version upgrades.
 - **Pattern library** (`dot patterns`) — architect, hardener, and refactor patterns bundled in `dot_config/ai/patterns/`
 - **MCP policy enforcement** (`dot mcp`) — validate the Model Context Protocol registry against policy
 - **AI commit messages** (`dot commit`) — conventional commits generated from the staged diff
-- **AI tools** (`dot ai`) — Claude Code, Codex, GitHub Copilot, Gemini CLI, and friends managed via Mise
+- **AI tools** (`dot ai`) — Codex, GitHub Copilot, Gemini CLI, and friends managed via Mise; Claude Code via Anthropic's native installer
 - **Attestation logs** — every agent session is logged with a policy hash and an outcome
 
 </details>

--- a/defaults/dot_config/mise/conf.d/00-dotfiles.toml
+++ b/defaults/dot_config/mise/conf.d/00-dotfiles.toml
@@ -85,7 +85,7 @@ uv = "latest"
 "pipx:shell-gpt" = "latest"
 
 # AI tools
-"npm:@anthropic-ai/claude-code" = "latest"
+# "npm:@anthropic-ai/claude-code" = "latest"  # disabled 2026-06-04: npm 11 skips the platform-native optionalDependency on global installs, breaking the binary. Use Anthropic's native installer instead (~/.local/bin/claude, self-updating).
 "npm:@github/copilot" = "latest"
 "npm:@google/gemini-cli" = "latest"
 "npm:codex-cli" = "latest"

--- a/defaults/dot_config/mise/conf.d/00-dotfiles.toml
+++ b/defaults/dot_config/mise/conf.d/00-dotfiles.toml
@@ -88,8 +88,10 @@ uv = "latest"
 # "npm:@anthropic-ai/claude-code" = "latest"  # disabled 2026-06-04: npm 11 skips the platform-native optionalDependency on global installs, breaking the binary. Use Anthropic's native installer instead (~/.local/bin/claude, self-updating).
 "npm:@github/copilot" = "latest"
 "npm:@google/gemini-cli" = "latest"
-"npm:codex-cli" = "latest"
-"npm:opencode-ai" = "latest"
+# codex provided by the native `codex` pin above; `npm:codex-cli` was an
+# unrelated legacy package (codex.js) that collided on the `codex` bin name.
+# opencode provided by the native `opencode` pin in mise.toml; `npm:opencode-ai`
+# was a redundant duplicate using the broken npm optional-dep wrapper pattern.
 kiro-cli = "latest"
 "npm:autohand-cli" = "latest"
 "npm:@qwen-code/qwen-code" = "latest"

--- a/docs/manual/02-tutorials/01-first-install.md
+++ b/docs/manual/02-tutorials/01-first-install.md
@@ -184,7 +184,7 @@ After `dot doctor` reports a healthy score, you have:
 | **Editor** | Neovim with lazy.nvim + LSP + theme-synced colorscheme |
 | **Terminal** | Ghostty/Alacritty/Kitty/WezTerm configs (pick whichever is installed) |
 | **Git** | Signed commits, delta diff, conventional commit template |
-| **AI tooling** | Claude Code, Codex, Copilot CLI, Gemini CLI via mise |
+| **AI tooling** | Codex, Copilot CLI, Gemini CLI via mise; Claude Code via Anthropic's native installer |
 | **Secret store** | Age key, SOPS config, `dot secrets` command ready |
 | **Security** | Gitleaks, detect-secrets baseline, signed attestation log |
 | **Theme engine** | K-Means wallpaper extractor, system + custom wallpaper discovery |

--- a/install/provision/run_onchange_15-ai-cli-tools.sh.tmpl
+++ b/install/provision/run_onchange_15-ai-cli-tools.sh.tmpl
@@ -47,8 +47,8 @@ if command -v mise >/dev/null 2>&1; then
     # Claude Code installed via native installer above (npm optional-dep bug).
     "npm:@github/copilot"
     "npm:@google/gemini-cli"
-    "npm:codex-cli"
-    "npm:opencode-ai"
+    # codex + opencode come from native mise pins (codex, opencode), not npm:
+    # npm:codex-cli was a legacy package collision; npm:opencode-ai a broken dup.
     "npm:autohand-cli"
     "npm:@qwen-code/qwen-code"
     "npm:@guizmo-ai/zai-cli"

--- a/install/provision/run_onchange_15-ai-cli-tools.sh.tmpl
+++ b/install/provision/run_onchange_15-ai-cli-tools.sh.tmpl
@@ -9,13 +9,42 @@ set -euo pipefail
 log_info() { printf '\n[INFO] %s\n' "$*"; }
 log_error() { printf '\n[ERROR] %s\n' "$*" >&2; }
 
+# Install Claude Code via Anthropic's native installer.
+# npm 11 silently drops the platform-native optionalDependency on global
+# installs, leaving a broken binary, so Claude Code is NOT managed via
+# mise/npm like the other AI tools. The native installer fetches the
+# platform binary directly to ~/.local/bin/claude and self-updates.
+install_claude_native() {
+  if command -v claude >/dev/null 2>&1 || [ -x "$HOME/.local/bin/claude" ]; then
+    log_info "Claude Code already installed (native). Skipping."
+    return 0
+  fi
+  log_info "Installing Claude Code via native installer..."
+  local installer
+  installer=$(umask 077 && mktemp)
+  if curl -fsSL -o "$installer" https://claude.ai/install.sh; then
+    if [ "$(wc -c <"$installer")" -le 262144 ] && head -1 "$installer" | grep -q '^#!'; then
+      bash "$installer" || log_error "Claude Code native installer failed (continuing...)"
+    else
+      log_error "Claude Code installer failed validation. Install manually: https://claude.ai/install.sh"
+    fi
+    rm -f "$installer"
+  else
+    rm -f "$installer"
+    log_error "Failed to download Claude Code installer."
+  fi
+}
+
+# Claude Code is installed natively regardless of mise/npm availability.
+install_claude_native
+
 log_info "Installing AI CLI and dev tools via mise..."
 
 # Prefer mise for all AI tool installations (ensures topgrade can update them)
 if command -v mise >/dev/null 2>&1; then
   # AI tools — installed globally via mise for consistent updates
   AI_MISE_TOOLS=(
-    "npm:@anthropic-ai/claude-code"
+    # Claude Code installed via native installer above (npm optional-dep bug).
     "npm:@github/copilot"
     "npm:@google/gemini-cli"
     "npm:codex-cli"
@@ -91,7 +120,7 @@ else
 
   # Install AI CLI tools globally via npm
   AI_TOOLS=(
-    "@anthropic-ai/claude-code"
+    # Claude Code installed via native installer above (npm optional-dep bug).
     "@google/gemini-cli"
     "@openai/codex"
     "opencode-ai"

--- a/mise-versions.lock.json
+++ b/mise-versions.lock.json
@@ -22,7 +22,6 @@
   "just": "1.48.1",
   "kiro-cli": "1.28.3",
   "node": "24.14.0",
-  "npm:@anthropic-ai/claude-code": "2.1.86",
   "npm:@github/copilot": "1.0.13",
   "npm:@google/gemini-cli": "0.35.3",
   "npm:@guizmo-ai/zai-cli": "0.3.5",

--- a/scripts/dot/commands/ai.sh
+++ b/scripts/dot/commands/ai.sh
@@ -142,9 +142,11 @@ _ai_status_field() {
 }
 
 # binary -> mise package mapping
+# Note: claude is intentionally absent — it is installed via Anthropic's
+# native installer (see _ai_install_claude_native), not mise/npm, because
+# npm 11 drops the platform-native optionalDependency on global installs.
 _ai_mise_pkg() {
   case "$1" in
-    claude) echo "npm:@anthropic-ai/claude-code" ;;
     codex) echo "npm:@openai/codex" ;;
     copilot) echo "npm:@github/copilot" ;;
     goose) echo "pipx:goose-ai" ;;
@@ -160,6 +162,32 @@ _ai_mise_pkg() {
     zai) echo "npm:@guizmo-ai/zai-cli" ;;
     *) echo "" ;;
   esac
+}
+
+# Install Claude Code via Anthropic's native installer (~/.local/bin/claude,
+# self-updating). Used instead of mise because npm 11 silently drops the
+# platform-native optionalDependency on global installs, leaving a broken binary.
+_ai_install_claude_native() {
+  local name="${1:-Claude Code}"
+  local installer
+  installer=$(umask 077 && mktemp)
+  if curl -fsSL -o "$installer" https://claude.ai/install.sh &&
+    [ "$(wc -c <"$installer")" -le 262144 ] &&
+    head -1 "$installer" | grep -q '^#!'; then
+    if has_command gum; then
+      if gum spin --spinner dot --title "Installing $name (native installer)" -- bash "$installer"; then
+        ui_ok "$name" "installed"
+      else
+        ui_warn "$name" "install failed (continuing)"
+      fi
+    else
+      ui_info "Installing" "$name via native installer"
+      bash "$installer" || ui_warn "$name" "install failed (continuing)"
+    fi
+  else
+    ui_warn "$name" "installer download/validation failed (continuing)"
+  fi
+  rm -f "$installer"
 }
 
 cmd_ai_status() {
@@ -254,6 +282,10 @@ cmd_ai_status() {
       echo ""
       for entry in "${_ai_to_install[@]}"; do
         IFS='|' read -r name bin <<<"$entry"
+        if [[ "$bin" == "claude" ]]; then
+          _ai_install_claude_native "$name"
+          continue
+        fi
         local pkg
         pkg=$(_ai_mise_pkg "$bin")
         if [[ -n "$pkg" ]]; then

--- a/scripts/ops/chezmoi-apply.sh
+++ b/scripts/ops/chezmoi-apply.sh
@@ -151,12 +151,38 @@ check_cmd() {
   return 1
 }
 
+# Install Claude Code via Anthropic's native installer instead of mise:
+# npm 11 drops the platform-native optionalDependency on global installs,
+# leaving a broken binary. The native installer self-updates ~/.local/bin/claude.
+_install_claude_native() {
+  local label="${1:-Claude Code}"
+  local installer
+  installer=$(umask 077 && mktemp)
+  if curl -fsSL -o "$installer" https://claude.ai/install.sh &&
+    [ "$(wc -c <"$installer")" -le 262144 ] &&
+    head -1 "$installer" | grep -q '^#!'; then
+    if command -v gum &>/dev/null; then
+      if gum spin --spinner dot --title "Installing $label (native installer)" -- bash "$installer"; then
+        ui_ok "$label" "installed"
+      else
+        ui_warn "$label" "install failed (continuing)"
+      fi
+    else
+      ui_info "Installing" "$label via native installer"
+      bash "$installer" || ui_warn "$label" "install failed (continuing)"
+    fi
+  else
+    ui_warn "$label" "installer download/validation failed (continuing)"
+  fi
+  rm -f "$installer"
+}
+
 echo ""
 ui_header "AI provider CLI checks (optional)"
 
-# binary|mise_package|label
+# binary|mise_package|label  (claude uses the native installer, not mise)
 _AI_PROVIDERS=(
-  "claude|npm:@anthropic-ai/claude-code|Claude Code"
+  "claude|native|Claude Code"
   "copilot|npm:@github/copilot|Copilot CLI"
   "gemini|npm:@google/gemini-cli|Gemini CLI"
   "sgpt|pipx:shell-gpt|Shell-GPT"
@@ -224,6 +250,10 @@ if [[ ${#_ai_missing[@]} -gt 0 ]] && [[ "${DOTFILES_NONINTERACTIVE:-0}" != "1" ]
       echo ""
       for _entry in "${_ai_to_install[@]}"; do
         IFS='|' read -r _bin _pkg _label <<<"$_entry"
+        if [[ "$_bin" == "claude" ]]; then
+          _install_claude_native "$_label"
+          continue
+        fi
         if command -v gum &>/dev/null; then
           if gum spin --spinner dot --title "Installing $_label ($_pkg)" -- \
             mise use -g "$_pkg@latest" 2>&1; then

--- a/tests/regression/test_integration.sh
+++ b/tests/regression/test_integration.sh
@@ -63,7 +63,9 @@ done < "$REPO_ROOT/defaults/dot_config/mise/conf.d/00-dotfiles.toml"
 assert_equals "0" "$unmatched" "mise config.toml must have balanced quotes"
 
 test_start "integration_mise_has_ai_tools"
-assert_file_contains "$REPO_ROOT/defaults/dot_config/mise/conf.d/00-dotfiles.toml" "npm:@anthropic-ai/claude-code" "mise must include Claude Code"
+# Claude Code is installed via Anthropic's native installer, not mise/npm:
+# npm 11 drops the platform-native optionalDependency on global installs.
+assert_file_contains "$REPO_ROOT/install/provision/run_onchange_15-ai-cli-tools.sh.tmpl" "claude.ai/install.sh" "provisioning must install Claude Code via native installer"
 assert_file_contains "$REPO_ROOT/defaults/dot_config/mise/conf.d/00-dotfiles.toml" "npm:@google/gemini-cli" "mise must include Gemini CLI"
 
 test_start "integration_mise_has_modern_cli_tools"

--- a/tests/snapshots/doctor.snap
+++ b/tests/snapshots/doctor.snap
@@ -26,7 +26,7 @@
   ✓    pueue daemon                        running
 
 == AI CLIs ==
-  ✓    claude                              ~/.local/share/mise/installs/npm-anthropic-ai-claude-code/latest/bin/claude
+  ✓    claude                              ~/.local/bin/claude
   ✓    copilot                             ~/.local/share/mise/installs/npm-github-copilot/latest/bin/copilot
   ✓    gemini                              ~/.local/share/mise/installs/npm-google-gemini-cli/latest/bin/gemini
   ✓    sgpt                                ~/.local/bin/sgpt


### PR DESCRIPTION
## Why

`claude` was broken on this machine with `Error: claude native binary not installed`. Root cause: **npm 11 silently drops platform-specific `optionalDependencies` on global installs**, so the mise npm-backend install of `@anthropic-ai/claude-code` never got its native sidecar (`@anthropic-ai/claude-code-darwin-arm64`), leaving a stub bin. Confirmed reproducible with a clean cache, `--include=optional`, `--force`, and an empty npmrc — it's not a local config issue.

## What

**Claude Code → native installer** (commit `9ebffed`)
- Switched Claude Code off mise/npm onto Anthropic's native installer (`~/.local/bin/claude`, self-updating), which fetches the platform binary directly and bypasses the npm bug.
- `install/provision/run_onchange_15`: new `install_claude_native()` runs before the mise/npm block (idempotent; validates installer size + shebang).
- `dot ai` + `chezmoi-apply` "install missing providers" flows now special-case claude to the native installer instead of `mise use -g`.
- Dropped the mise pin, stale lockfile entry, and old `doctor.snap` path; updated docs + the integration regression test.

**Audit of the other npm AI tools** (commit `383b545`)
Checked every other mise-managed AI tool for the same bug. Only two needed action — both pre-existing config issues, not the npm bug:
- Removed `npm:codex-cli` — resolved to a legacy package (codex.js 0.1.3) that collided on the `codex` bin name. Codex is already provided by the native `codex` pin.
- Removed `npm:opencode-ai` — a broken-wrapper duplicate of the native `opencode` pin (mise.toml, 1.2.16).

Both shims already served the native builds, so removing the pins is a no-op at runtime (verified: `codex` 0.135.0 and `opencode` 1.2.16 still resolve + run). The rest are fine: **copilot** has a working JS fallback; **gemini/qwen** only ship optional native *addons*; **zai** has no native deps.

## Verification
- `claude --version` → `2.1.162 (Claude Code)`, resolving to the native arm64 binary
- shellcheck (`--severity=error`) + shfmt (`-i 2 -ci`) clean on all touched scripts
- provisioning template renders via `chezmoi execute-template`
- `tests/regression/test_integration.sh` — 0 failures
- TOML parses; `codex`/`opencode` re-verified working after pin removal

## Notes for reviewers
- `doctor.snap` was generated on the primary machine (`rousseau-mbp-m1`); only the claude path line was updated. The full snapshot already drifts on other machines and should be regenerated on the primary via `tests/snapshots/update.sh`.
- Out of scope (flagged, not changed): the *no-mise npm fallback* branch in the provisioning script still lists `@openai/codex` and `opencode-ai`, which would hit the same optional-dep bug if anyone installs without mise. Happy to harden separately (opencode has a native installer; codex has a brew formula).


---
THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co


<!-- ci: re-validate signature -->
