### PR TITLE
fix(ci): backlog from #938 — theme nil-guard + shfmt-absent skip

### DIFF
--- a/defaults/dot_config/firefox/user.js.tmpl
+++ b/defaults/dot_config/firefox/user.js.tmpl
@@ -4,7 +4,8 @@
 
 /* global user_pref */
 
-{{- $t := index .themes .theme -}}
+{{- $t := index .themes (default "big-sur-dark" .theme) -}}
+{{- if not $t -}}{{- $t = index .themes "big-sur-dark" -}}{{- end -}}
 
 // Disable telemetry
 user_pref("toolkit.telemetry.enabled", false);

--- a/tests/regression/test_static_analysis.sh
+++ b/tests/regression/test_static_analysis.sh
@@ -122,14 +122,20 @@ assert_equals "0" "$failures" "new scripts must not have unquoted variables (SC2
 
 test_start "shfmt_formatting"
 failures=0
-for f in "${CHANGED_SCRIPTS[@]}"; do
-  filepath="$REPO_ROOT/$f"
-  [[ -f "$filepath" ]] || continue
-  if ! shfmt -d -i 2 -ci "$filepath" >/dev/null 2>&1; then
-    printf '    shfmt: %s\n' "$f"
-    failures=$((failures + 1))
-  fi
-done
+if command -v shfmt >/dev/null 2>&1; then
+  for f in "${CHANGED_SCRIPTS[@]}"; do
+    filepath="$REPO_ROOT/$f"
+    [[ -f "$filepath" ]] || continue
+    if ! shfmt -d -i 2 -ci "$filepath" >/dev/null 2>&1; then
+      printf '    shfmt: %s\n' "$f"
+      failures=$((failures + 1))
+    fi
+  done
+else
+  # shfmt is not present in every CI job (the dedicated shell-lint job
+  # installs and runs it). Skip rather than false-fail on command-not-found.
+  printf '    shfmt not installed — skipping (covered by the shell-lint job)\n'
+fi
 assert_equals "0" "$failures" "all changed scripts must pass shfmt -i 2 -ci"
 
 # ═══════════════════════════════════════════════════════════════


### PR DESCRIPTION
Fixes the two real failures tracked in #938 (un-masked once the workflows could start again):

## `Test / Windows` — chezmoi render crash
`dot_config/firefox/user.js.tmpl` was the only theme template using the unguarded `index .themes .theme`. When the selected theme isn't in the committed `themes.toml` (the `flower-dark` default lives only in the in-flight `themes.toml` rework), `$t` is nil and `$t.mode` crashes `chezmoi apply --dry-run`. Adopt the same `default` + fallback-to-`big-sur-dark` guard the other theme templates already use. **Does not change your intended theme defaults.**

## `Test / Unit Test Suite` — false shfmt failure
The test-suite job installs `ripgrep` (and the runner has `shellcheck`) but **not `shfmt`**, so `shfmt -d` hit command-not-found and every checked file counted as a failure. Guard `shfmt_formatting` with `command -v shfmt` and skip when absent — formatting is still enforced by the dedicated shell-lint job (which installs shfmt). The other ✗ lines in that job were diagnostic output from passing tests (4840 passed, this was the only failure).

Verified locally: `test_static_analysis.sh` passes with shfmt present (51/51) and skips cleanly without it; firefox template renders.

---

THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co