### PR TITLE
fix(release): retire superseded Homebrew bumps

### DIFF
--- a/.github/workflows/release-distribute-homebrew.yml
+++ b/.github/workflows/release-distribute-homebrew.yml
@@ -73,8 +73,8 @@ jobs:
           fi
           # Remove leading 'v' for VERSION
           VERSION="${TAG#v}"
-          echo "tag=$TAG" >> $GITHUB_OUTPUT
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Download release asset
         id: download-asset
@@ -103,7 +103,7 @@ jobs:
             echo "::error::Asset ${ASSET_NAME} not found in release ${TAG} after ~5min"
             exit 1
           fi
-          echo "asset_path=${ASSET_PATH}" >> $GITHUB_OUTPUT
+          echo "asset_path=${ASSET_PATH}" >> "$GITHUB_OUTPUT"
 
       - name: Compute SHA256 of tarball
         id: compute-sha256
@@ -111,7 +111,7 @@ jobs:
           set -euo pipefail
           ASSET_PATH="${{ steps.download-asset.outputs.asset_path }}"
           SHA256=$(sha256sum "$ASSET_PATH" | awk '{print $1}')
-          echo "sha256=${SHA256}" >> $GITHUB_OUTPUT
+          echo "sha256=${SHA256}" >> "$GITHUB_OUTPUT"
           echo "SHA256: ${SHA256}"
 
       - name: Update Homebrew formula
@@ -135,21 +135,18 @@ jobs:
           # Update the url line - match the full url line and replace version
           NEW_URL="https://github.com/sebastienrousseau/dotfiles/releases/download/${TAG}/dot-${VERSION}.tar.gz"
           URL_RE="https://github\.com/sebastienrousseau/dotfiles/releases/download/v[0-9.]+/dot-[0-9.]+\.tar\.gz"
-          sed -i -E "s|^  url '${URL_RE}'\$|  url '${NEW_URL}'|" dot.rb
+          sed -i -E "s|^  url \"${URL_RE}\"\$|  url \"${NEW_URL}\"|" dot.rb
 
-          # Update the sha256 line. The template may carry either a real
-          # 64-hex digest from the previous release OR a literal
-          # placeholder (e.g. PLACEHOLDER_FILL_ON_v0.2.503_PUBLICATION).
-          # Match anything between the quotes so first-time substitution
-          # is not silently skipped.
+          # Match anything inside the canonical double quotes so a stale
+          # digest cannot silently survive the release rewrite.
           sed -i \
-            -E "s|^  sha256 '[^']*'$|  sha256 '${SHA256}'|" \
+            -E "s|^  sha256 \"[^\"]*\"$|  sha256 \"${SHA256}\"|" \
             dot.rb
 
           # Fail loudly if the substitution didn't take — a passing
           # workflow that ships an unhashed formula is the worst-case
           # outcome here.
-          if ! grep -qE "^  sha256 '${SHA256}'\$" dot.rb; then
+          if ! grep -qE "^  sha256 \"${SHA256}\"\$" dot.rb; then
             echo "::error::sha256 substitution failed — formula still shows:"
             grep -n sha256 dot.rb || true
             exit 1
@@ -162,7 +159,7 @@ jobs:
 
           echo "Updated formula:"
           cat dot.rb
-          echo "formula_path=$(pwd)/dot.rb" >> $GITHUB_OUTPUT
+          echo "formula_path=$(pwd)/dot.rb" >> "$GITHUB_OUTPUT"
 
       - name: Clone homebrew-tap repository
         id: clone-tap
@@ -207,6 +204,12 @@ jobs:
 
           # Commit the change
           git add Formula/dot.rb
+          if git diff --cached --quiet; then
+            echo "Formula/dot.rb already matches dot ${VERSION}; no bump commit needed."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "branch_name=$BRANCH_NAME" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           git commit -S -m "dot ${VERSION}
 
           Update Homebrew formula for dotfiles CLI release ${VERSION}."
@@ -215,7 +218,8 @@ jobs:
           # safely without clobbering unrelated commits.
           git push --force-with-lease origin "$BRANCH_NAME"
 
-          echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+          echo "branch_name=$BRANCH_NAME" >> "$GITHUB_OUTPUT"
 
       - name: Open Pull Request to homebrew-tap
         env:
