### PR TITLE
fix(ci): push AUR package to master, not main

### DIFF
--- a/.github/workflows/release-distribute-aur.yml
+++ b/.github/workflows/release-distribute-aur.yml
@@ -154,7 +154,12 @@ jobs:
 
           git add PKGBUILD .SRCINFO
           git commit -m "dot ${VERSION}"
-          git push origin main
+          # AUR repositories use the `master` branch — do NOT rename this to
+          # `main`. `HEAD:master` is robust whether the clone landed on an
+          # existing `master` (published package) or an unborn default branch
+          # (first publish). This line was wrongly swept master→main in #961's
+          # default-branch rename, which broke AUR publishing from v0.2.510.
+          git push origin HEAD:master
 
       - name: Print AUR URL
         run: |


### PR DESCRIPTION
## Summary

Fixes AUR publishing, which has failed on every release since **v0.2.510**.

## Root cause

AUR git repositories use the **`master`** branch. The `master → main` default-branch rename (#961, shipped in v0.2.510) swept the AUR publish step's push line along with everything else:

```diff
-          git push origin master
+          git push origin main
```

But that line pushes to the **AUR remote** (`ssh://aur@aur.archlinux.org/dot-cli-git.git`), not this repo — so every release since failed at the *"Commit and push to AUR"* step with:

```
error: src refspec main does not match any
error: failed to push some refs to 'ssh://aur.archlinux.org/dot-cli-git.git'
```

(Confirmed: `Release / Distribute AUR` = success on v0.2.505/507/508, then **failure** on v0.2.510 and v0.2.511 — the two releases after the rename.)

## Fix

```diff
-          git push origin main
+          git push origin HEAD:master
```

`HEAD:master` is robust whether the clone landed on an existing `master` (published package) or an unborn default branch (first publish). Added a comment so the line isn't re-swept in a future rename.

## Verification

- `python3 -c "import yaml; yaml.safe_load(...)"` → workflow YAML still valid.
- The other distribution jobs (Homebrew, Scoop, npm) push to their own `main`-based repos and already succeed — unchanged.
- Real validation is the next tagged release's `Distribute AUR` job going green.

THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co
