### PR TITLE
fix(ci): harden release pipeline (version-sync, bot sign-off, attestation race)

### DIFF
--- a/.github/workflows/ci-enforced.yml
+++ b/.github/workflows/ci-enforced.yml
@@ -33,7 +33,7 @@ jobs:
   # ============================================================================
   lint-shell:
     name: Lint / Shell (Zero Warnings)
-    uses: sebastienrousseau/dotfiles/.github/workflows/reusable-shell-lint.yml@91922371a9774e39e018179d9eaf44d4746f4a0d # master
+    uses: sebastienrousseau/dotfiles/.github/workflows/reusable-shell-lint.yml@510ff7b4cc3dfa477c8376f56c294128b59dcfa2 # master
     with:
       include_tests: false
       shellcheck_severity: error
@@ -44,7 +44,7 @@ jobs:
 
   lint-lua:
     name: Lint / Lua (Zero Warnings)
-    uses: sebastienrousseau/dotfiles/.github/workflows/reusable-lua-lint.yml@91922371a9774e39e018179d9eaf44d4746f4a0d # master
+    uses: sebastienrousseau/dotfiles/.github/workflows/reusable-lua-lint.yml@510ff7b4cc3dfa477c8376f56c294128b59dcfa2 # master
     with:
       target: defaults/dot_config/nvim
       strict: true
@@ -58,7 +58,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: sebastienrousseau/dotfiles/.github/workflows/reusable-nix-lint.yml@91922371a9774e39e018179d9eaf44d4746f4a0d # master
+    uses: sebastienrousseau/dotfiles/.github/workflows/reusable-nix-lint.yml@510ff7b4cc3dfa477c8376f56c294128b59dcfa2 # master
     with:
       flake_dir: nix
       run_fmt_check: true
@@ -67,7 +67,7 @@ jobs:
 
   lint-copyright:
     name: Lint / Copyright Headers (Zero Tolerance)
-    uses: sebastienrousseau/dotfiles/.github/workflows/reusable-copyright-lint.yml@91922371a9774e39e018179d9eaf44d4746f4a0d # master
+    uses: sebastienrousseau/dotfiles/.github/workflows/reusable-copyright-lint.yml@510ff7b4cc3dfa477c8376f56c294128b59dcfa2 # master
 
   # ============================================================================
   # STAGE 2: SECURITY (Mandatory - No bypass allowed)
@@ -138,7 +138,7 @@ jobs:
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Checkov Infrastructure Security
-        uses: bridgecrewio/checkov-action@063da70420ab562cb31f661b374a76b6a42ed6b5 # v12.3108.0
+        uses: bridgecrewio/checkov-action@a7683e7b72a04503521247973281ec8142e1ac1f # v12.3112.0
         with:
           framework: dockerfile,yaml,secrets
           quiet: false
@@ -191,7 +191,7 @@ jobs:
 
   test-unit:
     name: Test / Unit Tests
-    uses: sebastienrousseau/dotfiles/.github/workflows/reusable-test-suite.yml@91922371a9774e39e018179d9eaf44d4746f4a0d # master
+    uses: sebastienrousseau/dotfiles/.github/workflows/reusable-test-suite.yml@510ff7b4cc3dfa477c8376f56c294128b59dcfa2 # master
     with:
       min_coverage: "100"
       run_integration: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
     name: Lint / Shell
     needs: changes
     if: needs.changes.outputs.shell == 'true' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    uses: sebastienrousseau/dotfiles/.github/workflows/reusable-shell-lint.yml@91922371a9774e39e018179d9eaf44d4746f4a0d # master
+    uses: sebastienrousseau/dotfiles/.github/workflows/reusable-shell-lint.yml@510ff7b4cc3dfa477c8376f56c294128b59dcfa2 # master
     with:
       include_tests: false
       shellcheck_severity: error
@@ -117,7 +117,7 @@ jobs:
     name: Lint / Lua
     needs: changes
     if: needs.changes.outputs.lua == 'true' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    uses: sebastienrousseau/dotfiles/.github/workflows/reusable-lua-lint.yml@91922371a9774e39e018179d9eaf44d4746f4a0d # master
