### PR TITLE
perf(dot): cut hot-path forks (resolve/route/tput) — 1.18× faster startup

### DIFF
--- a/bin/dot
+++ b/bin/dot
@@ -469,7 +469,17 @@ _dot_command_route() {
   if [[ -z "$command_name" ]]; then
     return 1
   fi
-  awk -F'|' -v command_name="$command_name" '$1 == command_name { print $2; exit }' < <(_dot_command_routes)
+  # Pure-bash scan of the route table — avoids the extra awk fork on the hot
+  # path of every invocation (routes stay in _dot_command_routes for the
+  # tooling/tests that parse them from source).
+  local cmd module
+  while IFS='|' read -r cmd module; do
+    if [[ "$cmd" == "$command_name" ]]; then
+      printf '%s\n' "$module"
+      return 0
+    fi
+  done < <(_dot_command_routes)
+  return 1
 }
 
 show_help_overview() {
@@ -576,7 +586,9 @@ resolve_source_dir() { _resolve_source_dir; }
 # Routes COMMAND to the appropriate command module in scripts/dot/commands/.
 # Each module receives the original COMMAND as its first argument so that its
 # internal case statement can dispatch to the right sub-function.
-_SOURCE_DIR="$(_resolve_source_dir)"
+# Reuse the source dir already resolved at startup (line ~69) instead of
+# re-running _resolve_source_dir (several cd/pwd subshells) on every invocation.
+_SOURCE_DIR="$_DOT_SRC"
 _CMD_DIR="${_SOURCE_DIR}/scripts/dot/commands"
 
 _dispatch() {

--- a/lib/dot/ui.sh
+++ b/lib/dot/ui.sh
@@ -96,18 +96,23 @@ ui_init() {
     fi
   fi
 
-  # --- Color palette (tput) ---
-  if [[ -t 1 ]] && [[ -z "${NO_COLOR:-}" ]] && command -v tput >/dev/null 2>&1 && tput setaf 1 >/dev/null 2>&1; then
+  # --- Color palette (hardcoded ANSI; no tput forks) ---
+  # This previously forked ~10 `tput` processes on every ui_init, and because
+  # the dispatched command module re-sources ui.sh and re-inits, that doubled
+  # to ~20 forks per invocation on a TTY. The escapes below are exactly what
+  # `tput bold/sgr0/setaf` emit on a standard terminal (the bin/dot fallback
+  # already hardcodes the same idea), so appearance is unchanged with zero forks.
+  if [[ -t 1 ]] && [[ -z "${NO_COLOR:-}" ]] && [[ "${TERM:-}" != "dumb" ]]; then
     UI_COLOR=1
-    BOLD="$(tput bold)"
-    NORMAL="$(tput sgr0)"
-    RED="$(tput setaf 1)"
-    GREEN="$(tput setaf 2)"
-    YELLOW="$(tput setaf 3)"
-    BLUE="$(tput setaf 4)"
-    MAGENTA="$(tput setaf 5)"
-    CYAN="$(tput setaf 6)"
-    GRAY="$(tput setaf 8)"
+    BOLD=$'\033[1m'
+    NORMAL=$'\033[0m'
+    RED=$'\033[31m'
+    GREEN=$'\033[32m'
+    YELLOW=$'\033[33m'
+    BLUE=$'\033[34m'
+    MAGENTA=$'\033[35m'
+    CYAN=$'\033[36m'
+    GRAY=$'\033[90m'
   fi
 
   UI_INITED=1

--- a/scripts/dot/commands/agent.sh
+++ b/scripts/dot/commands/agent.sh
@@ -88,12 +88,13 @@ _agent_apply_profile_env() {
   # Split declare-and-assign to avoid masking the field-getter's exit
   # code (SC2155). If the profile JSON is malformed, the assignment
   # now fails the function instead of silently exporting an empty value.
-  local approval filesystem network mcp_profile max_steps
-  approval="$(_agent_profile_field "$name" "approval")"
-  filesystem="$(_agent_profile_field "$name" "filesystem")"
-  network="$(_agent_profile_field "$name" "network")"
-  mcp_profile="$(_agent_profile_field "$name" "mcpProfile")"
-  max_steps="$(_agent_profile_field "$name" "maxSteps")"
+  local approval filesystem network mcp_profile max_steps tuple
+  # One jq read of all five policy fields (was five separate jq processes on
+  # every profile application). `|| return 1` preserves fail-on-malformed.
+  tuple="$(jq -r --arg name "$name" \
+    '.profiles[$name] | [.approval, .filesystem, .network, .mcpProfile, .maxSteps] | @tsv' \
+    "$(_agent_profiles_file)")" || return 1
+  IFS=$'\t' read -r approval filesystem network mcp_profile max_steps <<<"$tuple"
   export DOT_AGENT_APPROVAL="$approval"
   export DOT_AGENT_FILESYSTEM="$filesystem"
   export DOT_AGENT_NETWORK="$network"

--- a/scripts/dot/commands/ai.sh
+++ b/scripts/dot/commands/ai.sh
@@ -147,9 +147,7 @@ _ai_get_cached_status() {
 
 # Look up field $2 (2=present 0/1, 3=version) for binary $1 from the
 # cached TSV. Replaces a bash-4 associative array for macOS bash 3.2.
-_ai_status_field() {
-  awk -F'\t' -v b="$1" -v f="$2" '$1==b{print $f;exit}' "$AI_STATUS_CACHE_FILE" 2>/dev/null
-}
+# (Removed _ai_status_field — cmd_ai_status now reads both fields in one awk.)
 
 # _ai_mise_pkg (binary -> mise package map) is defined in lib/dot/ai-install.sh.
 
@@ -193,8 +191,13 @@ cmd_ai_status() {
       ui_section "$category"
       current_category="$category"
     fi
-    if [[ "$(_ai_status_field "$bin" 2)" == "1" ]]; then
-      ver="$(_ai_status_field "$bin" 3)"
+    # One awk over the cache line for this tool (was two: field 2 and field 3).
+    local _st_installed _st_ver
+    IFS=$'\t' read -r _st_installed _st_ver < <(
+      awk -F'\t' -v b="$bin" '$1==b{print $2"\t"$3;exit}' "$AI_STATUS_CACHE_FILE" 2>/dev/null
+    )
+    if [[ "$_st_installed" == "1" ]]; then
+      ver="$_st_ver"
       [[ -z "$ver" ]] && ver="installed"
       [[ "$bin" == "claude" ]] && ver="${ver%% *}"
       ui_ok "$name" "$ver — $desc"

--- a/scripts/dot/commands/fleet.sh
+++ b/scripts/dot/commands/fleet.sh
@@ -202,9 +202,13 @@ cmd_fleet_drift() {
       local count="${1:-20}"
       tail -n "$count" "$_DRIFT_HISTORY_FILE" | while IFS= read -r line; do
         local time status file_count
-        time="$(printf '%s' "$line" | jq -r '.time' 2>/dev/null || echo "?")"
-        status="$(printf '%s' "$line" | jq -r '.status' 2>/dev/null || echo "?")"
-        file_count="$(printf '%s' "$line" | jq '.files | length' 2>/dev/null || echo 0)"
+        # One jq per line (was three: .time, .status, .files|length).
+        IFS=$'\t' read -r time status file_count < <(
+          printf '%s' "$line" | jq -r '[.time, .status, (.files | length)] | @tsv' 2>/dev/null
+        )
+        [[ -n "$time" ]] || time="?"
+        [[ -n "$status" ]] || status="?"
+        [[ -n "$file_count" ]] || file_count=0
         if [[ "$status" == "clean" ]]; then
           ui_ok "$time" "clean"
         else

--- a/scripts/dot/commands/lint.sh
+++ b/scripts/dot/commands/lint.sh
@@ -19,6 +19,33 @@ dot_ui_command_banner "Lint" "${1:-}"
 SHELLCHECK_ARGS=(--severity=error -e SC1091 -e SC2030 -e SC2031)
 SHFMT_ARGS=(-i 2 -ci)
 
+# True only if the file's shebang names a shell that both shellcheck and shfmt
+# can process. The old `grep -qiE 'shell|bash|sh'` matched loosely — "sh" hit
+# "fish", and `file` output pulled in python3 scripts — so non-shell files
+# landed in the lint set and produced spurious SC1071 / shfmt parse "errors".
+_lint_is_shell() {
+  local first interp
+  first="$(head -1 "$1" 2>/dev/null)"
+  case "$first" in '#!'*) ;; *) return 1 ;; esac
+  interp="${first#\#!}"
+  interp="${interp#"${interp%%[![:space:]]*}"}" # ltrim
+  case "$interp" in
+    */env[[:space:]]*)
+      interp="${interp#*/env}"
+      interp="${interp#"${interp%%[![:space:]]*}"}"
+      interp="${interp%%[[:space:]]*}"
+      ;;
+    *)
+      interp="${interp%%[[:space:]]*}"
+      interp="${interp##*/}"
+      ;;
+  esac
+  case "$interp" in
+    sh | bash | dash | ksh | mksh | ash) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 cmd_lint() {
   local mode="${1:-all}"
   local src_dir
@@ -40,11 +67,10 @@ cmd_lint() {
   chezmoi_src="$(resolve_chezmoi_source_dir)"
   [[ -z "$chezmoi_src" ]] && chezmoi_src="$src_dir"
 
-  # dot_local/bin/executable_* scripts (shell scripts only)
+  # dot_local/bin/executable_* scripts — shell scripts only (skip python/zsh/etc
+  # by inspecting the shebang, so shellcheck/shfmt never see files they can't parse).
   while IFS= read -r -d '' f; do
-    if file "$f" 2>/dev/null | grep -qiE 'shell|bash|sh'; then
-      files+=("$f")
-    elif head -1 "$f" 2>/dev/null | grep -qE '^#!.*(bash|sh)'; then
+    if _lint_is_shell "$f"; then
       files+=("$f")
     fi
   done < <(find "$chezmoi_src/dot_local/bin" -name 'executable_*' -type f -print0 2>/dev/null)
@@ -69,17 +95,16 @@ cmd_lint() {
       if has_command shellcheck; then
         ui_section "ShellCheck"
         echo ""
-        local sc_fail=0
-        for f in "${files[@]}"; do
-          if ! shellcheck "${SHELLCHECK_ARGS[@]}" "$f" 2>/dev/null; then
-            sc_fail=$((sc_fail + 1))
-          fi
-        done
-        if [[ "$sc_fail" -eq 0 ]]; then
+        # One shellcheck invocation over all files (was one fork per file).
+        # gcc format is one line per issue, so failing files = unique paths.
+        local sc_out
+        sc_out="$(shellcheck -f gcc "${SHELLCHECK_ARGS[@]}" "${files[@]}" 2>/dev/null || true)"
+        if [[ -z "$sc_out" ]]; then
           ui_ok "shellcheck" "$total files clean"
         else
-          sc_errors=$sc_fail
-          ui_err "shellcheck" "$sc_fail file(s) with errors"
+          printf '%s\n' "$sc_out"
+          sc_errors=$(printf '%s\n' "$sc_out" | cut -d: -f1 | sort -u | grep -c .)
+          ui_err "shellcheck" "$sc_errors file(s) with errors"
         fi
         echo ""
       else
@@ -91,17 +116,15 @@ cmd_lint() {
       if has_command shfmt; then
         ui_section "shfmt"
         echo ""
-        local fmt_fail=0
-        for f in "${files[@]}"; do
-          if ! shfmt "${SHFMT_ARGS[@]}" -d "$f" >/dev/null 2>&1; then
-            fmt_fail=$((fmt_fail + 1))
-          fi
-        done
-        if [[ "$fmt_fail" -eq 0 ]]; then
+        # `shfmt -l` lists files needing formatting in one invocation
+        # (was `shfmt -d` per file).
+        local fmt_list
+        fmt_list="$(shfmt "${SHFMT_ARGS[@]}" -l "${files[@]}" 2>/dev/null || true)"
+        if [[ -z "$fmt_list" ]]; then
           ui_ok "shfmt" "$total files formatted correctly"
         else
-          fmt_errors=$fmt_fail
-          ui_err "shfmt" "$fmt_fail file(s) need formatting"
+          fmt_errors=$(printf '%s\n' "$fmt_list" | grep -c .)
+          ui_err "shfmt" "$fmt_errors file(s) need formatting"
         fi
         echo ""
       else
@@ -118,17 +141,19 @@ cmd_lint() {
       fi
       ui_section "Auto-fixing with shfmt"
       echo ""
-      local fixed=0
-      for f in "${files[@]}"; do
-        if ! shfmt "${SHFMT_ARGS[@]}" -d "$f" >/dev/null 2>&1; then
+      # Find files needing formatting in one `shfmt -l` pass, then only
+      # rewrite that (usually small) set — was `shfmt -d` per file.
+      local fmt_list fixed=0
+      fmt_list="$(shfmt "${SHFMT_ARGS[@]}" -l "${files[@]}" 2>/dev/null || true)"
+      if [[ -z "$fmt_list" ]]; then
+        ui_ok "shfmt" "All files already formatted"
+      else
+        while IFS= read -r f; do
+          [[ -n "$f" ]] || continue
           shfmt "${SHFMT_ARGS[@]}" -w "$f"
           ui_ok "fixed" "${f#"$src_dir/"}"
           fixed=$((fixed + 1))
-        fi
-      done
-      if [[ "$fixed" -eq 0 ]]; then
-        ui_ok "shfmt" "All files already formatted"
-      else
+        done <<<"$fmt_list"
         ui_ok "shfmt" "$fixed file(s) reformatted"
       fi
       echo ""


### PR DESCRIPTION
Addresses the findings in #955 — fork reduction across the `dot` CLI.

## Changes

### Startup hot path
1. **Resolve memoise** (`bin/dot`) — reuse the source dir resolved at startup instead of re-running `_resolve_source_dir` (cd/pwd subshells) in the dispatcher.
2. **Route lookup** (`bin/dot`) — pure-bash scan instead of `awk` over a `cat`-heredoc process-substitution (heredoc kept for the tests that parse it).
3. **tput storm** (`lib/dot/ui.sh`) — `ui_init` hardcodes the ANSI palette instead of forking ~10 `tput` (doubled to ~20 on a TTY via the child re-init). Same appearance, zero forks.

### Per-command
4. **`dot lint` batching + non-shell-file fix** — one `shellcheck`/`shfmt` invocation instead of one per file (~620 forks → 2). Also fixed the file collection: the old `grep 'sh'` matched `fish` and pulled in `python3` scripts, causing 3 false SC1071 + 3 false format errors. `_lint_is_shell` inspects the shebang.
5. **Single-pass jq/awk** — `agent.sh` reads 5 policy fields in one `jq @tsv` (was 5); `ai.sh` status reads flag+version in one `awk`/tool (was 2); `fleet.sh` drift-history uses one `jq @tsv`/line (was 3).

## Benchmarks (hyperfine, back-to-back A/B, same machine state)

| Command | Before | After | Speedup |
|---|---|---|---|
| `dot version` | 23.7 ms | 20.0 ms | **1.18×** |
| `dot lint --check` | ~14 s | ~9 s | **~1.5×** |

Plus: **tput ~10–20 forks/interactive invocation → 0** (deterministic); `dot lint` now reports **310 files clean, 0 errors** (was 314 with 6 false errors).

## Verification
version/help/dispatch work; colors render under a pty; `dot ai`/`mode current`/`fleet history` run correctly; route + lint + agent/ai/fleet unit tests pass; shellcheck/shfmt clean.

## Deferred (follow-up in #955)
- **platform.sh memoise** — skipped to avoid conflicting with the BSD change in the v0.2.509 branch (same functions).

---
THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co