### PR TITLE
fix(ai): repair amp/cursor installs and stop duplicate banners

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Dotfiles - gitignore
 # v0.2.500
 
+# Locally built Go binaries (dot-ai-tui is built to ~/.local/bin via run_onchange)
+defaults/dot_local/share/dot-ai-tui/dot-ai-tui
+
 # OS Artifacts
 .DS_Store
 .AppleDouble

--- a/defaults/dot_local/share/dot-ai-tui/main.go
+++ b/defaults/dot_local/share/dot-ai-tui/main.go
@@ -472,8 +472,12 @@ func highlight(text string) string {
 func execDone(error) tea.Msg { return refresh() }
 
 // dotExec suspends the TUI for an interactive `dot ai <args…>` then refreshes.
+// DOT_AI_RAW=1 suppresses the command banner: the cockpit is already the UI,
+// and shelling out per tool (e.g. install) would otherwise reprint the full
+// Version/Command/Summary block on every invocation.
 func dotExec(args ...string) tea.Cmd {
 	c := execCommand("dot", append([]string{"ai"}, args...)...)
+	c.Env = append(os.Environ(), "DOT_AI_RAW=1")
 	return tea.ExecProcess(c, execDone)
 }
 

--- a/lib/dot/ai-commands.sh
+++ b/lib/dot/ai-commands.sh
@@ -194,6 +194,10 @@ cmd_ai_install() {
         install_agy_native "Antigravity CLI"
         continue
         ;;
+      amp)
+        install_amp_native "Amp"
+        continue
+        ;;
       cursor-agent)
         install_cursor_native "Cursor CLI"
         continue

--- a/lib/dot/ai-install.sh
+++ b/lib/dot/ai-install.sh
@@ -23,7 +23,7 @@ _ai_mise_pkg() {
     copilot) echo "npm:@github/copilot" ;;
     goose) echo "" ;;
     crush) echo "npm:@charmland/crush" ;;
-    amp) echo "npm:@sourcegraph/amp" ;;
+    amp) echo "" ;; # native installer (npm versions are prerelease-only; mise filters them out)
     cursor-agent) echo "" ;;
     grok) echo "" ;;
     aider) echo "pipx:aider-chat" ;;
@@ -149,12 +149,43 @@ install_grok_native() {
   # LCOV_EXCL_STOP
 }
 
+install_amp_native() {
+  # LCOV_EXCL_START — network curl|bash installer (see install_agy_native).
+  # amp publishes only prerelease-tagged npm versions (0.0.<epoch>-g<sha>),
+  # which mise's npm backend filters out — `@latest` resolves to nothing.
+  # Use Sourcegraph's native installer instead of mise.
+  local label="${1:-Amp}"
+  local installer
+  installer=$(umask 077 && mktemp)
+  if curl -fsSL -o "$installer" https://ampcode.com/install.sh &&
+    [ "$(wc -c <"$installer")" -le 524288 ] &&
+    head -1 "$installer" | grep -q '^#!'; then
+    if command -v gum >/dev/null 2>&1; then
+      if gum spin --spinner dot --title "Installing $label (native installer)" -- bash "$installer"; then
+        ui_ok "$label" "installed"
+      else
+        ui_warn "$label" "install failed (continuing)"
+      fi
+    else
+      ui_info "Installing" "$label via native installer"
+      bash "$installer" || ui_warn "$label" "install failed (continuing)"
+    fi
+  else
+    ui_warn "$label" "installer download/validation failed (continuing)"
+  fi
+  rm -f "$installer"
+  # LCOV_EXCL_STOP
+}
+
 install_cursor_native() {
   # LCOV_EXCL_START — network curl|bash installer (see install_agy_native).
   local label="${1:-Cursor CLI}"
   local installer
   installer=$(umask 077 && mktemp)
-  if curl -fsSL -o "$installer" https://cursor.com/install &&
+  # cursor.com/install User-Agent-sniffs: a default curl UA is served the
+  # marketing HTML page (which fails the shebang check below), while a
+  # browser-like UA gets the real install script. Spoof a browser UA.
+  if curl -fsSL -A "Mozilla/5.0" -o "$installer" https://cursor.com/install &&
     [ "$(wc -c <"$installer")" -le 524288 ] &&
     head -1 "$installer" | grep -q '^#!'; then
     if command -v gum >/dev/null 2>&1; then

--- a/lib/dot/ai-install.sh
+++ b/lib/dot/ai-install.sh
@@ -160,15 +160,24 @@ install_amp_native() {
   if curl -fsSL -o "$installer" https://ampcode.com/install.sh &&
     [ "$(wc -c <"$installer")" -le 524288 ] &&
     head -1 "$installer" | grep -q '^#!'; then
+    # Pre-resolve the version and pass it via AMP_VERSION. The installer's
+    # own version fetch leaves stray whitespace in the string, which it
+    # then splices into the checksum URL — curl rejects the malformed URL
+    # ("Malformed input to a URL function") and the install dies. Setting
+    # AMP_VERSION skips that fetch entirely. Empty on failure: the
+    # installer falls back to its own (possibly-working) fetch.
+    local amp_version
+    amp_version="$(curl -fsSL https://static.ampcode.com/cli/cli-version.txt 2>/dev/null | tr -d '[:space:]')"
     if command -v gum >/dev/null 2>&1; then
-      if gum spin --spinner dot --title "Installing $label (native installer)" -- bash "$installer"; then
+      if gum spin --spinner dot --title "Installing $label (native installer)" -- \
+        env AMP_VERSION="$amp_version" bash "$installer"; then
         ui_ok "$label" "installed"
       else
         ui_warn "$label" "install failed (continuing)"
       fi
     else
       ui_info "Installing" "$label via native installer"
-      bash "$installer" || ui_warn "$label" "install failed (continuing)"
+      AMP_VERSION="$amp_version" bash "$installer" || ui_warn "$label" "install failed (continuing)"
     fi
   else
     ui_warn "$label" "installer download/validation failed (continuing)"

--- a/lib/dot/utils.sh
+++ b/lib/dot/utils.sh
@@ -201,6 +201,9 @@ dot_command_summary() {
     apply | sync)
       echo "Apply dotfiles changes (sync is an alias for apply)."
       ;;
+    ai)
+      echo "AI fleet cockpit, gateway, tools, and cost."
+      ;;
     update)
       echo "Pull latest changes from remote, then apply."
       ;;

