### PR TITLE
fix(release): restore SLSA provenance generation

### DIFF
--- a/.github/workflows/security-release.yml
+++ b/.github/workflows/security-release.yml
@@ -241,7 +241,7 @@ jobs:
     # documented exception to the repo's otherwise-strict SHA-pinning
     # convention; Scorecard's Pinned-Dependencies check explicitly
     # exempts SLSA-generator from SHA pinning for this reason.
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
     with:
       base64-subjects: "${{ needs.sbom.outputs.hash }}"
       upload-assets: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@
 
 ## Project Overview
 
-Chezmoi-managed dotfiles for macOS, Linux, WSL, and PowerShell 7.5+. Version `0.2.513`.
+Chezmoi-managed dotfiles for macOS, Linux, WSL, and PowerShell 7.5+. Version `0.2.514`.
 
 ## Key Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@
 
 ## Project Overview
 
-Chezmoi-managed dotfiles for macOS, Linux, WSL, and PowerShell 7.5+. Version `0.2.513`.
+Chezmoi-managed dotfiles for macOS, Linux, WSL, and PowerShell 7.5+. Version `0.2.514`.
 
 ## Key Commands
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 <p align="center">
   <a href="https://github.com/sebastienrousseau/dotfiles/actions"><img src="https://img.shields.io/github/actions/workflow/status/sebastienrousseau/dotfiles/ci.yml?style=for-the-badge&logo=githubactions&logoColor=white" alt="Build" /></a>
-  <a href="https://github.com/sebastienrousseau/dotfiles/releases/latest"><img src="https://img.shields.io/badge/Version-v0.2.513-blue?style=for-the-badge&logo=semanticrelease&logoColor=white" alt="Version" /></a>
+  <a href="https://github.com/sebastienrousseau/dotfiles/releases/latest"><img src="https://img.shields.io/badge/Version-v0.2.514-blue?style=for-the-badge&logo=semanticrelease&logoColor=white" alt="Version" /></a>
   <a href="https://github.com/sebastienrousseau/dotfiles/releases"><img src="https://img.shields.io/github/downloads/sebastienrousseau/dotfiles/total?style=for-the-badge&logo=github&logoColor=white" alt="Downloads" /></a>
   <a href="https://codespaces.new/sebastienrousseau/dotfiles"><img src="https://img.shields.io/badge/Open%20in-Codespaces-blue?style=for-the-badge&logo=github&logoColor=white" alt="Open in GitHub Codespaces" /></a>
   <a href="https://scorecard.dev/viewer/?uri=github.com/sebastienrousseau/dotfiles"><img src="https://img.shields.io/ossf-scorecard/github.com/sebastienrousseau/dotfiles?style=for-the-badge&logo=linuxfoundation&logoColor=white&label=OpenSSF%20Scorecard" alt="OpenSSF Scorecard" /></a>
