### PR TITLE
fix(apply): make dot apply/update unattended and macOS-safe

### DIFF
--- a/scripts/ops/chezmoi-apply.sh
+++ b/scripts/ops/chezmoi-apply.sh
@@ -19,9 +19,11 @@ export DOT_COMMAND="apply"
 # (macOS) expanding an empty array under `set -u` is an "unbound
 # variable" error, which would fire on every clean `dot sync`.
 _TMPFILES=()
+_LOCK_DIR=""
 cleanup() {
   set +u
   rm -f "${_TMPFILES[@]}" 2>/dev/null
+  [[ -n "$_LOCK_DIR" ]] && rmdir "$_LOCK_DIR" 2>/dev/null
   set -u
 }
 trap cleanup EXIT
@@ -39,7 +41,9 @@ Environment Variables:
   DOTFILES_CHEZMOI_APPLY_FLAGS    Extra flags for chezmoi apply
   DOTFILES_CHEZMOI_VERBOSE=1      Enable verbose output
   DOTFILES_CHEZMOI_KEEP_GOING=1   Continue on errors
-  DOTFILES_NONINTERACTIVE=1       Force non-interactive mode
+  DOTFILES_NONINTERACTIVE=1       Skip interactive menus (AI provider installer)
+  DOTFILES_INTERACTIVE_APPLY=1    Re-enable chezmoi overwrite prompts
+                                  (apply is unattended/--force by default)
   DOTFILES_ALIAS_STRICT_MODE=1    Run alias governance checks
   DOTFILES_SNAPSHOT_ON_APPLY=1    Create baseline snapshot (default)
   DOTFILES_POST_APPLY_REPAIR=1   Run post-apply repairs (default)
