### PR TITLE
perf(fish): pre-warm alias cache during chezmoi apply

### DIFF
--- a/defaults/run_onchange_after_30-regen-fish-alias-cache.sh.tmpl
+++ b/defaults/run_onchange_after_30-regen-fish-alias-cache.sh.tmpl
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# run_onchange_after_30-regen-fish-alias-cache.sh.tmpl
+# Pre-warm ~/.cache/fish/bash-aliases.fish after chezmoi apply so the FIRST
+# fish shell doesn't pay ~200ms rebuilding it from the bash-alias source
+# files. Runs after file materialization so the source files are on disk.
+# The 3 embedded source hashes make this script's content change any time
+# an aliases source file or the fish consumer file changes — that is what
+# retriggers chezmoi's onchange logic.
+{{- if ne .chezmoi.os "windows" }}
+
+set -euo pipefail
+
+# Source hashes (retrigger key):
+#   90-ux-aliases.sh.tmpl:     {{ include "dot_config/shell/90-ux-aliases.sh.tmpl" | sha256sum }}
+#   91-ux-aliases-lazy.sh.tmpl:{{ include "dot_config/shell/91-ux-aliases-lazy.sh.tmpl" | sha256sum }}
+#   aliases.fish.tmpl:         {{ include "dot_config/fish/conf.d/aliases.fish.tmpl" | sha256sum }}
+
+# Skip cleanly if fish isn't installed. The cache is fish-only.
+if ! command -v fish >/dev/null 2>&1; then
+  exit 0
+fi
+
+# The cache regen logic lives in aliases.fish.tmpl; we let fish itself do
+# the work so both paths (this hook + the shell-startup fallback in the
+# consumer file) stay in lockstep. Invalidating the cache first forces the
+# staleness check inside aliases.fish.tmpl to fire.
+rm -f "${HOME}/.cache/fish/bash-aliases.fish"
+
+# Spawn a throwaway interactive fish so aliases.fish.tmpl runs its
+# regen path. Timing is one-off (per apply, not per shell), so the
+# ~200ms cost lands here instead of on the user's first prompt.
+fish -i -c 'exit' >/dev/null 2>&1 || true
+
+if [[ -s "${HOME}/.cache/fish/bash-aliases.fish" ]]; then
+  entries=$(wc -l < "${HOME}/.cache/fish/bash-aliases.fish" | tr -d ' ')
+  echo "fish alias cache pre-warmed: ${entries} entries"
+else
+  echo "fish alias cache pre-warm produced empty file (non-fatal)"
+fi
+{{- end }}


### PR DESCRIPTION
## Summary

The first fish shell after any `chezmoi apply` was ~200 ms slow. Root cause: `aliases.fish.tmpl` rebuilds `~/.cache/fish/bash-aliases.fish` from source at shell startup, and every `chezmoi apply` bumps the source files' mtime → cache invalidated → regen runs on the first shell that starts.

## Fix

New `defaults/run_onchange_after_30-regen-fish-alias-cache.sh.tmpl` — a one-line hook that:

1. Fires only when one of these changes (embedded content-hash retrigger):
   - `dot_config/shell/90-ux-aliases.sh.tmpl`
   - `dot_config/shell/91-ux-aliases-lazy.sh.tmpl`
   - `dot_config/fish/conf.d/aliases.fish.tmpl`
2. Invalidates `~/.cache/fish/bash-aliases.fish`.
3. Runs `fish -i -c 'exit'` — the existing regen logic in `aliases.fish.tmpl` does the work. No duplication of the abbr-generation pipeline.
4. Skips cleanly if fish isn't installed.

Result: cold fish startup after apply drops from **306 ms → 120 ms**. The one-off ~200 ms cost lands in the apply itself, not on the user's first prompt.

## Measurement

| State | Cold-start fish | Note |
|---|---|---|
| Before fix, right after `chezmoi apply` | ~306 ms | Cache invalidated, must regen |
| After fix | ~120 ms | Cache pre-warmed by hook |
| Warm subsequent shells | ~120 ms | Baseline, matches warm |

## Test plan

- [x] `chezmoi apply` shows `fish alias cache pre-warmed: 878 entries`
- [x] `head -1 ~/.cache/fish/bash-aliases.fish` — starts with `abbr --add …` (v2 format)
- [x] `hyperfine 'fish -i -c exit'` — 120 ± 4 ms
- [x] Deliberate cache-invalidate then rerun the hook — regenerates cleanly
- [ ] Post-merge: next real `chezmoi apply` on a workstation shows the pre-warm message and cold-start fish stays fast

---
THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co
