### PR TITLE
fix(install): require bash explicitly + fix sh -c install doc

### DIFF
--- a/defaults/dot_config/shell/README.md
+++ b/defaults/dot_config/shell/README.md
@@ -27,7 +27,7 @@ Welcome to your universally compatible, high-performance dotfiles configuration,
 To install these dotfiles on a new machine, run:
 
 ```bash
-sh -c "$(curl -fsSL https://raw.githubusercontent.com/sebastienrousseau/dotfiles/v0.2.508/install.sh)"
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/sebastienrousseau/dotfiles/v0.2.508/install.sh)"
 ```
 
 This command will:

--- a/install.sh
+++ b/install.sh
@@ -5,6 +5,17 @@
 # Usage: bash -c "$(curl -fsSL https://raw.githubusercontent.com/sebastienrousseau/dotfiles/master/install.sh)"
 # (or ./install.sh locally)
 
+# This installer uses bash features (set -o pipefail, arrays, [[ ]]). If it is
+# run under a POSIX/other shell — e.g. `sh install.sh` or piped to `sh` where
+# /bin/sh is dash — fail fast with a clear message instead of the cryptic
+# "set: Illegal option -o pipefail" from the next line. Kept strictly POSIX so
+# it parses in any shell before bash takes over.
+if [ -z "${BASH_VERSION:-}" ]; then
+  echo "install.sh requires bash. Run:  bash install.sh" >&2
+  echo "  or:  bash -c \"\$(curl -fsSL https://raw.githubusercontent.com/sebastienrousseau/dotfiles/master/install.sh)\"" >&2
+  exit 1
+fi
+
 set -euo pipefail
 
 # Restrict the permissions of any file/dir we create during bootstrap.


### PR DESCRIPTION
## Problem

`install.sh` uses bash features (`set -o pipefail`, arrays, `[[ ]]`) but had **no bash guard**, and `defaults/dot_config/shell/README.md` documented:
```sh
sh -c "$(curl -fsSL …/install.sh)"
```
On Linux where `/bin/sh` is **dash**, that dies immediately with `set: Illegal option -o pipefail` (the root README correctly uses `bash` everywhere — this deployed doc was the outlier).

## Fix

1. **Strictly-POSIX guard** at the top of `install.sh` (before `set -euo pipefail`): if `BASH_VERSION` is unset it prints a clear "requires bash" message and exits, instead of the cryptic pipefail error. Catches `sh install.sh` / `dash install.sh`.
2. **Doc fix**: shell-hub README now uses `bash -c` (matches root README + install.sh's own usage line).

## Verified
- `bash -n install.sh` clean; shellcheck clean.
- `dash install.sh` → clear "requires bash" message (was: `Illegal option -o pipefail`).
- `bash install.sh` → unaffected.

> Note: the guard can't rescue `sh -c "$(curl … install.sh)"` (the whole bash body is parse-checked before the guard executes), but the doc no longer recommends that form — `bash -c` is the documented path.

---
THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co