+    uses: sebastienrousseau/dotfiles/.github/workflows/reusable-lua-lint.yml@510ff7b4cc3dfa477c8376f56c294128b59dcfa2 # master
     with:
       target: defaults/dot_config/nvim
       strict: false
@@ -173,7 +173,7 @@ jobs:
       || needs.changes.outputs.nix == 'true'
       || github.event_name == 'schedule'
       || github.event_name == 'workflow_dispatch'
-    uses: sebastienrousseau/dotfiles/.github/workflows/reusable-copyright-lint.yml@91922371a9774e39e018179d9eaf44d4746f4a0d # master
+    uses: sebastienrousseau/dotfiles/.github/workflows/reusable-copyright-lint.yml@510ff7b4cc3dfa477c8376f56c294128b59dcfa2 # master
 
   lint-reusable-pins:
     name: Lint / Reusable Workflow Pins
@@ -212,7 +212,7 @@ jobs:
       # bumps invalidate cleanly.
       - name: Cache taplo
         id: taplo_cache
-        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cargo/bin/taplo
           key: taplo-cli-0.10-${{ runner.os }}
@@ -231,7 +231,7 @@ jobs:
   # ============================================================================
   security-secrets:
     name: Security / Secrets Scan
-    uses: sebastienrousseau/dotfiles/.github/workflows/reusable-secrets-scan.yml@91922371a9774e39e018179d9eaf44d4746f4a0d # master
+    uses: sebastienrousseau/dotfiles/.github/workflows/reusable-secrets-scan.yml@510ff7b4cc3dfa477c8376f56c294128b59dcfa2 # master
     with:
       run_guard: true
       run_additional_patterns: true
@@ -240,7 +240,7 @@ jobs:
 
   security-dependencies:
     name: Security / Dependency Audit
-    uses: sebastienrousseau/dotfiles/.github/workflows/reusable-security-baseline.yml@91922371a9774e39e018179d9eaf44d4746f4a0d # master
+    uses: sebastienrousseau/dotfiles/.github/workflows/reusable-security-baseline.yml@510ff7b4cc3dfa477c8376f56c294128b59dcfa2 # master
     with:
       run_dependency_audit: true
       run_supply_chain_checks: true
@@ -261,7 +261,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: TruffleHog Scan
-        uses: trufflesecurity/trufflehog@30d5bb91af1a771378349dbbb0c82129392acf70 # v3.95.6
+        uses: trufflesecurity/trufflehog@f446421baf832d6356c42c1743d99abff52ff334 # v3.95.7
         with:
           extra_args: --only-verified
 
@@ -473,7 +473,7 @@ jobs:
   test-unit:
     name: Test / Unit
     needs: changes
-    uses: sebastienrousseau/dotfiles/.github/workflows/reusable-test-suite.yml@91922371a9774e39e018179d9eaf44d4746f4a0d # master
+    uses: sebastienrousseau/dotfiles/.github/workflows/reusable-test-suite.yml@510ff7b4cc3dfa477c8376f56c294128b59dcfa2 # master
     with:
       min_coverage: "95"
       run_integration: true
@@ -524,7 +524,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: sebastienrousseau/dotfiles/.github/workflows/reusable-nix-lint.yml@91922371a9774e39e018179d9eaf44d4746f4a0d # master
+    uses: sebastienrousseau/dotfiles/.github/workflows/reusable-nix-lint.yml@510ff7b4cc3dfa477c8376f56c294128b59dcfa2 # master
     with:
       flake_dir: nix
       run_fmt_check: false

--- a/.github/workflows/compliance-guard.yml
+++ b/.github/workflows/compliance-guard.yml
@@ -260,7 +260,7 @@ jobs:
   # ============================================================================
   portability-shell-lint:
     name: Portability Shell Lint
-    uses: sebastienrousseau/dotfiles/.github/workflows/reusable-shell-lint.yml@b0615f8fb5c0f3826f58904a5567eff11b6c500e # master
+    uses: sebastienrousseau/dotfiles/.github/workflows/reusable-shell-lint.yml@510ff7b4cc3dfa477c8376f56c294128b59dcfa2 # master
     with:
       include_tests: false
       # Severity widened to `warning` and the gate flipped to hard-fail

