### PR TITLE
docs(claude): add script-handover rule to global CLAUDE.md

### DIFF
--- a/defaults/dot_claude/CLAUDE.md
+++ b/defaults/dot_claude/CLAUDE.md
@@ -22,6 +22,27 @@
 - Shell: 2-space indent, set -euo pipefail
 - Lua: stylua formatting
 
+## Handing over commands
+
+Whenever I need to run shell steps myself (signed-commit flows
+where your Bash tool can't reach my ssh-agent, interactive
+prompts, anything destructive that needs my eyes first), hand
+them over as ONE runnable script — never scattered one-liners.
+
+- A single fenced ```bash block, or a file under `.git/`, or
+  somewhere else outside the working tree.
+- First line: `set -euo pipefail`.
+- Quote heredocs (`<<'EOF'`) so commit messages don't
+  interpolate.
+- Normalise cwd up front: `cd "$(git rev-parse --show-toplevel)"`.
+- Multi-phase work goes in one script with labelled sections,
+  not multiple scripts I have to chain.
+- After the script, one line on what it does and what to tell
+  you next.
+
+Applies to every project, not just the one this preference was
+captured in.
+
 ## Tools
 
 - Package manager: mise (not asdf, not nvm)

--- a/defaults/dot_claude/CLAUDE.md
+++ b/defaults/dot_claude/CLAUDE.md
@@ -27,18 +27,25 @@
 Whenever I need to run shell steps myself (signed-commit flows
 where your Bash tool can't reach my ssh-agent, interactive
 prompts, anything destructive that needs my eyes first), hand
-them over as ONE runnable script — never scattered one-liners.
+them over as ONE runnable script FILE that I can invoke by path
+— never a fenced copy-paste block, never scattered one-liners.
 
-- A single fenced ```bash block, or a file under `.git/`, or
-  somewhere else outside the working tree.
-- First line: `set -euo pipefail`.
+- Write the script to disk: `.git/<name>.sh` for repo-local
+  work, or another path outside the working tree.
+- `chmod +x` it so I can run it directly: `./.git/<name>.sh`.
+- Shebang `#!/usr/bin/env bash`, first line of body
+  `set -euo pipefail`.
 - Quote heredocs (`<<'EOF'`) so commit messages don't
   interpolate.
-- Normalise cwd up front: `cd "$(git rev-parse --show-toplevel)"`.
+- Normalise cwd up front: `cd "$(git rev-parse --show-toplevel)"`
+  (or an explicit absolute path).
 - Multi-phase work goes in one script with labelled sections,
   not multiple scripts I have to chain.
 - After the script, one line on what it does and what to tell
   you next.
+
+A fenced ```bash block in chat is NOT a script — it's a
+copy-paste instruction. Write the file.
 
 Applies to every project, not just the one this preference was
 captured in.


### PR DESCRIPTION
## Summary

Adds a **cross-project script-handover rule** to the global Claude Code CLAUDE.md, deployed to `~/.claude/CLAUDE.md` on every install.

Now that this branch is rebased on the post-v0.2.509 master, the *only* diff against `origin/master` is 28 lines in one file — everything else (v0.2.509 release, MkDocs Material migration, custom dark + terminal-green docs theme) is already merged.

## What changes

**File touched:** `defaults/dot_claude/CLAUDE.md` (+28 / −0)

A new section `## Handing over commands` states:

> Whenever I need to run shell steps myself (signed-commit flows where your Bash tool can't reach my ssh-agent, interactive prompts, anything destructive that needs my eyes first), hand them over as ONE runnable script FILE that I can invoke by path — never a fenced copy-paste block, never scattered one-liners.

Concretely, the rule mandates:

- Write the script to disk (`.git/<name>.sh` for repo-local work, or an absolute path outside the working tree).
- `chmod +x` so it can be invoked directly: `./.git/<name>.sh`.
- Shebang `#!/usr/bin/env bash`; first body line `set -euo pipefail`.
- Quote heredocs (`<<'EOF'`) so commit messages don't interpolate.
- Normalise cwd up front (`cd "$(git rev-parse --show-toplevel)"` or an explicit absolute path).
- Multi-phase work goes in **one** script with labelled sections, not multiple scripts chained by the user.
- After the script, one line explaining what it does and what to say next.

A fenced ` ```bash ` block in chat is explicitly **not** a script — it's a copy-paste instruction. Write the file.

The rule applies to every project, not just this repo.

## Commits (2)

| SHA | Subject |
|---|---|
| `93bd36d1` | docs(claude): always hand shell steps over as runnable scripts |
| `07ce689b` | docs(claude): tighten script-handover rule — file, not block |

Both SSH-signed and DCO-signed-off. The tightening follow-up came from a real-world session where a fenced code block wasn't treated as satisfying the rule.

## Deploy path

`defaults/dot_claude/CLAUDE.md` is chezmoi-managed. `chezmoi apply` writes it to `~/.claude/CLAUDE.md`, where Claude Code auto-loads it as user-level cross-project instructions — every future session picks the rule up automatically, no per-repo opt-in.

## Test plan

- [x] Both commits SSH-signed with ED25519 key (`git log --show-signature`).
- [x] DCO check green (both commits carry `Signed-off-by:` trailer).
- [x] Rebased on post-v0.2.509 master; no conflicts.
- [ ] After merge: `chezmoi apply` on any workstation deploys the updated `~/.claude/CLAUDE.md`.

---
THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co