@@ -52,7 +52,7 @@
 
 ```bash
 curl -fsSL -o /tmp/dotfiles-install.sh \
-  https://raw.githubusercontent.com/sebastienrousseau/dotfiles/v0.2.513/install.sh
+  https://raw.githubusercontent.com/sebastienrousseau/dotfiles/v0.2.514/install.sh
 echo "d5a04c5e2813a93a63c8ecce9655cf3d107f6068862c6eba84a92cf22f801c7e  /tmp/dotfiles-install.sh" \
   | shasum -a 256 -c
 bash /tmp/dotfiles-install.sh

--- a/bin/dot
+++ b/bin/dot
@@ -4,7 +4,7 @@
 # Copyright (c) 2015-2026 Sebastien Rousseau
 set -euo pipefail
 
-# Dotfiles CLI Entry Point - v0.2.513
+# Dotfiles CLI Entry Point - v0.2.514
 
 # Ensure XDG Base Directory variables are set
 export XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"
@@ -22,7 +22,7 @@ if [ -e "${HOME}/.nix-profile/etc/profile.d/nix.sh" ]; then
   . "${HOME}/.nix-profile/etc/profile.d/nix.sh"
 fi
 
-VERSION="0.2.513"
+VERSION="0.2.514"
 
 COMMAND="${1:-}"
 if [ -n "${1:-}" ]; then
@@ -38,8 +38,8 @@ _resolve_source_dir() {
 
   if script_path="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd 2>/dev/null)"; then
     script_dir="$script_path"
-    # Post-v0.2.513: the canonical dispatcher lives at <repo>/bin/dot, so
-    # $script_dir/.. is the repo root. Pre-v0.2.513 (and chezmoi-deployed
+    # Post-v0.2.514: the canonical dispatcher lives at <repo>/bin/dot, so
+    # $script_dir/.. is the repo root. Pre-v0.2.514 (and chezmoi-deployed
     # wrapper invocations that still exec the canonical) the dispatcher
     # was at <repo>/dot_local/bin/executable_dot, so $script_dir/../..
     # was the repo. Probe both to cover the transition.

--- a/defaults/.chezmoidata.toml
+++ b/defaults/.chezmoidata.toml
@@ -1,5 +1,5 @@
 # Active profile - change this to switch configurations
-dotfiles_version = "0.2.513"
+dotfiles_version = "0.2.514"
 profile = "laptop"
 
 # Machine preset — set per-host in ~/.config/chezmoi/chezmoi.toml:

--- a/defaults/.chezmoitemplates/README.md
+++ b/defaults/.chezmoitemplates/README.md
@@ -5,7 +5,7 @@
   align="right"
 />
 
-# Chezmoi Templates (v0.2.513)
+# Chezmoi Templates (v0.2.514)
 
 Modular shell configuration managed by Chezmoi
 

--- a/defaults/.chezmoitemplates/aliases/README.md
+++ b/defaults/.chezmoitemplates/aliases/README.md
@@ -5,7 +5,7 @@
   align="right"
 />
 
-# Dotfiles Aliases (v0.2.513)
+# Dotfiles Aliases (v0.2.514)
 
 Modular alias definitions managed by Chezmoi
 

--- a/defaults/.chezmoitemplates/functions/README.md
+++ b/defaults/.chezmoitemplates/functions/README.md
@@ -5,7 +5,7 @@
   align="right"
 />
 
-# Dotfiles Functions (v0.2.513)
+# Dotfiles Functions (v0.2.514)
 
 > Modular shell utilities managed by Chezmoi
 

--- a/defaults/dot_config/shell/README.md
+++ b/defaults/dot_config/shell/README.md
@@ -27,7 +27,7 @@ Welcome to your universally compatible, high-performance dotfiles configuration,
 To install these dotfiles on a new machine, run:
 
 ```bash