@@ -226,6 +230,23 @@ jobs:
           BRANCH_NAME="${{ steps.prepare-bump.outputs.branch_name }}"
           BASE_BRANCH="${{ steps.clone-tap.outputs.default_branch }}"
           cd homebrew-tap
+
+          # A newer release makes all earlier dot bump PRs obsolete. Close
+          # them and delete their branches before handling the current PR.
+          while IFS= read -r superseded; do
+            [[ -n "$superseded" ]] || continue
+            gh pr close "$superseded" --delete-branch \
+              --comment "Superseded by dot ${VERSION}."
+          done < <(
+            gh pr list --state open --limit 100 --json number,headRefName | \
+              jq -r --arg branch "$BRANCH_NAME" \
+                '.[] | select((.headRefName | startswith("bump/dot-")) and .headRefName != $branch) | .number'
+          )
+
+          if [[ "${{ steps.prepare-bump.outputs.changed }}" != "true" ]]; then
+            echo "Homebrew formula is already current for dot ${VERSION}."
+            exit 0
+          fi
 
           # If a PR for this branch already exists (re-run), comment a refresh
           # note instead of failing on duplicate.

--- a/.github/workflows/sbom-diff.yml
+++ b/.github/workflows/sbom-diff.yml
@@ -101,10 +101,9 @@ jobs:
             fi
 
             echo 'SBOM_EOF'
+            echo "added=$ADDED_COUNT"
+            echo "removed=$REMOVED_COUNT"
           } >> "$GITHUB_OUTPUT"
-
-          echo "added=$ADDED_COUNT" >> "$GITHUB_OUTPUT"
-          echo "removed=$REMOVED_COUNT" >> "$GITHUB_OUTPUT"
 
       - name: Upload SBOM artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -212,8 +211,10 @@ jobs:
           fail-build: ${{ github.base_ref == 'main' && 'true' || 'false' }}
           severity-cutoff: high
           output-format: json
+          output-file: results.json
 
       - name: Upload CVE scan results
+        if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: cve-scan-results

