### PR TITLE
docs: fix hardcoded absolute links to relative paths

### DIFF
--- a/docs/interop/A2A.md
+++ b/docs/interop/A2A.md
@@ -8,8 +8,8 @@ The repository now ships an agent card and an A2A-ready discovery document.
 
 Artifacts:
 
-- [agent-card.json](/home/seb/.dotfiles/dot_config/dotfiles/agent-card.json)
-- [agent.json](/home/seb/.dotfiles/.well-known/agent.json)
+- [agent-card.json](../../defaults/dot_config/dotfiles/agent-card.json)
+- [agent.json](../../.well-known/agent.json)
 
 Core properties:
 

--- a/docs/operations/TRUSTED_AGENT_WORKSTATION.md
+++ b/docs/operations/TRUSTED_AGENT_WORKSTATION.md
@@ -20,12 +20,12 @@ It defines a signed, local-first workstation baseline for agentic development on
 
 The source of truth lives in tracked JSON artifacts:
 
-- [policy-bundles.json](/home/seb/.dotfiles/dot_config/dotfiles/policy-bundles.json)
-- [agent-profiles.json](/home/seb/.dotfiles/dot_config/dotfiles/agent-profiles.json)
-- [mcp-policy.json](/home/seb/.dotfiles/dot_config/dotfiles/mcp-policy.json)
-- [mcp-registry.json](/home/seb/.dotfiles/dot_config/dotfiles/mcp-registry.json)
-- [model-registry.json](/home/seb/.dotfiles/dot_config/dotfiles/model-registry.json)
-- [prompt-registry.json](/home/seb/.dotfiles/dot_config/dotfiles/prompt-registry.json)
+- [policy-bundles.json](../../defaults/dot_config/dotfiles/policy-bundles.json)
+- [agent-profiles.json](../../defaults/dot_config/dotfiles/agent-profiles.json)
+- [mcp-policy.json](../../defaults/dot_config/dotfiles/mcp-policy.json)
+- [mcp-registry.json](../../defaults/dot_config/dotfiles/mcp-registry.json)
+- [model-registry.json](../../defaults/dot_config/dotfiles/model-registry.json)
+- [prompt-registry.json](../../defaults/dot_config/dotfiles/prompt-registry.json)
 
 ## Enterprise path
 

--- a/docs/security/AUTOMATION_SECRETS.md
+++ b/docs/security/AUTOMATION_SECRETS.md
@@ -21,6 +21,6 @@ render_with_liquid: false
 ## Provisioning notes
 
 1. Store the SSH signing private key in GitHub Actions as `ACTIONS_BOT_SIGNING_KEY`.
-2. Store the matching public key in [allowed_signers](/home/seb/.dotfiles/dot_config/git/allowed_signers).
+2. Store the matching public key in [allowed_signers](../../defaults/dot_config/git/allowed_signers.tmpl).
 3. Rotate the key on personnel or workstation change.
 4. Fail closed when secrets are absent.

--- a/docs/security/MCP_POLICY.md
+++ b/docs/security/MCP_POLICY.md
@@ -21,9 +21,9 @@ Properties:
 
 ## Policy artifact
 
-The source of truth lives in [mcp-policy.json](/home/seb/.dotfiles/dot_config/dotfiles/mcp-policy.json).
-Approved package pins live in [mcp-lock.json](/home/seb/.dotfiles/dot_config/dotfiles/mcp-lock.json).
-Tracked server registry entries live in [mcp-registry.json](/home/seb/.dotfiles/dot_config/dotfiles/mcp-registry.json).
+The source of truth lives in [mcp-policy.json](../../defaults/dot_config/dotfiles/mcp-policy.json).
+Approved package pins live in [mcp-lock.json](../../defaults/dot_config/dotfiles/mcp-lock.json).
+Tracked server registry entries live in [mcp-registry.json](../../defaults/dot_config/dotfiles/mcp-registry.json).
 
 Current defaults:
 
@@ -75,4 +75,4 @@ Current approved refs:
 - active servers match the tracked registry entries
 - remote HTTP transports are HTTPS and OAuth-backed
 
-Policy bundle baselines live in [policy-bundles.json](/home/seb/.dotfiles/dot_config/dotfiles/policy-bundles.json).
+Policy bundle baselines live in [policy-bundles.json](../../defaults/dot_config/dotfiles/policy-bundles.json).