@@ -67,25 +71,55 @@ fi
 has_flag() {
   local needle="$1"
   local arg
+  # Guard the expansion: on bash 3.2 (macOS) iterating an empty array
+  # under `set -u` is an unbound-variable error.
+  [[ ${#args[@]} -eq 0 ]] && return 1
   for arg in "${args[@]}"; do
     [[ "$arg" == "$needle" ]] && return 0
   done
   return 1
 }
 
-# In non-interactive runs, prevent TTY prompts from blocking apply.
-if [[ "${DOTFILES_NONINTERACTIVE:-0}" == "1" ]] && ! has_flag "--force"; then
+# Apply unattended by default, like an OS package manager. chezmoi is
+# always run below under `gum spin` or with its output captured, so it
+# never has a controlling TTY; its "<file> has changed since chezmoi last
+# wrote it" confirmation prompt therefore cannot be answered and aborts
+# the run with "could not open a new TTY". Passing --force applies the
+# canonical source without prompting, so local drift to *managed* files
+# yields to the source — exactly how `apt`/system updates behave. Keep
+# machine-specific tweaks in the unmanaged ~/.zshrc.local or
+# ~/.config/zsh/rc.d.local/*.zsh, which chezmoi never overwrites.
+# Opt back into chezmoi's prompts with DOTFILES_INTERACTIVE_APPLY=1.
+if [[ "${DOTFILES_INTERACTIVE_APPLY:-0}" != "1" ]] && ! has_flag "--force"; then
   args+=("--force")
+fi
+
+# Whether interactive menus (the optional AI-provider installer below) may
+# prompt. Suppressed without a TTY, under CI, or when non-interactive is
+# requested — so unattended runs never hang waiting on input.
+INTERACTIVE=1
+if [[ "${DOTFILES_NONINTERACTIVE:-0}" == "1" ]] || [[ -n "${CI:-}" ]] || [[ ! -t 0 ]] || [[ ! -t 1 ]]; then
+  INTERACTIVE=0
 fi
 
 ui_init
 
-# Prevent concurrent execution
-LOCK_FILE="${XDG_RUNTIME_DIR:-/tmp}/dotfiles-chezmoi-apply.lock"
-exec 9>"$LOCK_FILE"
-if ! flock -n 9; then
+# Prevent concurrent execution. flock(1) is Linux-only — it does not exist
+# on macOS, where `! flock` previously took the "already running" branch and
+# made `dot apply` a silent no-op. Use flock where present, otherwise fall
+# back to an atomic mkdir lock (portable to macOS/BSD).
+_lock_base="${XDG_RUNTIME_DIR:-${TMPDIR:-/tmp}}/dotfiles-chezmoi-apply"
+if command -v flock >/dev/null 2>&1; then
+  exec 9>"${_lock_base}.lock"
+  if ! flock -n 9; then
+    ui_warn "Already running" "Another instance is active"
+    exit 0
+  fi
+elif ! mkdir "${_lock_base}.lock.d" 2>/dev/null; then
   ui_warn "Already running" "Another instance is active"
   exit 0
+else
+  _LOCK_DIR="${_lock_base}.lock.d" # removed by cleanup() on exit
 fi
 
 run_step() {
@@ -187,7 +221,7 @@ for _entry in "${_AI_PROVIDERS[@]}"; do
   fi
 done
 
-if [[ ${#_ai_missing[@]} -gt 0 ]] && [[ "${DOTFILES_NONINTERACTIVE:-0}" != "1" ]]; then
+if [[ ${#_ai_missing[@]} -gt 0 ]] && [[ "$INTERACTIVE" == "1" ]]; then
   if command -v mise &>/dev/null; then
     echo ""
     _ai_install_action=""

--- a/scripts/ops/chezmoi-update.sh
+++ b/scripts/ops/chezmoi-update.sh
@@ -14,6 +14,20 @@ if [[ "${DOTFILES_CHEZMOI_VERBOSE:-0}" = "1" ]]; then
   args+=("--verbose")
 fi
 
+# Apply unattended by default (see chezmoi-apply.sh). `chezmoi update` runs
+# `apply` internally, so without --force it blocks on the "<file> has
+# changed since chezmoi last wrote it" prompt — and `dot update` is often
+# run from cron/CI/--async with no TTY, where that prompt aborts the run.
+# --force makes updates land like an OS package-manager update; opt back
+# into prompting with DOTFILES_INTERACTIVE_APPLY=1.
+if [[ "${DOTFILES_INTERACTIVE_APPLY:-0}" != "1" ]]; then
+  _has_force=0
+  if [[ ${#args[@]} -gt 0 ]]; then
+    for _a in "${args[@]}"; do [[ "$_a" == "--force" ]] && _has_force=1; done
+  fi
+  [[ "$_has_force" == "0" ]] && args+=("--force")
+fi
+
 ASYNC=false
 if [[ "${DOTFILES_ASYNC_UPDATE:-0}" = "1" ]]; then
   ASYNC=true

--- a/tests/regression/test_boundary_edge_cases.sh
+++ b/tests/regression/test_boundary_edge_cases.sh
@@ -80,10 +80,16 @@ fi
 # ═══════════════════════════════════════════════════════════════
 
 test_start "edge_apply_has_lock_mechanism"
-assert_file_contains "$REPO_ROOT/scripts/ops/chezmoi-apply.sh" "LOCK_FILE" "apply must use lock file"
+assert_file_contains "$REPO_ROOT/scripts/ops/chezmoi-apply.sh" ".lock" "apply must use a lock file/dir"
 
 test_start "edge_apply_flock_guard"
-assert_file_contains "$REPO_ROOT/scripts/ops/chezmoi-apply.sh" "flock" "apply must use flock for concurrency"
+assert_file_contains "$REPO_ROOT/scripts/ops/chezmoi-apply.sh" "flock" "apply must use flock where available"
+
+test_start "edge_apply_mkdir_lock_fallback"
+# flock(1) is Linux-only; apply must fall back to an atomic mkdir lock so
+# concurrency stays guarded on macOS/BSD (regression: `! flock` previously
+# took the "already running" branch, making `dot apply` a silent no-op).
+assert_file_contains "$REPO_ROOT/scripts/ops/chezmoi-apply.sh" ".lock.d" "apply must fall back to a mkdir lock on macOS/BSD"
 
 test_start "edge_rollback_has_lock"
 assert_file_contains "$REPO_ROOT/scripts/ops/rollback.sh" "lock" "rollback must have lock mechanism"

--- a/tests/regression/test_boundary_edge_cases.sh
+++ b/tests/regression/test_boundary_edge_cases.sh
@@ -335,7 +335,7 @@ assert_file_exists "$REPO_ROOT/defaults/dot_config/shell/00-core-paths.sh.tmpl" 
 test_start "edge_alias_files_under_50kb"
 oversized=0
 while IFS= read -r f; do
-  size=$(wc -c < "$f" | tr -d ' ')
+  size=$(wc -c <"$f" | tr -d ' ')
   if [[ "$size" -gt 51200 ]]; then
     oversized=$((oversized + 1))
   fi
@@ -345,7 +345,7 @@ assert_equals "0" "$oversized" "no alias files exceed 50KB"
 test_start "edge_function_files_under_50kb"
 oversized=0
 while IFS= read -r f; do
-  size=$(wc -c < "$f" | tr -d ' ')
+  size=$(wc -c <"$f" | tr -d ' ')
   if [[ "$size" -gt 51200 ]]; then
     oversized=$((oversized + 1))
   fi


### PR DESCRIPTION
## Problem

`dot apply` / `dot update` couldn't run unattended — they broke the OS-update-style "just apply the latest" workflow (cron, CI, agents, piped output, or any non-TTY caller). Two distinct bugs:

1. **TTY prompt deadlock.** chezmoi always runs under `gum spin`/captured output, so it never has a controlling TTY. When a managed file had local drift, chezmoi's `"<file> has changed since chezmoi last wrote it"` confirmation couldn't be answered and aborted with `could not open a new TTY`.
2. **macOS silent no-op.** The concurrency lock used `flock(1)`, which **doesn't exist on macOS**. `! flock` (command-not-found → rc 127) took the "already running" branch, so `dot apply` exited 0 **without applying anything**.

## Fix

- **Unattended by default:** pass `--force` so the canonical source is applied without prompting — like `apt`/system updates. Drift to *managed* files yields to the source. Opt back into chezmoi's prompts with `DOTFILES_INTERACTIVE_APPLY=1`. Machine-local tweaks belong in the unmanaged `~/.zshrc.local` or `~/.config/zsh/rc.d.local/*.zsh` (chezmoi never overwrites those).
- **Portable lock:** use `flock` where present, else an atomic `mkdir` lock (macOS/BSD-safe), cleaned up on exit.
- **Interactivity-aware AI menu:** the optional AI-provider installer prompts only with a real TTY (and not under CI).
- **bash 3.2 safety:** guard `has_flag` against empty-array expansion.
- Same `--force` default applied to `chezmoi-update.sh`.

## Verification (macOS, this machine)

- Ran the new `chezmoi-apply.sh` non-interactively: no TTY error, no "already running" no-op, **Status: ✓ Clean**.
- `dot doctor` → **✓ Healthy — All checks passed** (exit 0); `chezmoi: ✓ synchronized`.
- Pre-existing `.zshrc` grok-installer drift relocated to the unmanaged `~/.zshrc.local`; `grok` still on PATH, chezmoi drift now 0.

---
THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co