--- a/bin/dot
+++ b/bin/dot
@@ -345,6 +345,7 @@ EOF
 _dot_help_details() {
   cat <<'EOF'
 sync|Apply the current dotfiles to this machine.|dot sync\ndot sync --check
+init|Bootstrap a dotfiles repository through chezmoi.|dot init alice\ndot init alice/configs --dry-run
 add|Start managing a file with chezmoi.|dot add ~/.gitconfig
 diff|Show pending dotfile changes before applying.|dot diff
 status|Show local drift in the managed home state.|dot status

--- a/defaults/dot_local/bin/executable_corralctl-sync.sh
+++ b/defaults/dot_local/bin/executable_corralctl-sync.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2015-2026 Sebastien Rousseau
 set -euo pipefail
 
 # Scheduled corralctl sync of sebastienrousseau repos into ~/Code.

--- a/defaults/dot_local/share/dot-ai-tui/go.mod
+++ b/defaults/dot_local/share/dot-ai-tui/go.mod
@@ -28,5 +28,5 @@ require (
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/sys v0.44.0 // indirect
-	golang.org/x/text v0.3.8 // indirect
+	golang.org/x/text v0.39.0 // indirect
 )

--- a/defaults/dot_local/share/dot-ai-tui/go.sum
+++ b/defaults/dot_local/share/dot-ai-tui/go.sum
@@ -53,5 +53,5 @@ golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.44.0 h1:ildZl3J4uzeKP07r2F++Op7E9B29JRUy+a27EibtBTQ=
 golang.org/x/sys v0.44.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
-golang.org/x/text v0.3.8 h1:nAL+RVCQ9uMn3vJZbV+MRnydTJFPf8qqY42YiA6MrqY=
-golang.org/x/text v0.3.8/go.mod h1:E6s5w1FMmriuDzIBO73fBruAKo1PCIq6d2Q6DHfQ8WQ=
+golang.org/x/text v0.39.0 h1:UbZz4pLOvn600D6Oh6GGEI6VAmndrEBLv8/6BEXzyus=
+golang.org/x/text v0.39.0/go.mod h1:3UwRclnC2g0TU9x8PZiyfOajCd1zaUNHF9cvqcQZ+ZM=

--- a/examples/example-cli-utilities.sh
+++ b/examples/example-cli-utilities.sh
@@ -7,7 +7,7 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 # Verify all executable scripts have valid syntax
 count=0
-for script in "$repo_root"/dot_local/bin/executable_*; do
+for script in "$repo_root"/defaults/dot_local/bin/executable_*; do
   [[ -d "$script" ]] && continue
   # Skip non-shell files
   head -1 "$script" | grep -q 'bash\|sh' || continue
@@ -19,6 +19,7 @@ printf 'All %d CLI utilities pass syntax check.\n' "$count"
 # List key utilities with descriptions
 printf '\nKey CLI utilities:\n'
 printf '  dot           — Dotfiles management CLI\n'
+printf '  corralctl-sync.sh — Scheduled repository synchronization\n'
 printf '  dot-ai        — AI RAG query tool\n'
 printf '  ai_core       — AI operations wrapper\n'
 printf '  ai-update     — AI tools updater\n'

--- a/install/homebrew/dot.rb
+++ b/install/homebrew/dot.rb
@@ -12,28 +12,28 @@
 #   brew install --build-from-source dot.rb && dot version
 
 class Dot < Formula
-  desc 'Declarative dotfiles CLI for macOS, Linux, WSL, and PowerShell'
-  homepage 'https://github.com/sebastienrousseau/dotfiles'
-  url 'https://github.com/sebastienrousseau/dotfiles/releases/download/v0.2.503/dot-0.2.503.tar.gz'
-  sha256 'PLACEHOLDER_FILL_ON_v0.2.503_PUBLICATION'
-  license 'MIT'
+  desc "Declarative dotfiles CLI for macOS, Linux, WSL, and PowerShell"
+  homepage "https://github.com/sebastienrousseau/dotfiles"
+  url "https://github.com/sebastienrousseau/dotfiles/releases/download/v0.2.511/dot-0.2.511.tar.gz"
+  sha256 "6b9f435ebeaca6ff5ec9e6c7458972cb1b8d43b80959a75ff990b629ff5af2cf"
+  license "MIT"
 
-  depends_on 'bash' => :build
-  depends_on 'chezmoi'
+  depends_on "bash" => :build
+  depends_on "chezmoi"
 
   # Optional but commonly used by the framework:
-  depends_on 'gum'      => :recommended
-  depends_on 'jq'       => :recommended
-  depends_on 'starship' => :recommended
+  depends_on "gum"      => :recommended
+  depends_on "jq"       => :recommended
+  depends_on "starship" => :recommended
 
   def install
-    bin.install 'bin/dot'
-    bin.install Dir['bin/dot-*']
-    lib.install Dir['lib/*']
-    man1.install 'share/man/man1/dot.1'
-    zsh_completion.install 'share/zsh/site-functions/_dot'
-    bash_completion.install 'share/bash-completion/completions/dot'
-    fish_completion.install 'share/fish/vendor_completions.d/dot.fish'
+    bin.install "bin/dot"
+    bin.install Dir["bin/dot-*"]
+    lib.install Dir["lib/*"]
+    man1.install "share/man/man1/dot.1"
+    zsh_completion.install "share/zsh/site-functions/_dot"
+    bash_completion.install "share/bash-completion/completions/dot"
+    fish_completion.install "share/fish/vendor_completions.d/dot.fish"
   end
 
   test do

--- a/scripts/diagnostics/aliases-manifest.sh
+++ b/scripts/diagnostics/aliases-manifest.sh
@@ -42,9 +42,15 @@ resolve_chezmoi_source_dir() {
 src_root="${1:-$(resolve_source_dir)}"
 src_dir="$(resolve_chezmoi_source_dir "$src_root")"
 
-rg -n \
-  -e '^[[:space:]]*alias[[:space:]]+[A-Za-z0-9_.:-]+=' \
-  -e '^[[:space:]]*[^#"'\'']*&&[[:space:]]*alias[[:space:]]+[A-Za-z0-9_.:-]+=' \
-  "$src_dir/.chezmoitemplates/aliases" \
-  "$src_dir/.chezmoitemplates/functions" |
-  sed -E 's#^([^:]+):([0-9]+):.*alias[[:space:]]+([A-Za-z0-9_.:-]+)=(.*)$#\3\t\4\t\1\t\2#'
+alias_pattern='^[[:space:]]*alias[[:space:]]+[A-Za-z0-9_.:-]+='
+conditional_alias_pattern='^[[:space:]]*[^#"'\'']*&&[[:space:]]*alias[[:space:]]+[A-Za-z0-9_.:-]+='
+search_paths=(
+  "$src_dir/.chezmoitemplates/aliases"
+  "$src_dir/.chezmoitemplates/functions"
+)
+
+if command -v rg >/dev/null 2>&1; then
+  rg -n -e "$alias_pattern" -e "$conditional_alias_pattern" "${search_paths[@]}"
+else
+  grep -rEn -e "$alias_pattern" -e "$conditional_alias_pattern" "${search_paths[@]}"
+fi | sed -E 's#^([^:]+):([0-9]+):.*alias[[:space:]]+([A-Za-z0-9_.:-]+)=(.*)$#\3\t\4\t\1\t\2#'

