### PR TITLE
fix(theme): resolve dynamic HEIC to per-mode frame on macOS

### DIFF
--- a/scripts/theme/wallpaper-sync.sh
+++ b/scripts/theme/wallpaper-sync.sh
@@ -397,6 +397,56 @@ ensure_linux_compatible() {
   printf '%s\n' "$wp"
 }
 
+# macOS: a dynamic appearance HEIC (two frames + apple_desktop:apr metadata)
+# set as a plain imageFile gets pinned to a single frame and stops tracking
+# Light/Dark — so Light mode can show the dark frame. Extract the frame that
+# matches the requested mode (0 = light, 1 = dark, per Apple's apr convention,
+# same as the Linux -0/-1 path) to a small single-image HEIC and apply that
+# instead. Single-image HEICs and non-HEICs are returned unchanged.
+macos_appearance_frame() {
+  local wp="$1" mode="$2"
+  [[ "${wp##*.}" == "heic" ]] || {
+    printf '%s\n' "$wp"
+    return
+  }
+  command -v magick &>/dev/null || {
+    printf '%s\n' "$wp"
+    return
+  }
+  local frames
+  frames="$(magick identify "$wp" 2>/dev/null | wc -l | tr -d ' ')"
+  [[ "${frames:-0}" -ge 2 ]] || {
+    printf '%s\n' "$wp"
+    return
+  }
+
+  local idx=0
+  [[ "$mode" == "dark" ]] && idx=1
+  local cache_dir="$WALLPAPER_DIR/.dot-frames"
+  mkdir -p "$cache_dir" 2>/dev/null || {
+    printf '%s\n' "$wp"
+    return
+  }
+  local frame
+  frame="$cache_dir/$(basename "${wp%.heic}")-${mode}.heic"
+
+  # Reuse a cached frame that is newer than its source wallpaper.
+  if [[ -f "$frame" && "$frame" -nt "$wp" ]]; then
+    printf '%s\n' "$frame"
+    return
+  fi
+  local tmp
+  tmp="$(mktemp "${frame%.heic}.XXXXXX.heic")"
+  if magick "${wp}[${idx}]" "$tmp" 2>/dev/null && [[ -s "$tmp" ]]; then
+    if mv -f "$tmp" "$frame" 2>/dev/null; then
+      printf '%s\n' "$frame"
+      return
+    fi
+  fi
+  rm -f "$tmp" 2>/dev/null
+  printf '%s\n' "$wp"
+}
+
 # Apply wallpaper based on platform and compositor
 apply_wallpaper() {
   local wp="$1"
@@ -408,6 +458,10 @@ apply_wallpaper() {
 
   case "$(uname -s)" in
     Darwin)
+      # Resolve a dynamic HEIC down to the mode-appropriate static frame so
+      # macOS renders the right appearance instead of pinning one frame.
+      wp="$(macos_appearance_frame "$wp" "$mode")"
+
       # macOS Sonoma+ moved wallpaper state to ~/Library/Application Support/
       # com.apple.wallpaper/Store/Index.plist, owned by WallpaperAgent. Each
       # Space and Display has its own entry, and AppleScript's `every desktop`

--- a/tests/unit/theme/test_theme_wallpaper_sync.sh
+++ b/tests/unit/theme/test_theme_wallpaper_sync.sh
@@ -24,6 +24,17 @@ else
   printf '%b\n' "  ${RED}✗${NC} $CURRENT_TEST"
 fi
 
+# macos_appearance_frame must return non-HEIC wallpapers unchanged so static
+# wallpapers are never rewritten; only multi-frame dynamic HEICs get resolved
+# to a per-mode frame (that path is macOS + magick specific).
+test_start "appearance_frame_passthrough_non_heic"
+_af_out="$(
+  eval "$(sed -n '/^macos_appearance_frame()/,/^}/p' "$SCRIPT_FILE")"
+  WALLPAPER_DIR=/tmp
+  macos_appearance_frame "/a/b/pic.png" "light"
+)"
+assert_equals "$_af_out" "/a/b/pic.png" "non-HEIC wallpaper returned unchanged"
+
 # Slice 2: drive real line coverage of the script under test
 cov_exercise_script "$SCRIPT_FILE"
 


### PR DESCRIPTION
## Summary

On macOS, a **dynamic appearance HEIC** (two frames + `apple_desktop:apr` metadata, e.g. `Bloom.heic` with `l=0`/`d=1`) was written into the WallpaperAgent store as `type: imageFile` — a **static** image. macOS then pinned a single frame and stopped tracking Light/Dark, so **Light mode could display the dark frame**.

The Linux/gsettings path already extracts per-mode frames (`-0` light / `-1` dark); the macOS path never got that treatment, and when wallpapers are single dynamic HEICs (no pre-extracted frames) every theme resolves to the raw HEIC and pins the wrong appearance.

## Fix

`wallpaper-sync.sh` gains `macos_appearance_frame()`, which — for a multi-frame HEIC on macOS — extracts the frame matching the active mode (`0 = light`, `1 = dark`) to a small single-image HEIC cached under `~/Pictures/Wallpapers/.dot-frames/` and applies that instead.

- Non-HEIC and single-frame wallpapers pass through unchanged.
- Falls back to the raw file when `magick` is unavailable.
- Cached frames are reused while newer than their source.

## Verification

- Isolated helper test: `Bloom.heic` → `Bloom-light.heic` (mean 0.217, light) / `Bloom-dark.heic` (mean 0.130, dark).
- Applied live: WallpaperAgent store moved from `Bloom.heic` (pinned dark) to `.dot-frames/Bloom-light.heic` — Light mode now shows the light frame.
- Added a regression test asserting non-HEIC wallpapers are returned untouched. All 6 wallpaper-sync tests pass; shellcheck + shfmt clean.

## Tradeoff

This applies a static per-mode frame, so toggling appearance *manually* in System Settings won't auto-swap the image — `dot theme` / `dot theme sync` remains the intended switch (it flips appearance and re-runs the sync). Native dynamic-provider switching would be a larger, more fragile change and is left out of scope.