-bash -c "$(curl -fsSL https://raw.githubusercontent.com/sebastienrousseau/dotfiles/v0.2.513/install.sh)"
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/sebastienrousseau/dotfiles/v0.2.514/install.sh)"
 ```
 
 This command will:

--- a/docs/COPYRIGHT
+++ b/docs/COPYRIGHT
@@ -1,5 +1,5 @@
 /*
-* 🅳🅾🆃🅵🅸🅻🅴🆂 (v0.2.513) - <https://github.com/sebastienrousseau/dotfiles>
+* 🅳🅾🆃🅵🅸🅻🅴🆂 (v0.2.514) - <https://github.com/sebastienrousseau/dotfiles>
 * Made With ❤️ in London, United Kingdom
 * Designed by
 * Copyright (c) 2015-2026. All rights reserved.

--- a/docs/manual/00-introduction.md
+++ b/docs/manual/00-introduction.md
@@ -4,7 +4,7 @@ render_with_liquid: false
 
 # Introduction
 
-This manual describes `.dotfiles` v0.2.513 — a trusted agent workstation baseline for macOS, Linux, and WSL.
+This manual describes `.dotfiles` v0.2.514 — a trusted agent workstation baseline for macOS, Linux, and WSL.
 
 The repository is more than a personal dotfiles collection. It ships as workstation infrastructure: signed, attested, multi-platform, AI-aware, and self-healing. Chezmoi handles templating and platform differences. The `dot` CLI sits on top and coordinates lifecycle operations.
 

--- a/docs/operations/HARD_AUDIT_2026.md
+++ b/docs/operations/HARD_AUDIT_2026.md
@@ -52,8 +52,8 @@ The goal stated by the maintainer: become the de facto workstation provisioning 
 
 ### 1.5 What's already excellent (keep)
 
-- **Release supply chain.** `security-release.yml` runs Cosign keyless signing + SBOM generation + SLSA provenance, all SHA-pinned. No findings.
-- **GitHub Actions hygiene.** Every `uses:` is SHA-pinned, reusable workflows blocked by `lint-reusable-pins.sh`. Strong.
+- **Release supply chain.** `security-release.yml` runs Cosign keyless signing + SBOM generation + SLSA provenance. Actions are SHA-pinned except the SLSA generator's required, documented `v2.1.0` tag reference.
+- **GitHub Actions hygiene.** Every non-exempt `uses:` is SHA-pinned; reusable workflows are blocked by `lint-reusable-pins.sh`. Strong.
 - **Secrets handling.** `scripts/lib/secrets_provider.sh` correctly isolates macOS keychain / `pass` / `age` providers with no plaintext leakage.
 - **Test suite.** 4035 unit tests, 47.57% measured line coverage with documented structural ceiling.
 

--- a/docs/security/CI_PINNING.md
+++ b/docs/security/CI_PINNING.md
@@ -12,6 +12,14 @@ Every external dependency the CI pipeline consumes must be pinned by
 3. **Container base images** — `FROM image:tag@sha256:<digest>` (closed by [#886](https://github.com/sebastienrousseau/dotfiles/pull/886)).
 4. **Release binaries downloaded at build time** — `curl … && echo "<sha256> ..." | sha256sum -c` (closed by [#888](https://github.com/sebastienrousseau/dotfiles/pull/888)).
 
+The sole exception is the SLSA generic reusable workflow. Its bootstrap
+validates that the caller reference has the form `refs/tags/vX.Y.Z` and
+fails when invoked through a bare commit SHA. Therefore
+`generator_generic_slsa3.yml` is pinned to the exact release tag
+`v2.1.0`; the corresponding commit SHA is recorded beside the call site
+and must be verified before any tag bump. OpenSSF Scorecard explicitly
+exempts the SLSA generator from its SHA-pinning check for this constraint.
+
 ## Why SHA-pin reusable workflows
 
 When `ci.yml` calls a reusable via `./.github/workflows/reusable-X.yml`,

--- a/install.sh
+++ b/install.sh
@@ -71,7 +71,7 @@ show_help() {
 Usage: install.sh [version] [options]
 
 Arguments:
-  version       The version (tag or branch) to install (default: v0.2.513)
+  version       The version (tag or branch) to install (default: v0.2.514)
 
 Options:
   --help        Show this help message
@@ -87,7 +87,7 @@ EOF
 }
 
 main() {
-  local version="v0.2.513"
+  local version="v0.2.514"
   local version_set=0
   local minimal=0
   local provision="${DOTFILES_PROVISION:-0}"
@@ -117,7 +117,7 @@ main() {
         # like `foobar` doesn't trigger a 30s+ network download attempt.
         # Caught by the install.sh fuzz harness (#881).
         if [[ ! "$arg" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+([-+][a-zA-Z0-9.-]+)?$ ]]; then
-          error "Unrecognized positional argument '$arg' — expected a semver version (e.g. v0.2.513)."
+          error "Unrecognized positional argument '$arg' — expected a semver version (e.g. v0.2.514)."
         fi
         version="$arg"
         version_set=1
@@ -369,7 +369,7 @@ main() {
   # 6. Initialize & Apply
   step "Applying Configuration..."
 
-  # ── Auto-migration for v0.2.513 reorg ─────────────────────────────────
+  # ── Auto-migration for v0.2.514 reorg ─────────────────────────────────
   # If the user is upgrading from a pre-0.2.503 install, run the
   # migration script BEFORE `chezmoi apply` so the reorg's source-
   # path moves don't cause chezmoi to delete deployed files.
@@ -378,7 +378,7 @@ main() {
   for migrate_src in "$SOURCE_DIR" "$LEGACY_SOURCE_DIR"; do
     migrate_script="$migrate_src/install/migrate/migrate-v0_2-to-v0_2_503.sh"
     if [[ -x "$migrate_script" ]]; then
-      echo "   Running v0.2.513 migration (idempotent; safe on fresh installs)..."
+      echo "   Running v0.2.514 migration (idempotent; safe on fresh installs)..."
       "$migrate_script" || echo "   migration exited non-zero — continuing apply"
       break
     fi

--- a/lib/dot/bento.sh
+++ b/lib/dot/bento.sh
@@ -33,7 +33,7 @@ _dotfiles_bento_render() {
 
   # Render a fixed-width card (42 cols) so output aligns in any terminal width
   printf "\n"
-  printf "  ${c_cyan}${c_bold}💎  D O T F I L E S${c_reset}  ${c_slate}[v0.2.513]${c_reset}\n"
+  printf "  ${c_cyan}${c_bold}💎  D O T F I L E S${c_reset}  ${c_slate}[v0.2.514]${c_reset}\n"
   printf "  ${c_slate}──────────────────────────────────────────${c_reset}\n"
 
   # Key system properties at a glance — answers "is my env healthy?" in 1 second

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sebastienrousseau/dotfiles",
-  "version": "0.2.513",
+  "version": "0.2.514",
   "description": "The Trusted Shell Platform — Universal dotfiles managed by Chezmoi. Features Bash & Zsh for macOS, Linux & WSL. Rust modern tooling & enterprise-grade security.",
   "main": "install.sh",
   "bin": {

--- a/scripts/git-hooks/pre-commit-audit.sh
+++ b/scripts/git-hooks/pre-commit-audit.sh
@@ -141,6 +141,6 @@ if [[ $FAILED -eq 1 ]]; then
   printf '%b\\n' "   (Use --no-verify to bypass if absolutely necessary)"
   exit 1
 else
-  printf '%b\n' "${GREEN}${BOLD}✅ Audit passed.${NC} v0.2.513 standards maintained."
+  printf '%b\n' "${GREEN}${BOLD}✅ Audit passed.${NC} v0.2.514 standards maintained."
   exit 0
 fi

--- a/scripts/version-sync.sh
+++ b/scripts/version-sync.sh
@@ -32,6 +32,7 @@ EXCLUDE_FILES=(
   "docs/operations/VERSION_SYNC.md"
   "docs/operations/RFC_v0_2_503_reorganization.md"
   "docs/operations/HARD_AUDIT_2026.md"
+  "docs/operations/COVERAGE.md"
   "docs/reference/ALIASES_DEPRECATIONS.md"
 
   # Security docs — INSTALL_VERIFICATION + CI_PINNING + SCORECARD

--- a/share/man/man1/dot.1
+++ b/share/man/man1/dot.1
@@ -1,4 +1,4 @@
-.TH DOT 1 "May 2026" "dotfiles v0.2.513" "User Commands"
+.TH DOT 1 "May 2026" "dotfiles v0.2.514" "User Commands"
 .SH NAME
 dot \- dotfiles management CLI
 .SH SYNOPSIS

--- a/tests/unit/ci/test_release_signing_contract.sh
+++ b/tests/unit/ci/test_release_signing_contract.sh
@@ -28,6 +28,15 @@ test_start "release_signing_asset_manifest"
 assert_file_contains "$SEC" "ALL_SHA256SUMS" "builds a SHA256SUMS manifest over release assets"
 
 # ── 2. SLSA build provenance for the release artefacts ──────────────────────
+test_start "release_slsa_generator_uses_required_tag_ref"
+assert_file_contains \
+  "$SEC" \
+  "generator_generic_slsa3.yml@v2.1.0" \
+  "SLSA generator uses its required version-tag reference"
+assert_output_not_contains \
+  "generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a" \
+  "cat '$SEC'"
+
 test_start "release_provenance_attestation"
 assert_file_exists "$PKG" "release-package workflow exists"
 assert_file_contains "$PKG" "actions/attest-build-provenance" "attests build provenance"


### PR DESCRIPTION
## Summary

- invoke the SLSA generic generator through its required exact version tag
- lock the exception with a release-signing contract test and document the pinning policy
- bump the dotfiles patch version to 0.2.514 and preserve historical coverage provenance

## Verification

- upstream `v2.1.0` resolves to `f7dd8c54c2067bafc12ca7a55595d5ee9b75204a`
- `actionlint -shellcheck='' .github/workflows/security-release.yml`
- `./scripts/version-sync.sh --verify 0.2.514`
- focused release-signing and reusable-pin tests
- full suite: 5,561 passed, 0 failed
- ShellCheck and `git diff --check`

## Follow-up

After merge, manually dispatch `security-release.yml` for `v0.2.513` to attach the missing provenance asset.


---
THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co