--- a/scripts/diagnostics/secret-governance.sh
+++ b/scripts/diagnostics/secret-governance.sh
@@ -13,7 +13,10 @@ STRICT="${DOTFILES_ALIAS_STRICT_MODE:-${DOTFILES_SECRETS_STRICT_MODE:-0}}"
 
 cd "$REPO_ROOT"
 
-mapfile -t staged_files < <(git diff --cached --name-only --diff-filter=ACM || true)
+staged_files=()
+while IFS= read -r staged_file; do
+  [[ -n "$staged_file" ]] && staged_files+=("$staged_file")
+done < <(git diff --cached --name-only --diff-filter=ACM || true)
 if [[ "${#staged_files[@]}" -eq 0 ]]; then
   echo "Secret governance: no staged files."
   exit 0

--- a/scripts/dot/commands/registry.sh
+++ b/scripts/dot/commands/registry.sh
@@ -89,7 +89,7 @@ _registry_fetch() {
   local now mtime
   now="$(date +%s)"
   if [[ -s "$cache_file" ]]; then
-    if mtime="$(stat -f %m "$cache_file" 2>/dev/null || stat -c %Y "$cache_file" 2>/dev/null)"; then
+    if mtime="$(stat -c %Y "$cache_file" 2>/dev/null || stat -f %m "$cache_file" 2>/dev/null)"; then
       if ((now - mtime < 21600)); then
         printf '%s\n' "$cache_file"
         return 0

--- a/scripts/qa/reliability-audit.sh
+++ b/scripts/qa/reliability-audit.sh
@@ -65,12 +65,12 @@ shell_syntax() {
 
 unit_tests() {
   cd "$REPO_ROOT"
-  ./tests/framework/test_runner.sh
+  ./tests/framework/test_runner.sh --jobs auto
 }
 
 integration_tests() {
   cd "$REPO_ROOT"
-  RUN_INTEGRATION=1 ./tests/framework/test_runner.sh -i
+  RUN_INTEGRATION=1 ./tests/framework/test_runner.sh --jobs auto -i
 }
 
 coverage_gate() {

--- a/scripts/version-sync.sh
+++ b/scripts/version-sync.sh
@@ -86,7 +86,7 @@ EXCLUDE_FILES=(
   "docs/operations/ARCHITECTURE_ROADMAP.md"
 
   # Dated release write-ups: each article records the release it
-  # shipped in (e.g. "shipped in v0.2.510" + a link to that release
+  # shipped in (for example, a release note plus a link to that release
   # tag). Those refs are historical fact, not current-version claims —
   # bumping them would falsify the history.
   "docs/articles/2026-07-05-fish-startup-abbr.md"
@@ -189,19 +189,19 @@ find_version_files() {
   rg -l "v?$VERSION_PATTERN" --type md . 2>/dev/null | sed 's|^\./||' >"$temp_file" || true
 
   # Add known files that should be checked even if they don't have versions yet
-  echo "README.md" >>"$temp_file"
-  echo "docs/reference/FEATURES.md" >>"$temp_file"
-  echo "docs/COPYRIGHT" >>"$temp_file"
-
   # Non-markdown and hidden-directory surfaces rg's `--type md` scan above
   # cannot reach: a shell script, and READMEs under the dotfile-hidden
   # `.chezmoitemplates/` tree (rg skips dot-dirs without --hidden). These
   # carry "current version" stamps that check-version-consistency.sh and
   # the test_version_consistency unit test enforce, so keep them in sync.
-  echo "scripts/git-hooks/pre-commit-audit.sh" >>"$temp_file"
-  echo "defaults/.chezmoitemplates/README.md" >>"$temp_file"
-  echo "defaults/.chezmoitemplates/functions/README.md" >>"$temp_file"
-  echo "defaults/.chezmoitemplates/aliases/README.md" >>"$temp_file"
+  printf '%s\n' \
+    "README.md" \
+    "docs/reference/FEATURES.md" \
+    "docs/COPYRIGHT" \
+    "scripts/git-hooks/pre-commit-audit.sh" \
+    "defaults/.chezmoitemplates/README.md" \
+    "defaults/.chezmoitemplates/functions/README.md" \
+    "defaults/.chezmoitemplates/aliases/README.md" >>"$temp_file"
 
   # Remove duplicates and filter existing files
   sort -u "$temp_file" | while IFS= read -r file; do

--- a/tests/framework/assertions.sh
+++ b/tests/framework/assertions.sh
@@ -19,6 +19,22 @@ TESTS_PASSED=0
 TESTS_FAILED=0
 CURRENT_TEST=""
 
+# Run a command with a time limit on GNU and BSD/macOS hosts. macOS does not
+# ship GNU timeout, so use gtimeout when available and Perl's alarm otherwise.
+run_with_timeout() {
+  local seconds="$1"
+  shift
+  if command -v timeout >/dev/null 2>&1; then
+    command timeout "$seconds" "$@"
+  elif command -v gtimeout >/dev/null 2>&1; then
+    command gtimeout "$seconds" "$@"
+  elif command -v perl >/dev/null 2>&1; then
+    perl -e 'alarm shift; exec @ARGV or exit 127' "$seconds" "$@"
+  else
+    "$@"
+  fi
+}
+
 # Colors
 RED='\033[0;31m'
 GREEN='\033[0;32m'

--- a/tests/regression/test_dot_commands_execution.sh
+++ b/tests/regression/test_dot_commands_execution.sh
@@ -50,14 +50,18 @@ DOT_CLI="$REPO_ROOT/bin/dot"
 sandbox="$(mktemp -d -t dot-exec.XXXXXX)"
 trap 'rm -rf "$sandbox"' EXIT
 mkdir -p "$sandbox/.config" "$sandbox/.local/share" "$sandbox/.cache" \
-  "$sandbox/.local/state"
+  "$sandbox/.local/state" "$sandbox/bin" "$sandbox/.cache/dotfiles/registry"
 ln -s "$REPO_ROOT" "$sandbox/.dotfiles"
+printf '#!/usr/bin/env bash\nexit 0\n' >"$sandbox/bin/chezmoi"
+chmod +x "$sandbox/bin/chezmoi"
+printf '{"version":1,"modules":[]}\n' >"$sandbox/.cache/dotfiles/registry/index.json"
 export HOME="$sandbox" \
   XDG_CONFIG_HOME="$sandbox/.config" \
   XDG_DATA_HOME="$sandbox/.local/share" \
   XDG_CACHE_HOME="$sandbox/.cache" \
   XDG_STATE_HOME="$sandbox/.local/state" \
-  CHEZMOI_SOURCE_DIR="$REPO_ROOT"
+  CHEZMOI_SOURCE_DIR="$REPO_ROOT" \
+  PATH="$sandbox/bin:$PATH"
 
 # Patterns that MUST NOT appear in stderr for any command. These
 # are the specific failure modes the audit turned up; any of them
@@ -72,7 +76,8 @@ readonly -a FORBIDDEN_STDERR_PATTERNS=(
 )
 
 # Commands to exercise. Format: `dot ARGS`, where ARGS is
-# whitespace-separated. Each is run with a 15s timeout.
+# whitespace-separated. Each is run with a 60s timeout so the parallel
+# reliability suite does not fail on a contended runner.
 #
 # We deliberately test READ-ONLY subcommands. Mutating commands
 # (sync/apply/commit/install/upgrade/add/edit/rollback/uninstall)
@@ -148,7 +153,7 @@ run_dot_and_assert_clean() {
   trap "rm -f $stdout_file $stderr_file" RETURN
 
   # shellcheck disable=SC2086
-  timeout 15 bash "$DOT_CLI" $args \
+  run_with_timeout 60 bash "$DOT_CLI" $args \
     >"$stdout_file" 2>"$stderr_file" \
     && exit_code=0 || exit_code=$?
 

--- a/tests/regression/test_dot_help_flag_universal.sh
+++ b/tests/regression/test_dot_help_flag_universal.sh
@@ -70,9 +70,11 @@ reset_sandbox() {
 # don't false-positive on ls-time updates.
 sandbox_snapshot() {
   local root="$1"
-  find "$root" -type f -print0 2>/dev/null \
-    | xargs -0 stat -f '%N %z' 2>/dev/null \
-    | sort
+  if stat -c '%n %s' "$root" >/dev/null 2>&1; then
+    find "$root" -type f -exec stat -c '%n %s' {} + 2>/dev/null | sort
+  else
+    find "$root" -type f -exec stat -f '%N %z' {} + 2>/dev/null | sort
+  fi
 }
 
 # ═══════════════════════════════════════════════════════════════
@@ -119,7 +121,7 @@ readonly -a HIDDEN_FROM_HELP=(
   # AI-related sub-dispatchers that operate purely on routing
   load-bench-pty
   # Sub-dispatcher modules that print their own help when invoked
-  agents init registry manual patterns
+  agents registry manual patterns
 )
 
 is_hidden_alias() {
@@ -221,7 +223,7 @@ check_help_flag_safe() {
     XDG_CACHE_HOME="$sandbox/.cache" \
     XDG_STATE_HOME="$sandbox/.local/state" \
     CHEZMOI_SOURCE_DIR="$REPO_ROOT" \
-    timeout 10 bash "$DOT_CLI" $cmd "$flag" \
+    run_with_timeout 10 bash "$DOT_CLI" $cmd "$flag" \
     >"$stdout_file" 2>"$stderr_file" \
     && exit_code=0 || exit_code=$?
 
@@ -334,7 +336,7 @@ out="$(HOME="$sandbox" \
     XDG_CACHE_HOME="$sandbox/.cache" \
     XDG_STATE_HOME="$sandbox/.local/state" \
     CHEZMOI_SOURCE_DIR="$REPO_ROOT" \
-    timeout 5 bash "$DOT_CLI" ai delegate -h 2>&1)"
+    run_with_timeout 5 bash "$DOT_CLI" ai delegate -h 2>&1)"
 if echo "$out" | grep -qE 'delegate|vibe|Executing.*pattern|api\.openai|api\.anthropic'; then
   # If the delegate was actually invoked, we'd see those markers.
   # Presence == regression.
@@ -365,7 +367,7 @@ if HOME="$sandbox" \
     XDG_STATE_HOME="$sandbox/.local/state" \
     CHEZMOI_SOURCE_DIR="$REPO_ROOT" \
     EDITOR=/bin/false \
-    timeout 5 bash "$DOT_CLI" edit -h >/dev/null 2>&1; then
+    run_with_timeout 5 bash "$DOT_CLI" edit -h >/dev/null 2>&1; then
   ((TESTS_PASSED++)) || true
   printf '%b\n' "  ${GREEN}✓${NC} $CURRENT_TEST"
 else
@@ -383,7 +385,7 @@ if HOME="$sandbox" \
     XDG_CACHE_HOME="$sandbox/.cache" \
     XDG_STATE_HOME="$sandbox/.local/state" \
     CHEZMOI_SOURCE_DIR="$REPO_ROOT" \
-    timeout 5 bash "$DOT_CLI" upgrade -h >/dev/null 2>&1; then
+    run_with_timeout 5 bash "$DOT_CLI" upgrade -h >/dev/null 2>&1; then
   ((TESTS_PASSED++)) || true
   printf '%b\n' "  ${GREEN}✓${NC} $CURRENT_TEST"
 else
@@ -402,7 +404,7 @@ if HOME="$sandbox" \
     XDG_CACHE_HOME="$sandbox/.cache" \
     XDG_STATE_HOME="$sandbox/.local/state" \
     CHEZMOI_SOURCE_DIR="$REPO_ROOT" \
-    timeout 5 bash "$DOT_CLI" backup -h >/dev/null 2>&1; then
+    run_with_timeout 5 bash "$DOT_CLI" backup -h >/dev/null 2>&1; then
   # Additional check: no .tar files created anywhere in the sandbox.
   if find "$sandbox" -name '*.tar*' -type f 2>/dev/null | grep -q .; then
     ((TESTS_FAILED++)) || true
@@ -428,7 +430,7 @@ if HOME="$sandbox" \
     XDG_CACHE_HOME="$sandbox/.cache" \
     XDG_STATE_HOME="$sandbox/.local/state" \
     CHEZMOI_SOURCE_DIR="$REPO_ROOT" \
-    timeout 5 bash "$DOT_CLI" sandbox -h >/dev/null 2>&1; then
+    run_with_timeout 5 bash "$DOT_CLI" sandbox -h >/dev/null 2>&1; then
   ((TESTS_PASSED++)) || true
   printf '%b\n' "  ${GREEN}✓${NC} $CURRENT_TEST"
 else
@@ -452,7 +454,7 @@ out="$(HOME="$sandbox" \
     XDG_CACHE_HOME="$sandbox/.cache" \
     XDG_STATE_HOME="$sandbox/.local/state" \
     CHEZMOI_SOURCE_DIR="$REPO_ROOT" \
-    timeout 5 bash "$DOT_CLI" search -- --help 2>&1)" || true
+    run_with_timeout 5 bash "$DOT_CLI" search -- --help 2>&1)" || true
 # `dot search` treats its arg as a keyword; either way (found or
 # not-found), it should not print the canonical `dot help` topic
 # for search. The presence of "Reference" / "Dotfiles Command

--- a/tests/regression/test_test_framework_invariants.sh
+++ b/tests/regression/test_test_framework_invariants.sh
@@ -60,7 +60,7 @@ check_suite_invariant() {
 
   local out results run passed failed
   # Give suites plenty of time (some do heavy shell probing).
-  out="$(timeout 180 bash "$suite_path" 2>&1)" || true
+  out="$(run_with_timeout 180 bash "$suite_path" 2>&1)" || true
 
   # The RESULTS: line is emitted by every well-formed suite.
   results="$(printf '%s\n' "$out" | grep -oE 'RESULTS:[0-9]+:[0-9]+:[0-9]+' | tail -1)"
@@ -83,8 +83,8 @@ check_suite_invariant() {
     ((TESTS_FAILED++)) || true
     printf '%b\n' "  ${RED}✗${NC} $CURRENT_TEST: invariant broken ($results)"
     printf '        RUN=%d != PASSED+FAILED=%d\n' "$run" "$((passed + failed))"
-    printf '        Fix: some `test_start` blocks fire multiple asserts.\n'
-    printf '        Split each assert under its own `test_start "name_kind"`.\n'
+    printf '%s\n' "        Fix: some \`test_start\` blocks fire multiple asserts."
+    printf '%s\n' "        Split each assert under its own \`test_start \"name_kind\"\`."
   fi
 }
 

--- a/tests/unit/auto/test_auto_bin_corralctl_sync_sh.sh
+++ b/tests/unit/auto/test_auto_bin_corralctl_sync_sh.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2015-2026 Sebastien Rousseau
+# shellcheck disable=SC1090,SC1091,SC2034
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+source "$SCRIPT_DIR/../../framework/assertions.sh"
+
+SCRIPT_FILE="$REPO_ROOT/defaults/dot_local/bin/executable_corralctl-sync.sh"
+
+test_start "corralctl_sync_script_exists"
+assert_file_exists "$SCRIPT_FILE" "scheduled corralctl sync wrapper must exist"
+
+test_start "corralctl_sync_script_syntax"
+assert_exit_code 0 "bash -n '$SCRIPT_FILE'"
+
+test_start "corralctl_sync_targets_owner"
+assert_file_contains "$SCRIPT_FILE" 'OWNER="sebastienrousseau"' "wrapper must target the configured GitHub owner"
+
+test_start "corralctl_sync_limits_concurrency"
+assert_file_contains "$SCRIPT_FILE" "corralctl \"\$OWNER\" -c 8" "wrapper must bound repository concurrency"
+
+test_start "corralctl_sync_writes_user_log"
+assert_file_contains "$SCRIPT_FILE" 'Library/Logs/corralctl.log' "wrapper must write a stable user log"
+
+test_start "corralctl_sync_notifies_failures"
+assert_file_contains "$SCRIPT_FILE" 'display notification' "wrapper must notify on synchronization failures"
+
+test_start "corralctl_sync_rotates_log"
+assert_file_contains "$SCRIPT_FILE" 'tail -n 2000' "wrapper must cap its log size"
+
+echo "RESULTS:$TESTS_RUN:$TESTS_PASSED:$TESTS_FAILED"

--- a/tests/unit/diagnostics/test_diagnostics_secret_governance.sh
+++ b/tests/unit/diagnostics/test_diagnostics_secret_governance.sh
@@ -29,6 +29,15 @@ test_start "secret_governance_shebang"
 first_line=$(head -n 1 "$TEST_SCRIPT")
 assert_equals "#!/usr/bin/env bash" "$first_line" "should have bash shebang"
 
+test_start "secret_governance_bash_3_compatible"
+if ! grep -q -F "mapfile" "$TEST_SCRIPT"; then
+  ((TESTS_PASSED++)) || true
+  printf '%b\n' "  ${GREEN}✓${NC} $CURRENT_TEST: supports macOS stock Bash 3.2"
+else
+  ((TESTS_FAILED++)) || true
+  printf '%b\n' "  ${RED}✗${NC} $CURRENT_TEST: mapfile requires Bash 4+"
+fi
+
 # Slice 3 (#883): exercise the script under sandbox for line coverage
 cov_exercise_script "$TEST_SCRIPT"
 

--- a/tests/unit/misc/test_qa_reliability_behaviour.sh
+++ b/tests/unit/misc/test_qa_reliability_behaviour.sh
@@ -57,7 +57,7 @@ test_start "qa_reliability_quick_skips_integration"
 stub_repo="$(make_stub_repo)"
 log_file="$stub_repo/run.log"
 if LOG_FILE="$log_file" bash "$stub_repo/scripts/qa/reliability-audit.sh" --quick >/dev/null 2>&1; then
-  if grep -q "test_runner:" "$log_file" && ! grep -q "test_runner:-i" "$log_file" && grep -q "docs_coverage" "$log_file" && grep -q "traceability_coverage" "$log_file"; then
+  if grep -q "test_runner:--jobs auto" "$log_file" && ! grep -q "test_runner:.* -i" "$log_file" && grep -q "docs_coverage" "$log_file" && grep -q "traceability_coverage" "$log_file"; then
     ((TESTS_PASSED++))
     printf '%b\n' "  ${GREEN}✓${NC} $CURRENT_TEST: quick mode runs unit path with docs and traceability coverage"
   else
@@ -74,7 +74,7 @@ test_start "qa_reliability_with_integration_runs_integration"
 stub_repo="$(make_stub_repo)"
 log_file="$stub_repo/run.log"
 if LOG_FILE="$log_file" bash "$stub_repo/scripts/qa/reliability-audit.sh" --with-integration >/dev/null 2>&1; then
-  if grep -q "test_runner:-i" "$log_file" && grep -q "docs_coverage" "$log_file" && grep -q "traceability_coverage" "$log_file"; then
+  if grep -q "test_runner:--jobs auto -i" "$log_file" && grep -q "docs_coverage" "$log_file" && grep -q "traceability_coverage" "$log_file"; then
     ((TESTS_PASSED++))
     printf '%b\n' "  ${GREEN}✓${NC} $CURRENT_TEST: integration flag runs integration suite with docs and traceability coverage"
   else


### PR DESCRIPTION
## Summary
- emit canonical Homebrew Ruby from the formula template
- safely no-op when a release formula is already current
- close and delete superseded `bump/dot-*` PR branches
- quote all GitHub output file writes
- restore copyright and example coverage for `corralctl-sync`

## Validation
- full `./tests/framework/test_runner.sh` suite
- exact copyright-header and examples contracts
- `actionlint .github/workflows/release-distribute-homebrew.yml`
- synthetic formula URL/checksum rewrite
- superseded PR selection against current tap state
- `ruby -c install/homebrew/dot.rb`
- `git diff --check`

---
THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co