### PR TITLE
fix(ci): poll for release asset so distribution succeeds first-run

### DIFF
--- a/.github/workflows/release-distribute-aur.yml
+++ b/.github/workflows/release-distribute-aur.yml
@@ -60,10 +60,20 @@ jobs:
           ASSET_NAME="dot-${VERSION}.tar.gz"
           echo "Downloading ${ASSET_NAME} from release ${TAG}..."
           mkdir -p assets
-          gh release download "$TAG" --dir assets --pattern "${ASSET_NAME}"
-          ASSET_PATH="$(find assets -name "${ASSET_NAME}" -type f | head -1)"
+          # The packaging workflow (release-package-dot.yml) uploads this asset
+          # in parallel on the same `release: published` event, so it may not be
+          # present yet when this job starts (the race that failed first-run
+          # distribution on v0.2.504/v0.2.505). Poll for it (~5 min) before failing.
+          ASSET_PATH=""
+          for attempt in $(seq 1 20); do
+            gh release download "$TAG" --dir assets --pattern "${ASSET_NAME}" --clobber 2>/dev/null || true
+            ASSET_PATH="$(find assets -name "${ASSET_NAME}" -type f | head -1)"
+            [[ -n "$ASSET_PATH" ]] && break
+            echo "Asset ${ASSET_NAME} not ready (attempt ${attempt}/20); waiting 15s..."
+            sleep 15
+          done
           if [[ -z "$ASSET_PATH" ]]; then
-            echo "::error::Asset ${ASSET_NAME} not found in release ${TAG}"
+            echo "::error::Asset ${ASSET_NAME} not found in release ${TAG} after ~5min"
             exit 1
           fi
           echo "asset_path=${ASSET_PATH}" >> $GITHUB_OUTPUT

--- a/.github/workflows/release-distribute-homebrew.yml
+++ b/.github/workflows/release-distribute-homebrew.yml
@@ -87,10 +87,20 @@ jobs:
           ASSET_NAME="dot-${VERSION}.tar.gz"
           echo "Downloading ${ASSET_NAME} from release ${TAG}..."
           mkdir -p assets
-          gh release download "$TAG" --dir assets --pattern "${ASSET_NAME}"
-          ASSET_PATH="$(find assets -name "${ASSET_NAME}" -type f | head -1)"
+          # The packaging workflow (release-package-dot.yml) uploads this asset
+          # in parallel on the same `release: published` event, so it may not be
+          # present yet when this job starts (the race that failed first-run
+          # distribution on v0.2.504/v0.2.505). Poll for it (~5 min) before failing.
+          ASSET_PATH=""
+          for attempt in $(seq 1 20); do
+            gh release download "$TAG" --dir assets --pattern "${ASSET_NAME}" --clobber 2>/dev/null || true
+            ASSET_PATH="$(find assets -name "${ASSET_NAME}" -type f | head -1)"
+            [[ -n "$ASSET_PATH" ]] && break
+            echo "Asset ${ASSET_NAME} not ready (attempt ${attempt}/20); waiting 15s..."
+            sleep 15
+          done
           if [[ -z "$ASSET_PATH" ]]; then
-            echo "::error::Asset ${ASSET_NAME} not found in release ${TAG}"
+            echo "::error::Asset ${ASSET_NAME} not found in release ${TAG} after ~5min"
             exit 1
           fi
           echo "asset_path=${ASSET_PATH}" >> $GITHUB_OUTPUT

--- a/.github/workflows/release-distribute-scoop.yml
+++ b/.github/workflows/release-distribute-scoop.yml
@@ -87,10 +87,20 @@ jobs:
           ASSET_NAME="dot-${VERSION}.zip"
           echo "Downloading ${ASSET_NAME} from release ${TAG}..."
           mkdir -p assets
-          gh release download "$TAG" --dir assets --pattern "${ASSET_NAME}"
-          ASSET_PATH="$(find assets -name "${ASSET_NAME}" -type f | head -1)"
+          # The packaging workflow (release-package-dot.yml) uploads this asset
+          # in parallel on the same `release: published` event, so it may not be
+          # present yet when this job starts (the race that failed first-run
+          # distribution on v0.2.504/v0.2.505). Poll for it (~5 min) before failing.
+          ASSET_PATH=""
+          for attempt in $(seq 1 20); do
+            gh release download "$TAG" --dir assets --pattern "${ASSET_NAME}" --clobber 2>/dev/null || true
+            ASSET_PATH="$(find assets -name "${ASSET_NAME}" -type f | head -1)"
+            [[ -n "$ASSET_PATH" ]] && break
+            echo "Asset ${ASSET_NAME} not ready (attempt ${attempt}/20); waiting 15s..."
+            sleep 15
+          done
           if [[ -z "$ASSET_PATH" ]]; then
-            echo "::error::Asset ${ASSET_NAME} not found in release ${TAG}"
+            echo "::error::Asset ${ASSET_NAME} not found in release ${TAG} after ~5min"
             exit 1
           fi
           echo "asset_path=${ASSET_PATH}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary

Fixes the release-day distribution race: the three `release-distribute-*` workflows download the `dot-<version>` asset that `release-package-dot.yml` uploads, but all four fire on the same `release: published` event in parallel — so the distributors hit "Download release asset" before the asset existed and failed. This required a manual re-run on **both v0.2.504 and v0.2.505**.

Wraps `gh release download` in a poll loop (20 x 15s, ~5 min; normally resolved in 1-2 tries) in all three workflows. Cross-workflow `needs:` is not possible (separate workflows, same event).

Validated: YAML parses (yq), embedded bash `bash -n` clean. Takes effect for v0.2.506+; v0.2.505 is already distributed (via the manual re-run).

---
THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co
