### PR TITLE
fix(ci): repin stale reusable-shell-lint pin (fixes master startup failures)

### DIFF
--- a/.github/workflows/bump-reusable-pins.yml
+++ b/.github/workflows/bump-reusable-pins.yml
@@ -41,7 +41,10 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # A PAT with `workflow` scope is required to push changes to
+          # .github/workflows/* (GITHUB_TOKEN is forbidden from doing so).
+          # Falls back to GITHUB_TOKEN, in which case the Open PR step skips.
+          token: ${{ secrets.WORKFLOW_PIN_BUMP_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Setup Git
         run: |
@@ -116,10 +119,25 @@ jobs:
       - name: Open PR
         if: steps.detect.outputs.changes != '0'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.WORKFLOW_PIN_BUMP_TOKEN || secrets.GITHUB_TOKEN }}
+          HAS_PAT: ${{ secrets.WORKFLOW_PIN_BUMP_TOKEN != '' }}
           SUMMARY: ${{ steps.detect.outputs.summary }}
         run: |
           set -euo pipefail
+          # GITHUB_TOKEN cannot push changes to .github/workflows/* (a GitHub
+          # App restriction), so without a PAT the push would hard-fail. Skip
+          # gracefully with a warning instead, and surface the pending bump.
+          if [[ "${HAS_PAT}" != "true" ]]; then
+            echo "::warning::WORKFLOW_PIN_BUMP_TOKEN not set — cannot push workflow-file pin bumps with GITHUB_TOKEN. Skipping the bump PR."
+            {
+              echo "### Stale reusable pins detected but not bumped"
+              echo
+              echo "Add a PAT with the \`workflow\` scope as the \`WORKFLOW_PIN_BUMP_TOKEN\` secret to enable the automated bump PR."
+              echo
+              printf '%s\n' "${SUMMARY}"
+            } >> "${GITHUB_STEP_SUMMARY}"
+            exit 0
+          fi
           git checkout -b "${BRANCH_NAME}"
           git add .github/workflows/
           git commit -m "$(cat <<MSG

--- a/.github/workflows/ci-enforced.yml
+++ b/.github/workflows/ci-enforced.yml
@@ -33,7 +33,7 @@ jobs:
   # ============================================================================
   lint-shell:
     name: Lint / Shell (Zero Warnings)
-    uses: sebastienrousseau/dotfiles/.github/workflows/reusable-shell-lint.yml@49bdc6f3aea9df02f8032e4ac16c6228b82ede94 # feat/v0.2.503
+    uses: sebastienrousseau/dotfiles/.github/workflows/reusable-shell-lint.yml@91922371a9774e39e018179d9eaf44d4746f4a0d # master
     with:
       include_tests: false
       shellcheck_severity: error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
     name: Lint / Shell
     needs: changes
     if: needs.changes.outputs.shell == 'true' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    uses: sebastienrousseau/dotfiles/.github/workflows/reusable-shell-lint.yml@49bdc6f3aea9df02f8032e4ac16c6228b82ede94 # feat/v0.2.503
+    uses: sebastienrousseau/dotfiles/.github/workflows/reusable-shell-lint.yml@91922371a9774e39e018179d9eaf44d4746f4a0d # master
     with:
       include_tests: false
       shellcheck_severity: error

--- a/scripts/theme/wallpaper-sync.sh
+++ b/scripts/theme/wallpaper-sync.sh
@@ -196,12 +196,12 @@ system_wallpaper_for_theme() {
     local sys_wp=""
     case "$family" in
       "macos - sonoma") sys_wp="$SYS_MAC/Sonoma.heic" ;;
-      "macos - blue")   sys_wp="$SYS_MAC/Mac Blue.heic" ;;
-      "macos - pink")   sys_wp="$SYS_MAC/Mac Pink.heic" ;;
+      "macos - blue") sys_wp="$SYS_MAC/Mac Blue.heic" ;;
+      "macos - pink") sys_wp="$SYS_MAC/Mac Pink.heic" ;;
       "macos - purple") sys_wp="$SYS_MAC/Mac Purple.heic" ;;
       "macos - yellow") sys_wp="$SYS_MAC/Mac Yellow.heic" ;;
       "macos - orange") sys_wp="$SYS_MAC/iMac Orange.heic" ;;
-      "macos - green")  sys_wp="$SYS_MAC/iMac Green.heic" ;;
+      "macos - green") sys_wp="$SYS_MAC/iMac Green.heic" ;;
       "macos - silver") sys_wp="$SYS_MAC/iMac Silver.heic" ;;
     esac
     if [[ -n "$sys_wp" && -f "$sys_wp" ]]; then


### PR DESCRIPTION
## Problem
After #936 merged, `ci.yml` and `ci-enforced.yml` failed at **startup** on `master` (0 jobs run), and **Bump Reusable Pins** hard-failed too.

- `ci.yml` / `ci-enforced.yml` pinned `reusable-shell-lint.yml@49bdc6f3… # feat/v0.2.503`. That commit is **no longer reachable** (feature branch deleted, commit GC'd), so GitHub cannot resolve the reusable workflow → startup failure.
- `bump-reusable-pins.yml` (which is meant to keep these pins fresh) pushed with `GITHUB_TOKEN`, which GitHub **forbids** from modifying `.github/workflows/*` files → hard failure. That's why the stale pin lingered instead of being auto-bumped.

## Fix
- Repin `reusable-shell-lint.yml` to `91922371 # master` in both files — the SHA the sibling reusable pins already use, where the file exists and is a valid `workflow_call` target. Verified all self-referencing reusable pins now resolve.
- `bump-reusable-pins.yml`: use `secrets.WORKFLOW_PIN_BUMP_TOKEN` (a PAT with `workflow` scope) when present; when absent, **skip the bump PR gracefully** with a warning + job-summary instead of failing.

## Note
For the bump workflow to actually push pin updates, add a PAT with `workflow` scope as the `WORKFLOW_PIN_BUMP_TOKEN` repo secret. Until then it skips cleanly (no red failure).

---

THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co