### PR TITLE
ci(release): harden AUR publishing and pin chezmoi

### DIFF
--- a/.github/workflows/release-distribute-aur.yml
+++ b/.github/workflows/release-distribute-aur.yml
@@ -46,8 +46,8 @@ jobs:
             exit 1
           fi
           VERSION="${TAG#v}"
-          echo "tag=$TAG" >> $GITHUB_OUTPUT
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Download release asset
         id: download-asset
@@ -76,7 +76,7 @@ jobs:
             echo "::error::Asset ${ASSET_NAME} not found in release ${TAG} after ~5min"
             exit 1
           fi
-          echo "asset_path=${ASSET_PATH}" >> $GITHUB_OUTPUT
+          echo "asset_path=${ASSET_PATH}" >> "$GITHUB_OUTPUT"
 
       - name: Compute SHA256 of tarball
         id: compute-sha256
@@ -84,7 +84,7 @@ jobs:
           set -euo pipefail
           ASSET_PATH="${{ steps.download-asset.outputs.asset_path }}"
           SHA256=$(sha256sum "$ASSET_PATH" | awk '{print $1}')
-          echo "sha256=${SHA256}" >> $GITHUB_OUTPUT
+          echo "sha256=${SHA256}" >> "$GITHUB_OUTPUT"
           echo "SHA256: ${SHA256}"
 
       - name: Configure AUR SSH
@@ -112,18 +112,33 @@ jobs:
         id: clone-aur
         run: |
           set -euo pipefail
-          if ! git clone ssh://aur@aur.archlinux.org/dot-cli-git.git aur-pkg 2>&1; then
-            echo "::error::First publication: the user must create the AUR package entry via the web UI at https://aur.archlinux.org/packages first"
-            exit 1
-          fi
+          # AUR periodically enters maintenance and rejects SSH clones. Retry
+          # transient endpoint failures for five minutes before surfacing the
+          # final git error. This also remains safe for first publication: an
+          # absent package fails consistently and reaches the same guidance.
+          clone_log="$(mktemp)"
+          trap 'rm -f "$clone_log"' EXIT
+          for attempt in $(seq 1 10); do
+            rm -rf aur-pkg
+            if git clone ssh://aur@aur.archlinux.org/dot-cli-git.git aur-pkg 2>"$clone_log"; then
+              exit 0
+            fi
+            cat "$clone_log" >&2
+            if [[ "$attempt" -lt 10 ]]; then
+              echo "AUR clone failed (attempt ${attempt}/10); retrying in 30s..."
+              sleep 30
+            fi
+          done
+          echo "::error::Unable to clone the AUR package after 10 attempts."
+          echo "The AUR may be unavailable. For a first publication, create the package entry first:"
+          echo "https://aur.archlinux.org/packages"
+          exit 1
 
       - name: Update PKGBUILD
         run: |
           set -euo pipefail
           VERSION="${{ steps.resolve-tag.outputs.version }}"
           SHA256="${{ steps.compute-sha256.outputs.sha256 }}"
-          ASSET_PATH="${{ steps.download-asset.outputs.asset_path }}"
-
           cp install/aur/PKGBUILD aur-pkg/PKGBUILD
           sed -i "s/^pkgver=.*/pkgver=${VERSION}/" aur-pkg/PKGBUILD
           sed -i "s/^sha256sums=(.*)$/sha256sums=('${SHA256}')/" aur-pkg/PKGBUILD
@@ -134,7 +149,7 @@ jobs:
         run: |
           set -euo pipefail
           docker run --rm \
-            -v $(pwd)/aur-pkg:/work \
+            -v "$(pwd)/aur-pkg:/work" \
             -w /work \
             archlinux/archlinux:base-devel \
             bash -c "useradd -m builder && chown -R builder:builder /work && su builder -c 'cd /work && makepkg --printsrcinfo > .SRCINFO'"

--- a/defaults/dot_config/mise/conf.d/00-dotfiles.toml
+++ b/defaults/dot_config/mise/conf.d/00-dotfiles.toml
@@ -59,7 +59,7 @@ ruff = "latest"
 yazi = "latest"
 zellij = "latest"
 zoxide = "latest"
-"aqua:twpayne/chezmoi" = "latest"
+"aqua:twpayne/chezmoi" = "2.72.0"
 "aqua:junegunn/fzf" = "latest"
 "aqua:FiloSottile/age" = "latest"
 # hyperfine intentionally NOT managed by mise: the aqua package for

--- a/mise-versions.lock.json
+++ b/mise-versions.lock.json
@@ -9,7 +9,7 @@
   "aqua:ollama/ollama": "0.19.0",
   "aqua:sharkdp/hyperfine": "1.20.0",
   "aqua:topgrade-rs/topgrade": "16.9.0",
-  "aqua:twpayne/chezmoi": "2.70.0",
+  "aqua:twpayne/chezmoi": "2.72.0",
   "atuin": "18.13.6",
   "bat": "0.26.1",
   "bun": "1.3.10",


### PR DESCRIPTION
## Summary
- pin mise-managed chezmoi to the verified 2.72.0 release
- synchronize the mise version lock
- retry transient AUR SSH clone failures for up to five minutes
- report a truthful terminal AUR error after retries

## Verification
- `actionlint .github/workflows/release-distribute-aur.yml`
- `pre-commit run yamllint --all-files --config config/pre-commit-config.yaml`
- `git diff --check`
- regression suites: 193/193 passing
- `make test` (local full reliability audit)

---
THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co