--- a/scripts/dot/commands/ai.sh
+++ b/scripts/dot/commands/ai.sh
@@ -249,14 +249,33 @@ cmd_ai_status() {
       echo ""
       for entry in "${_ai_to_install[@]}"; do
         IFS='|' read -r name bin <<<"$entry"
-        if [[ "$bin" == "claude" ]]; then
-          install_claude_native "$name"
-          continue
-        fi
-        if [[ "$bin" == "agy" ]]; then
-          install_agy_native "$name"
-          continue
-        fi
+        # Tools without a mise package use their vendor's native installer.
+        case "$bin" in
+          claude)
+            install_claude_native "$name"
+            continue
+            ;;
+          goose)
+            install_goose_native "$name"
+            continue
+            ;;
+          agy)
+            install_agy_native "$name"
+            continue
+            ;;
+          amp)
+            install_amp_native "$name"
+            continue
+            ;;
+          cursor-agent)
+            install_cursor_native "$name"
+            continue
+            ;;
+          grok)
+            install_grok_native "$name"
+            continue
+            ;;
+        esac
         local pkg
         pkg=$(_ai_mise_pkg "$bin")
         if [[ -n "$pkg" ]]; then


### PR DESCRIPTION
<!-- Verified for v0.2.507 release -->

## Summary

Fixes three reproducible failures seen when running `dot ai`:

1. **Duplicate command banner** — bare `dot ai` execs the cockpit (`dot-ai-tui`), whose install action shells out to `dot ai install <tool>` once per tool via `dotExec`. Unlike the streaming path, `dotExec` didn't set `DOT_AI_RAW=1`, so every invocation reprinted the full `Version/Command/Summary` block. Now sets `DOT_AI_RAW=1`.
2. **`amp` install always failed** — `@sourcegraph/amp` publishes only prerelease-tagged npm versions (`0.0.<epoch>-g<sha>`), which mise filters out, so `@latest` resolves to nothing (`mise ls-remote` returns empty). Routed through Sourcegraph's native installer (`ampcode.com/install.sh`).
3. **Cursor CLI "download/validation failed"** — `cursor.com/install` User-Agent-sniffs and serves marketing HTML to default curl (fails the shebang check). Now sends a browser UA to fetch the real install script.

## Also

- Unified the `cmd_ai_status` fallback install loop to use the native installers — `amp`/`cursor-agent`/`goose`/`grok` were previously skipped silently there.
- Added an `ai` case to `dot_command_summary` (banner showed the generic "Run a dotfiles command.").
- Gitignored the locally built `dot-ai-tui` binary.

## Verification

- Go: `build`, `vet`, `test` all pass.
- Shell: AI unit tests pass (0 failures); `shfmt -i 2 -ci`, `shellcheck --severity=error`, and `gofmt` all clean.
- Installer URLs confirmed to return valid `#!`-prefixed scripts under the exact curl flags used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co
