### PR TITLE
chore(release): v0.2.508

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@
 
 ## Project Overview
 
-Chezmoi-managed dotfiles for macOS, Linux, WSL, and PowerShell 7.5+. Version `0.2.507`.
+Chezmoi-managed dotfiles for macOS, Linux, WSL, and PowerShell 7.5+. Version `0.2.508`.
 
 ## Key Commands
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 This file documents all notable changes to this project.
 
+## v0.2.508 — 2026-06-30
+
+Makes `dot apply` / `dot update` behave like an OS package-manager update —
+unattended and reliable on macOS — and converts the cross-platform required
+check into an always-runs gate so documentation-only PRs are mergeable.
+
+### Fixed
+
+- **`dot apply` / `dot update` run unattended** (#946). They no longer stall on
+  chezmoi's "file changed since chezmoi last wrote it" prompt, which could not
+  be answered because chezmoi always runs under `gum spin`/captured output (no
+  controlling TTY) and aborted with "could not open a new TTY". They now apply
+  the canonical source with `--force` by default, like `apt`/system updates;
+  local drift to *managed* files yields to the source. Opt back into prompts
+  with `DOTFILES_INTERACTIVE_APPLY=1`, and keep machine-local tweaks in the
+  unmanaged `~/.zshrc.local` or `~/.config/zsh/rc.d.local/*.zsh`.
+- **macOS apply no-op** (#946). The concurrency lock used `flock(1)`, which does
+  not exist on macOS — `! flock` took the "already running" branch and made
+  `dot apply` exit 0 without applying anything. It now falls back to an atomic
+  `mkdir` lock when `flock` is absent (portable to macOS/BSD). The optional
+  AI-provider installer menu is also gated on real interactivity (TTY + not CI).
+
+### Changed
+
+- **CI required check** (#944). `Test on ubuntu-latest` (path-filtered, so it
+  never ran on docs-only PRs and left them unmergeable) is replaced by an
+  always-runs `Cross-Platform Tests` gate that reports success when the OS
+  matrix is skipped and failure when it fails.
+
 ## v0.2.507 — 2026-06-30
 
 This release ships the **`dot ai` cockpit** — an interactive Bubble Tea TUI for

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@
 
 ## Project Overview
 
-Chezmoi-managed dotfiles for macOS, Linux, WSL, and PowerShell 7.5+. Version `0.2.507`.
+Chezmoi-managed dotfiles for macOS, Linux, WSL, and PowerShell 7.5+. Version `0.2.508`.
 
 ## Key Commands
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 <p align="center">
   <a href="https://github.com/sebastienrousseau/dotfiles/actions"><img src="https://img.shields.io/github/actions/workflow/status/sebastienrousseau/dotfiles/ci.yml?style=for-the-badge&logo=githubactions&logoColor=white" alt="Build" /></a>
-  <a href="https://github.com/sebastienrousseau/dotfiles/releases/latest"><img src="https://img.shields.io/badge/Version-v0.2.507-blue?style=for-the-badge&logo=semanticrelease&logoColor=white" alt="Version" /></a>
+  <a href="https://github.com/sebastienrousseau/dotfiles/releases/latest"><img src="https://img.shields.io/badge/Version-v0.2.508-blue?style=for-the-badge&logo=semanticrelease&logoColor=white" alt="Version" /></a>
   <a href="https://github.com/sebastienrousseau/dotfiles/releases"><img src="https://img.shields.io/github/downloads/sebastienrousseau/dotfiles/total?style=for-the-badge&logo=github&logoColor=white" alt="Downloads" /></a>
   <a href="https://codespaces.new/sebastienrousseau/dotfiles"><img src="https://img.shields.io/badge/Open%20in-Codespaces-blue?style=for-the-badge&logo=github&logoColor=white" alt="Open in GitHub Codespaces" /></a>
   <a href="https://scorecard.dev/viewer/?uri=github.com/sebastienrousseau/dotfiles"><img src="https://img.shields.io/ossf-scorecard/github.com/sebastienrousseau/dotfiles?style=for-the-badge&logo=linuxfoundation&logoColor=white&label=OpenSSF%20Scorecard" alt="OpenSSF Scorecard" /></a>
@@ -52,7 +52,7 @@
 
 ```bash
 curl -fsSL -o /tmp/dotfiles-install.sh \
-  https://raw.githubusercontent.com/sebastienrousseau/dotfiles/v0.2.507/install.sh
+  https://raw.githubusercontent.com/sebastienrousseau/dotfiles/v0.2.508/install.sh
 echo "d5a04c5e2813a93a63c8ecce9655cf3d107f6068862c6eba84a92cf22f801c7e  /tmp/dotfiles-install.sh" \
   | shasum -a 256 -c
 bash /tmp/dotfiles-install.sh

--- a/bin/dot
+++ b/bin/dot
@@ -4,7 +4,7 @@
 # Copyright (c) 2015-2026 Sebastien Rousseau
 set -euo pipefail
 
-# Dotfiles CLI Entry Point - v0.2.507
+# Dotfiles CLI Entry Point - v0.2.508
 
 # Ensure XDG Base Directory variables are set
 export XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"
@@ -22,7 +22,7 @@ if [ -e "${HOME}/.nix-profile/etc/profile.d/nix.sh" ]; then
   . "${HOME}/.nix-profile/etc/profile.d/nix.sh"
 fi
 
-VERSION="0.2.507"
+VERSION="0.2.508"
 
 COMMAND="${1:-}"
 if [ -n "${1:-}" ]; then
@@ -38,8 +38,8 @@ _resolve_source_dir() {
 
   if script_path="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd 2>/dev/null)"; then
     script_dir="$script_path"
-    # Post-v0.2.507: the canonical dispatcher lives at <repo>/bin/dot, so
-    # $script_dir/.. is the repo root. Pre-v0.2.507 (and chezmoi-deployed
+    # Post-v0.2.508: the canonical dispatcher lives at <repo>/bin/dot, so
+    # $script_dir/.. is the repo root. Pre-v0.2.508 (and chezmoi-deployed
     # wrapper invocations that still exec the canonical) the dispatcher
     # was at <repo>/dot_local/bin/executable_dot, so $script_dir/../..
     # was the repo. Probe both to cover the transition.

--- a/defaults/.chezmoidata.toml
+++ b/defaults/.chezmoidata.toml
@@ -1,5 +1,5 @@
 # Active profile - change this to switch configurations
-dotfiles_version = "0.2.507"
+dotfiles_version = "0.2.508"
 profile = "laptop"
 
 # Machine preset — set per-host in ~/.config/chezmoi/chezmoi.toml:

--- a/defaults/.chezmoitemplates/README.md
+++ b/defaults/.chezmoitemplates/README.md
@@ -5,7 +5,7 @@
   align="right"
 />
 
-# Chezmoi Templates (v0.2.507)
+# Chezmoi Templates (v0.2.508)
 
 Modular shell configuration managed by Chezmoi
 

--- a/defaults/.chezmoitemplates/aliases/README.md
+++ b/defaults/.chezmoitemplates/aliases/README.md
@@ -5,7 +5,7 @@
   align="right"
 />
 
-# Dotfiles Aliases (v0.2.507)
+# Dotfiles Aliases (v0.2.508)
 
 Modular alias definitions managed by Chezmoi
 

--- a/defaults/.chezmoitemplates/functions/README.md
+++ b/defaults/.chezmoitemplates/functions/README.md
@@ -5,7 +5,7 @@
   align="right"
 />
 
-# Dotfiles Functions (v0.2.507)
+# Dotfiles Functions (v0.2.508)
 
 > Modular shell utilities managed by Chezmoi
 

--- a/defaults/dot_config/shell/README.md
+++ b/defaults/dot_config/shell/README.md
@@ -27,7 +27,7 @@ Welcome to your universally compatible, high-performance dotfiles configuration,
 To install these dotfiles on a new machine, run:
 
 ```bash
-sh -c "$(curl -fsSL https://raw.githubusercontent.com/sebastienrousseau/dotfiles/v0.2.507/install.sh)"
+sh -c "$(curl -fsSL https://raw.githubusercontent.com/sebastienrousseau/dotfiles/v0.2.508/install.sh)"
 ```
 
 This command will:

--- a/docs/COPYRIGHT
+++ b/docs/COPYRIGHT
@@ -1,5 +1,5 @@
 /*
-* 🅳🅾🆃🅵🅸🅻🅴🆂 (v0.2.507) - <https://github.com/sebastienrousseau/dotfiles>
+* 🅳🅾🆃🅵🅸🅻🅴🆂 (v0.2.508) - <https://github.com/sebastienrousseau/dotfiles>
 * Made With ❤️ in London, United Kingdom
 * Designed by
 * Copyright (c) 2015-2026. All rights reserved.

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ render_with_liquid: false
 Cross-platform, signed, local-first dotfiles for macOS, Linux, and WSL.
 
 [![Build](https://img.shields.io/github/actions/workflow/status/sebastienrousseau/dotfiles/ci.yml?style=for-the-badge&logo=github)](https://github.com/sebastienrousseau/dotfiles/actions)
-[![Version](https://img.shields.io/badge/Version-v0.2.507-blue?style=for-the-badge)](https://github.com/sebastienrousseau/dotfiles/releases/tag/v0.2.507)
+[![Version](https://img.shields.io/badge/Version-v0.2.508-blue?style=for-the-badge)](https://github.com/sebastienrousseau/dotfiles/releases/tag/v0.2.508)
 [![Downloads](https://img.shields.io/github/downloads/sebastienrousseau/dotfiles/total?style=for-the-badge)](https://github.com/sebastienrousseau/dotfiles/releases)
 
 This site is published from the `docs/` directory on `master` and tracks the current workstation baseline, operational guidance, and security material for the repository.
@@ -38,6 +38,6 @@ This site is published from the `docs/` directory on `master` and tracks the cur
 
 ## Current Release
 
-- Current tagged release: [`v0.2.507`](https://github.com/sebastienrousseau/dotfiles/releases/tag/v0.2.507)
+- Current tagged release: [`v0.2.508`](https://github.com/sebastienrousseau/dotfiles/releases/tag/v0.2.508)
 - Latest release feed: [GitHub releases](https://github.com/sebastienrousseau/dotfiles/releases/latest)
 - Source repository: [sebastienrousseau/dotfiles](https://github.com/sebastienrousseau/dotfiles)

--- a/docs/manual/00-introduction.md
+++ b/docs/manual/00-introduction.md
@@ -4,7 +4,7 @@ render_with_liquid: false
 
 # Introduction
 
-This manual describes `.dotfiles` v0.2.507 — a trusted agent workstation baseline for macOS, Linux, and WSL.
+This manual describes `.dotfiles` v0.2.508 — a trusted agent workstation baseline for macOS, Linux, and WSL.
 
 The repository is more than a personal dotfiles collection. It ships as workstation infrastructure: signed, attested, multi-platform, AI-aware, and self-healing. Chezmoi handles templating and platform differences. The `dot` CLI sits on top and coordinates lifecycle operations.
 

--- a/install.sh
+++ b/install.sh
@@ -60,7 +60,7 @@ show_help() {
 Usage: install.sh [version] [options]
 
 Arguments:
-  version       The version (tag or branch) to install (default: v0.2.507)
+  version       The version (tag or branch) to install (default: v0.2.508)
 
 Options:
   --help        Show this help message
@@ -76,7 +76,7 @@ EOF
 }
 
 main() {
-  local version="v0.2.507"
+  local version="v0.2.508"
   local version_set=0
   local minimal=0
   local provision="${DOTFILES_PROVISION:-0}"
@@ -106,7 +106,7 @@ main() {
         # like `foobar` doesn't trigger a 30s+ network download attempt.
         # Caught by the install.sh fuzz harness (#881).
         if [[ ! "$arg" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+([-+][a-zA-Z0-9.-]+)?$ ]]; then
-          error "Unrecognized positional argument '$arg' — expected a semver version (e.g. v0.2.507)."
+          error "Unrecognized positional argument '$arg' — expected a semver version (e.g. v0.2.508)."
         fi
         version="$arg"
         version_set=1
@@ -351,7 +351,7 @@ main() {
   # 6. Initialize & Apply
   step "Applying Configuration..."
 
-  # ── Auto-migration for v0.2.507 reorg ─────────────────────────────────
+  # ── Auto-migration for v0.2.508 reorg ─────────────────────────────────
   # If the user is upgrading from a pre-0.2.503 install, run the
   # migration script BEFORE `chezmoi apply` so the reorg's source-
   # path moves don't cause chezmoi to delete deployed files.
@@ -360,7 +360,7 @@ main() {
   for migrate_src in "$SOURCE_DIR" "$LEGACY_SOURCE_DIR"; do
     migrate_script="$migrate_src/install/migrate/migrate-v0_2-to-v0_2_503.sh"
     if [[ -x "$migrate_script" ]]; then
-      echo "   Running v0.2.507 migration (idempotent; safe on fresh installs)..."
+      echo "   Running v0.2.508 migration (idempotent; safe on fresh installs)..."
       "$migrate_script" || echo "   migration exited non-zero — continuing apply"
       break
     fi

--- a/lib/dot/bento.sh
+++ b/lib/dot/bento.sh
@@ -32,7 +32,7 @@ _dotfiles_bento_render() {
 
   # Render a fixed-width card (42 cols) so output aligns in any terminal width
   printf "\n"
-  printf "  ${c_cyan}${c_bold}💎  D O T F I L E S${c_reset}  ${c_slate}[v0.2.507]${c_reset}\n"
+  printf "  ${c_cyan}${c_bold}💎  D O T F I L E S${c_reset}  ${c_slate}[v0.2.508]${c_reset}\n"
   printf "  ${c_slate}──────────────────────────────────────────${c_reset}\n"
 
   # Key system properties at a glance — answers "is my env healthy?" in 1 second

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sebastienrousseau/dotfiles",
-  "version": "0.2.507",
+  "version": "0.2.508",
   "description": "The Trusted Shell Platform — Universal dotfiles managed by Chezmoi. Features Bash & Zsh for macOS, Linux & WSL. Rust modern tooling & enterprise-grade security.",
   "main": "install.sh",
   "bin": {

--- a/scripts/git-hooks/pre-commit-audit.sh
+++ b/scripts/git-hooks/pre-commit-audit.sh
@@ -141,6 +141,6 @@ if [[ $FAILED -eq 1 ]]; then
   printf '%b\\n' "   (Use --no-verify to bypass if absolutely necessary)"
   exit 1
 else
-  printf '%b\n' "${GREEN}${BOLD}✅ Audit passed.${NC} v0.2.507 standards maintained."
+  printf '%b\n' "${GREEN}${BOLD}✅ Audit passed.${NC} v0.2.508 standards maintained."
   exit 0
 fi

--- a/share/man/man1/dot.1
+++ b/share/man/man1/dot.1
@@ -1,4 +1,4 @@
-.TH DOT 1 "May 2026" "dotfiles v0.2.507" "User Commands"
+.TH DOT 1 "May 2026" "dotfiles v0.2.508" "User Commands"
 .SH NAME
 dot \- dotfiles management CLI
 .SH SYNOPSIS


### PR DESCRIPTION
## v0.2.508

Bumps the version across all live surfaces (`.chezmoidata.toml`, `package.json`, `bin/dot`, man page, `bento.sh` banner, README badge, `CLAUDE.md`, `AGENTS.md`, `install.sh`) and adds the CHANGELOG entry. `check-version-consistency.sh` passes (all 8 version surfaces match `0.2.508`).

### Highlights since v0.2.507

- **fix(apply):** `dot apply` / `dot update` run unattended and macOS-safe (#946) — `--force` by default so they never stall on chezmoi's overwrite prompt under `gum spin`/no-TTY; portable `flock`-or-`mkdir` lock (fixes the macOS silent no-op); AI-installer menu gated on real interactivity. Opt back into prompts with `DOTFILES_INTERACTIVE_APPLY=1`.
- **ci(cross-platform):** the required check is now an always-runs `Cross-Platform Tests` gate, so documentation-only PRs are mergeable (#944).

Tag + GitHub Release will follow once this merges.

---
THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co