### PR TITLE
fix(zsh): only install alias shims when alias expansion is off

### DIFF
--- a/defaults/dot_config/shell/90-ux-aliases.sh.tmpl
+++ b/defaults/dot_config/shell/90-ux-aliases.sh.tmpl
@@ -79,6 +79,11 @@ fi
 _dotfiles_alias_shims() {
   [[ -n "${_DOTFILES_ALIAS_SHIMS_LOADED:-}" ]] && return 0
   _DOTFILES_ALIAS_SHIMS_LOADED=1
+  # Remove any same-named aliases first so the function definitions below
+  # don't trip zsh's "defining function based on alias" parse error when
+  # shims are force-enabled (DOTFILES_FORCE_ALIAS_SHIMS=1) while aliases
+  # are still active. `|| true` keeps it safe under `set -e`.
+  unalias c q e h l ll la lt lr lra lta d i a _ 2>/dev/null || true
   c() { clear_screen; }
   q() { exit; }
   e() { "${EDITOR:-nano}" "$@"; }
@@ -103,7 +108,14 @@ _dotfiles_alias_shims() {
 }
 
 if [ -n "${ZSH_VERSION:-}" ]; then
-  if ! setopt | grep -q '^aliases$' || [[ "${DOTFILES_FORCE_ALIAS_SHIMS:-0}" == "1" ]]; then
+  # Only install the function shims when zsh alias expansion is actually
+  # OFF. `[[ -o aliases ]]` is the correct test — the previous
+  # `setopt | grep '^aliases$'` never matched because `setopt` does not
+  # list options at their default (aliases is on by default), so the shims
+  # ran on every interactive login and collided with the same-named
+  # aliases (e.g. `c`), emitting "defining function based on alias" and a
+  # parse error.
+  if ! [[ -o aliases ]] || [[ "${DOTFILES_FORCE_ALIAS_SHIMS:-0}" == "1" ]]; then
     _dotfiles_alias_shims
   fi
 fi


### PR DESCRIPTION
## Symptom

Interactive zsh login printed:
```
/Users/seb/.config/shell/90-ux-aliases.sh:3: defining function based on alias `c'
/Users/seb/.config/shell/90-ux-aliases.sh:2788: parse error near `()'
```

## Cause

`90-ux-aliases.sh` installs function shims (`c`, `q`, `e`, `l`, …) for the case where zsh **alias expansion is disabled**, gated by:
```sh
if ! setopt | grep -q '^aliases$'; then _dotfiles_alias_shims; fi
```
That test never matches: `setopt` only lists options that **differ from their default**, and `aliases` is on by default — so the guard was always true and the shims ran on **every** interactive login. Defining `c() { clear_screen; }` while `alias c='clear_screen'` is active makes zsh warn "defining function based on alias `c`" and then **parse-error**, breaking startup.

## Fix

- Use the correct zsh option test `[[ -o aliases ]]` — shims load only when alias expansion is genuinely off.
- `unalias` the shim names at the top of `_dotfiles_alias_shims` so the `DOTFILES_FORCE_ALIAS_SHIMS=1` path can't collide either.

## Verified

- zsh with aliases **on** → shims skip (no collision); `c` stays the alias. Fresh `zsh -ic` login: no warning, no parse error.
- zsh with aliases **off** → shims still load (function fallback intact).
- Deployed locally via `chezmoi apply`; startup is clean.

---
THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co