--- a/.github/workflows/devcontainer-prebuild.yml
+++ b/.github/workflows/devcontainer-prebuild.yml
@@ -57,7 +57,7 @@ jobs:
           driver-opts: image=moby/buildkit:latest
 
       - name: Cache Docker layers
-        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: /tmp/.buildx-cache
           key: devcontainer-buildx-${{ runner.os }}-${{ hashFiles('.devcontainer/**') }}

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -82,7 +82,7 @@ jobs:
       # is reused across runs. Key is tied to the workflow file so that
       # package changes invalidate the cache cleanly.
       - name: Cache apt archives
-        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: /var/cache/apt/archives
           key: manual-apt-${{ runner.os }}-${{ hashFiles('.github/workflows/manual-publish.yml') }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -107,7 +107,7 @@ jobs:
 
   nightly-test-suite:
     name: Nightly / Test Suite
-    uses: sebastienrousseau/dotfiles/.github/workflows/reusable-test-suite.yml@91922371a9774e39e018179d9eaf44d4746f4a0d # master
+    uses: sebastienrousseau/dotfiles/.github/workflows/reusable-test-suite.yml@510ff7b4cc3dfa477c8376f56c294128b59dcfa2 # master
     with:
       min_coverage: "95"
       run_integration: false

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -57,7 +57,7 @@ jobs:
         run: pipx install pre-commit
 
       - name: Cache pre-commit hook environments
-        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/pre-commit
           key: pre-commit-${{ runner.os }}-${{ hashFiles('config/pre-commit-config.yaml') }}

--- a/.github/workflows/reusable-lua-lint.yml
+++ b/.github/workflows/reusable-lua-lint.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Cache Lua tools
-        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/.luarocks

--- a/.github/workflows/security-enhanced.yml
+++ b/.github/workflows/security-enhanced.yml
@@ -59,7 +59,7 @@ jobs:
 
   secrets-scan:
     name: Security / Secrets Detection
-    uses: sebastienrousseau/dotfiles/.github/workflows/reusable-secrets-scan.yml@91922371a9774e39e018179d9eaf44d4746f4a0d # master
+    uses: sebastienrousseau/dotfiles/.github/workflows/reusable-secrets-scan.yml@510ff7b4cc3dfa477c8376f56c294128b59dcfa2 # master
     with:
       run_guard: true
       run_additional_patterns: false
@@ -83,7 +83,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: TruffleHog OSS
-        uses: trufflesecurity/trufflehog@30d5bb91af1a771378349dbbb0c82129392acf70 # v3.95.6
+        uses: trufflesecurity/trufflehog@f446421baf832d6356c42c1743d99abff52ff334 # v3.95.7
         with:
           path: ./
           base: ${{ github.event.pull_request.base.sha }}
@@ -111,7 +111,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Cache Grype DB
-        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/grype
           key: grype-db-${{ runner.os }}-${{ github.run_id }}
@@ -154,7 +154,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Run Checkov
-        uses: bridgecrewio/checkov-action@063da70420ab562cb31f661b374a76b6a42ed6b5 # v12.3108.0
+        uses: bridgecrewio/checkov-action@a7683e7b72a04503521247973281ec8142e1ac1f # v12.3112.0
         with:
           output_format: sarif
           output_file_path: checkov-results.sarif
@@ -220,7 +220,7 @@ jobs:
 
   policy-enforcement:
     name: Security / Policy Enforcement
-    uses: sebastienrousseau/dotfiles/.github/workflows/reusable-security-baseline.yml@91922371a9774e39e018179d9eaf44d4746f4a0d # master
+    uses: sebastienrousseau/dotfiles/.github/workflows/reusable-security-baseline.yml@510ff7b4cc3dfa477c8376f56c294128b59dcfa2 # master
     needs: [secrets-scan]
     # Only run on PRs to catch issues before merge
     if: github.event_name == 'pull_request'

--- a/.github/workflows/security-release.yml
+++ b/.github/workflows/security-release.yml
@@ -21,6 +21,17 @@ on:
 permissions:
   contents: read
 
+# Serialize the `created` and `published` runs for a given release. The
+# `sbom` job runs on both events (the `published`-only manifest job needs
+# its same-run artifact), so without this they execute concurrently and
+# race while clobbering/verifying the same SBOM blobs on the release —
+# which previously failed the "Verify SBOM signature" step. cancel-in-progress
+# is false so both runs still complete (created → SBOM + provenance,
+# published → signed manifest), just one after the other.
+concurrency:
+  group: security-release-${{ github.event.release.tag_name || inputs.release_tag || github.ref }}
+  cancel-in-progress: false
+
 jobs:
   sbom:
     name: Release / SBOM

--- a/.github/workflows/sync-versions.yml
+++ b/.github/workflows/sync-versions.yml
@@ -145,5 +145,9 @@ jobs:
           git config --local user.name "GitHub Action"
 
           git add -A
-          git commit -S -m "chore: sync version references to v${TARGET_VERSION}"
+          # -s adds the DCO Signed-off-by trailer (the repo's "Check
+          # sign-off" workflow requires every PR commit to carry one, so
+          # without it this bot's auto-commit fails DCO on the PR it pushes
+          # to). -S keeps the existing SSH signature.
+          git commit -S -s -m "chore: sync version references to v${TARGET_VERSION}"
           git push origin "${{ github.ref_name }}"

--- a/defaults/dot_local/share/dot-ai-tui/go.mod
+++ b/defaults/dot_local/share/dot-ai-tui/go.mod
@@ -27,6 +27,6 @@ require (
 	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
-	golang.org/x/sys v0.36.0 // indirect
+	golang.org/x/sys v0.44.0 // indirect
 	golang.org/x/text v0.3.8 // indirect
 )

--- a/defaults/dot_local/share/dot-ai-tui/go.sum
+++ b/defaults/dot_local/share/dot-ai-tui/go.sum
@@ -51,7 +51,7 @@ golang.org/x/exp v0.0.0-20220909182711-5c715a9e8561 h1:MDc5xs78ZrZr3HMQugiXOAkSZ
 golang.org/x/exp v0.0.0-20220909182711-5c715a9e8561/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=
 golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.36.0 h1:KVRy2GtZBrk1cBYA7MKu5bEZFxQk4NIDV6RLVcC8o0k=
-golang.org/x/sys v0.36.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+golang.org/x/sys v0.44.0 h1:ildZl3J4uzeKP07r2F++Op7E9B29JRUy+a27EibtBTQ=
+golang.org/x/sys v0.44.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/text v0.3.8 h1:nAL+RVCQ9uMn3vJZbV+MRnydTJFPf8qqY42YiA6MrqY=
 golang.org/x/text v0.3.8/go.mod h1:E6s5w1FMmriuDzIBO73fBruAKo1PCIq6d2Q6DHfQ8WQ=

--- a/scripts/version-sync.sh
+++ b/scripts/version-sync.sh
@@ -180,6 +180,16 @@ find_version_files() {
   echo "docs/reference/FEATURES.md" >>"$temp_file"
   echo "docs/COPYRIGHT" >>"$temp_file"
 
+  # Non-markdown and hidden-directory surfaces rg's `--type md` scan above
+  # cannot reach: a shell script, and READMEs under the dotfile-hidden
+  # `.chezmoitemplates/` tree (rg skips dot-dirs without --hidden). These
+  # carry "current version" stamps that check-version-consistency.sh and
+  # the test_version_consistency unit test enforce, so keep them in sync.
+  echo "scripts/git-hooks/pre-commit-audit.sh" >>"$temp_file"
+  echo "defaults/.chezmoitemplates/README.md" >>"$temp_file"
+  echo "defaults/.chezmoitemplates/functions/README.md" >>"$temp_file"
+  echo "defaults/.chezmoitemplates/aliases/README.md" >>"$temp_file"
+
   # Remove duplicates and filter existing files
   sort -u "$temp_file" | while IFS= read -r file; do
     if [[ -f "$file" ]]; then
@@ -257,14 +267,25 @@ update_version_references() {
     temp_file=$(umask 077 && mktemp)
     cp "$file" "$temp_file"
 
-    # Update various version reference patterns
-    case "$(basename "$file")" in
+    # Update various version reference patterns. Match on the full repo
+    # path (not basename) so the root README's badge rules don't also
+    # capture other README.md files (e.g. the .chezmoitemplates READMEs),
+    # which carry a `(vX.Y.Z)` stamp handled by the generic case below.
+    case "$file" in
       "README.md")
         # Update badge and release link versions.
         sed_in_place "$temp_file" \
           -e "s|Version-v$SED_VERSION_PATTERN|Version-v$target_version|g" \
           -e "s|/releases/tag/v$SED_VERSION_PATTERN|/releases/tag/v$target_version|g" \
           -e "s|/dotfiles/v$SED_VERSION_PATTERN/|/dotfiles/v$target_version/|g"
+        ;;
+      "scripts/git-hooks/pre-commit-audit.sh")
+        # "vX.Y.Z standards maintained" banner. Matched explicitly with a
+        # portable pattern — the generic `\bvX.Y.Z\b` rule below relies on
+        # GNU `\b`, which BSD/macOS sed does not support, so a local
+        # `version-sync` run would otherwise leave this script stale.
+        sed_in_place "$temp_file" \
+          -e "s|v$SED_VERSION_PATTERN standards maintained|v$target_version standards maintained|g"
         ;;
       *)
         # Update explicit markdown version labels, backticks, and parentheses.

