### PR TITLE
docs(ci): fix AUR secret setup reference

### DIFF
--- a/.github/workflows/release-distribute-aur.yml
+++ b/.github/workflows/release-distribute-aur.yml
@@ -93,7 +93,7 @@ jobs:
         run: |
           set -euo pipefail
           if [[ -z "${AUR_SSH_KEY}" ]]; then
-            echo "::error::Missing AUR_SSH_KEY secret. See docs/security/AUR_PUBLISHING.md for setup."
+            echo "::error::Missing AUR_SSH_KEY secret. See docs/operations/RELEASE_PIPELINE.md#secrets-used for setup."
             exit 1
           fi
           install -d -m 700 ~/.ssh


### PR DESCRIPTION
## Summary
- replace the missing AUR publishing guide reference
- point the workflow error to the canonical release-pipeline secrets documentation

## Verification
- `actionlint .github/workflows/release-distribute-aur.yml`
- `git diff --check`
- confirmed no `AUR_PUBLISHING.md` references remain

---
THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co