--- a/docs/security/SECURITY_CHECKLIST.md
+++ b/docs/security/SECURITY_CHECKLIST.md
@@ -11,7 +11,7 @@ Use this checklist before cutting any new release (e.g., `v0.x.x`) to ensure sup
 - [ ] **Pinned Version**: Update `install.sh` `VERSION` variable to match the release tag.
 - [ ] **Docs Sync**: Ensure `README.md` and `.github/PULL_REQUEST_TEMPLATE.md` installer URLs point to the new tag (not `main`).
 - [ ] **Clean Build**: Verify `install.sh` does not curl random scripts from third parties without pinning.
-- [ ] **SOUP Register**: Review [SOUP_REGISTER.md](/home/seb/.dotfiles/docs/security/SOUP_REGISTER.md) and confirm all active external components have an owner and validation path.
+- [ ] **SOUP Register**: Review [SOUP_REGISTER.md](SOUP_REGISTER.md) and confirm all active external components have an owner and validation path.
 
 ## 2. Secrets & Leak Prevention
 

--- a/docs/security/SOUP_REGISTER.md
+++ b/docs/security/SOUP_REGISTER.md
@@ -12,13 +12,13 @@ Controlled inventory for software of unknown pedigree used by the dotfiles platf
 
 | Component | Source | Version control | Verification path | Owner | Status |
 | :--- | :--- | :--- | :--- | :--- | :--- |
-| Homebrew installer | `raw.githubusercontent.com/Homebrew/install` | Moving upstream script, gated by `HOMEBREW_INSTALLER_SHA256` | SHA-256 in [package_managers.sh](/home/seb/.dotfiles/install/lib/package_managers.sh) | Repo maintainer | Conditional |
+| Homebrew installer | `raw.githubusercontent.com/Homebrew/install` | Moving upstream script, gated by `HOMEBREW_INSTALLER_SHA256` | SHA-256 in [package_managers.sh](../../install/lib/package_managers.sh) | Repo maintainer | Conditional |
 | Chezmoi installer | `get.chezmoi.io` | Pinned by `CHEZMOI_INSTALLER_SHA256` when used | SHA-256 in `install/lib/chezmoi.sh` | Repo maintainer | Controlled |
 | GitHub Actions marketplace actions | GitHub Marketplace | Full commit SHA pinning | Workflow `uses:` pins | Repo maintainer | Controlled |
-| Grype container | `anchore/grype` | Pinned tag in workflow | Container tag in [security-enhanced.yml](/home/seb/.dotfiles/.github/workflows/security-enhanced.yml) | Repo maintainer | Controlled |
-| Trivy container | `aquasec/trivy` | Pinned tag in workflow | Container tag in [security-enhanced.yml](/home/seb/.dotfiles/.github/workflows/security-enhanced.yml) | Repo maintainer | Controlled |
+| Grype container | `anchore/grype` | Pinned tag in workflow | Container tag in [security-enhanced.yml](../../.github/workflows/security-enhanced.yml) | Repo maintainer | Controlled |
+| Trivy container | `aquasec/trivy` | Pinned tag in workflow | Container tag in [security-enhanced.yml](../../.github/workflows/security-enhanced.yml) | Repo maintainer | Controlled |
 | Checkov action | GitHub Marketplace | Full commit SHA pinning | Workflow `uses:` pin | Repo maintainer | Controlled |
-| Nix inputs | GitHub flakes | Locked in [flake.lock](/home/seb/.dotfiles/flake.lock) | `narHash` and revision lock | Repo maintainer | Controlled |
+| Nix inputs | GitHub flakes | Locked in [flake.lock](../../flake.lock) | `narHash` and revision lock | Repo maintainer | Controlled |
 | GitHub release metadata queries | GitHub API | Discovery only, not release validation | `update-deps.yml` query path | Repo maintainer | Monitored |
 
 ## Validation record


### PR DESCRIPTION
## Summary

Verification of docs content accuracy turned up **18 hardcoded absolute markdown links** (`/home/seb/.dotfiles/...`) across 6 docs files — broken on GitHub, on any other machine, and on macOS (`/Users` vs `/home`).

Converted each to a path relative to the linking file, applying the v0.2.503 reorg (`dot_config/` -> `defaults/dot_config/`) and pointing the git `allowed_signers` reference at its `.tmpl` source. Verified every target resolves from its file; 0 absolute links remain.

Files: A2A.md, TRUSTED_AGENT_WORKSTATION.md, AUTOMATION_SECRETS.md, MCP_POLICY.md, SECURITY_CHECKLIST.md, SOUP_REGISTER.md

---
THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co