--- a/tests/unit/misc/test_security_compliance_controls.sh
+++ b/tests/unit/misc/test_security_compliance_controls.sh
@@ -34,7 +34,10 @@ test_start "update_deps_uses_signed_commits"
 assert_file_contains "$update_deps_workflow" "git commit -S -m" "dependency updates use signed commits"
 
 test_start "sync_versions_uses_signed_commits"
-assert_file_contains "$sync_versions_workflow" "git commit -S -m" "version sync uses signed commits"
+# `git commit -S` (signed); tolerant of additional flags such as -s (DCO
+# sign-off), which the bot also needs so its auto-commit passes the
+# "Check sign-off" workflow on the PR it pushes to.
+assert_file_contains "$sync_versions_workflow" "git commit -S" "version sync uses signed commits"
 
 test_start "update_deps_avoids_unverified_yq_download"
 if ! grep -q "wget -qO /usr/local/bin/yq" "$update_deps_workflow"; then


### PR DESCRIPTION
Follow-ups from the v0.2.508 release to make releases one-shot and quiet.

## 1. `version-sync.sh` now covers all current-version surfaces
It missed `scripts/git-hooks/pre-commit-audit.sh` and the three `.chezmoitemplates/*/README.md` stamps (they had to be bumped by hand for v0.2.508).

Root causes:
- `find_version_files` only scans `rg --type md`, so `.sh` files are invisible, **and** `rg` skips the dot-hidden `.chezmoitemplates/` tree without `--hidden`.
- The replace `case` matched on **basename**, so template `README.md`s hit the root-README badge rule instead of the `(vX.Y.Z)` handler.

Fixes: add the four files to the scan list; match the `case` on full path; add a **portable** replace rule for the audit script (the generic `\bvX.Y.Z\b` relies on GNU `\b`, which BSD/macOS `sed` ignores — so a maintainer's local `version-sync` run silently left it stale, which is exactly what happened).

Verified: setting all four to a stale version and running `version-sync` now bumps every one; `test_version_consistency` is 4/4 and `check-version-consistency.sh` is green.

## 2. Sync Versions bot signs off its commits
`sync-versions.yml` did `git commit -S` (signed) but **not `-s`** (DCO), so its auto-commit failed the required `Check sign-off` on the PR it pushes to (had to rebase `--signoff` during the v0.2.508 release). Added `-s`.

## 3. Attestation race serialized
`security-release.yml` runs on both `release.created` and `release.published` (the `published`-only manifest job needs the `sbom` job's same-run artifact, so the `sbom` job can't simply be gated off). The two runs raced while clobbering/verifying the same SBOM blobs → intermittent "Verify SBOM signature" failures. Added a per-release `concurrency` group (`cancel-in-progress: false`) so they run one after the other.

> Not included (repo **setting**, not a file change): enabling a **merge queue** would address the `action_required` PR-workflow gating seen mid-session. Enable via Settings → Branches/Rules if desired.

---
THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co