### PR TITLE
fix(release): cover provenance in signed manifest

### DIFF
--- a/.github/workflows/security-release.yml
+++ b/.github/workflows/security-release.yml
@@ -135,7 +135,10 @@ jobs:
     # release, so downstream verifiers don't need to enumerate.
     if: github.event_name == 'workflow_dispatch' || github.event.action == 'published'
     runs-on: ubuntu-latest
-    needs: [sbom]
+    # Provenance is itself a release asset, so the manifest must wait until
+    # the generator uploads it. Running these jobs in parallel leaves the
+    # signed manifest incomplete and creates a verification race.
+    needs: [sbom, provenance]
     permissions:
       contents: write   # upload manifest + sig + cert
       id-token: write   # OIDC for Cosign keyless
@@ -293,10 +296,9 @@ jobs:
           echo "SBOM hash verified"
 
       - name: Verify provenance asset exists on release
-        if: github.event_name == 'release'
         env:
           GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ inputs.release_tag || github.event.release.tag_name }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@
 
 ## Project Overview
 
-Chezmoi-managed dotfiles for macOS, Linux, WSL, and PowerShell 7.5+. Version `0.2.514`.
+Chezmoi-managed dotfiles for macOS, Linux, WSL, and PowerShell 7.5+. Version `0.2.515`.
 
 ## Key Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@
 
 ## Project Overview
 
-Chezmoi-managed dotfiles for macOS, Linux, WSL, and PowerShell 7.5+. Version `0.2.514`.
+Chezmoi-managed dotfiles for macOS, Linux, WSL, and PowerShell 7.5+. Version `0.2.515`.
 
 ## Key Commands
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 <p align="center">
   <a href="https://github.com/sebastienrousseau/dotfiles/actions"><img src="https://img.shields.io/github/actions/workflow/status/sebastienrousseau/dotfiles/ci.yml?style=for-the-badge&logo=githubactions&logoColor=white" alt="Build" /></a>
-  <a href="https://github.com/sebastienrousseau/dotfiles/releases/latest"><img src="https://img.shields.io/badge/Version-v0.2.514-blue?style=for-the-badge&logo=semanticrelease&logoColor=white" alt="Version" /></a>
+  <a href="https://github.com/sebastienrousseau/dotfiles/releases/latest"><img src="https://img.shields.io/badge/Version-v0.2.515-blue?style=for-the-badge&logo=semanticrelease&logoColor=white" alt="Version" /></a>
   <a href="https://github.com/sebastienrousseau/dotfiles/releases"><img src="https://img.shields.io/github/downloads/sebastienrousseau/dotfiles/total?style=for-the-badge&logo=github&logoColor=white" alt="Downloads" /></a>
   <a href="https://codespaces.new/sebastienrousseau/dotfiles"><img src="https://img.shields.io/badge/Open%20in-Codespaces-blue?style=for-the-badge&logo=github&logoColor=white" alt="Open in GitHub Codespaces" /></a>
   <a href="https://scorecard.dev/viewer/?uri=github.com/sebastienrousseau/dotfiles"><img src="https://img.shields.io/ossf-scorecard/github.com/sebastienrousseau/dotfiles?style=for-the-badge&logo=linuxfoundation&logoColor=white&label=OpenSSF%20Scorecard" alt="OpenSSF Scorecard" /></a>
@@ -52,7 +52,7 @@
 
 ```bash
 curl -fsSL -o /tmp/dotfiles-install.sh \
-  https://raw.githubusercontent.com/sebastienrousseau/dotfiles/v0.2.514/install.sh
+  https://raw.githubusercontent.com/sebastienrousseau/dotfiles/v0.2.515/install.sh
 echo "d5a04c5e2813a93a63c8ecce9655cf3d107f6068862c6eba84a92cf22f801c7e  /tmp/dotfiles-install.sh" \
   | shasum -a 256 -c
 bash /tmp/dotfiles-install.sh

--- a/bin/dot
+++ b/bin/dot
@@ -4,7 +4,7 @@
 # Copyright (c) 2015-2026 Sebastien Rousseau
 set -euo pipefail
 
-# Dotfiles CLI Entry Point - v0.2.514
+# Dotfiles CLI Entry Point - v0.2.515
 
 # Ensure XDG Base Directory variables are set
 export XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"
@@ -22,7 +22,7 @@ if [ -e "${HOME}/.nix-profile/etc/profile.d/nix.sh" ]; then
   . "${HOME}/.nix-profile/etc/profile.d/nix.sh"
 fi
 
-VERSION="0.2.514"
+VERSION="0.2.515"
 
 COMMAND="${1:-}"
 if [ -n "${1:-}" ]; then
@@ -38,8 +38,8 @@ _resolve_source_dir() {
 
   if script_path="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd 2>/dev/null)"; then
     script_dir="$script_path"
-    # Post-v0.2.514: the canonical dispatcher lives at <repo>/bin/dot, so
-    # $script_dir/.. is the repo root. Pre-v0.2.514 (and chezmoi-deployed
+    # Post-v0.2.515: the canonical dispatcher lives at <repo>/bin/dot, so
+    # $script_dir/.. is the repo root. Pre-v0.2.515 (and chezmoi-deployed
     # wrapper invocations that still exec the canonical) the dispatcher
     # was at <repo>/dot_local/bin/executable_dot, so $script_dir/../..
     # was the repo. Probe both to cover the transition.

--- a/defaults/.chezmoidata.toml
+++ b/defaults/.chezmoidata.toml
@@ -1,5 +1,5 @@
 # Active profile - change this to switch configurations
-dotfiles_version = "0.2.514"
+dotfiles_version = "0.2.515"
 profile = "laptop"
 
 # Machine preset — set per-host in ~/.config/chezmoi/chezmoi.toml:

--- a/defaults/.chezmoitemplates/README.md
+++ b/defaults/.chezmoitemplates/README.md
@@ -5,7 +5,7 @@
   align="right"
 />
 
-# Chezmoi Templates (v0.2.514)
+# Chezmoi Templates (v0.2.515)
 
 Modular shell configuration managed by Chezmoi
 

--- a/defaults/.chezmoitemplates/aliases/README.md
+++ b/defaults/.chezmoitemplates/aliases/README.md
@@ -5,7 +5,7 @@
   align="right"
 />
 
-# Dotfiles Aliases (v0.2.514)
+# Dotfiles Aliases (v0.2.515)
 
 Modular alias definitions managed by Chezmoi
 

--- a/defaults/.chezmoitemplates/functions/README.md
+++ b/defaults/.chezmoitemplates/functions/README.md
@@ -5,7 +5,7 @@
   align="right"
 />
 
-# Dotfiles Functions (v0.2.514)
+# Dotfiles Functions (v0.2.515)
 
 > Modular shell utilities managed by Chezmoi
 

--- a/defaults/dot_config/shell/README.md
+++ b/defaults/dot_config/shell/README.md
@@ -27,7 +27,7 @@ Welcome to your universally compatible, high-performance dotfiles configuration,
 To install these dotfiles on a new machine, run:
 
 ```bash
-bash -c "$(curl -fsSL https://raw.githubusercontent.com/sebastienrousseau/dotfiles/v0.2.514/install.sh)"
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/sebastienrousseau/dotfiles/v0.2.515/install.sh)"
 ```
 
 This command will:

--- a/docs/COPYRIGHT
+++ b/docs/COPYRIGHT
@@ -1,5 +1,5 @@
 /*
-* 🅳🅾🆃🅵🅸🅻🅴🆂 (v0.2.514) - <https://github.com/sebastienrousseau/dotfiles>
+* 🅳🅾🆃🅵🅸🅻🅴🆂 (v0.2.515) - <https://github.com/sebastienrousseau/dotfiles>
 * Made With ❤️ in London, United Kingdom
 * Designed by
 * Copyright (c) 2015-2026. All rights reserved.

--- a/docs/manual/00-introduction.md
+++ b/docs/manual/00-introduction.md
@@ -4,7 +4,7 @@ render_with_liquid: false
 
 # Introduction
 
-This manual describes `.dotfiles` v0.2.514 — a trusted agent workstation baseline for macOS, Linux, and WSL.
+This manual describes `.dotfiles` v0.2.515 — a trusted agent workstation baseline for macOS, Linux, and WSL.
 
 The repository is more than a personal dotfiles collection. It ships as workstation infrastructure: signed, attested, multi-platform, AI-aware, and self-healing. Chezmoi handles templating and platform differences. The `dot` CLI sits on top and coordinates lifecycle operations.
 

--- a/install.sh
+++ b/install.sh
@@ -71,7 +71,7 @@ show_help() {
 Usage: install.sh [version] [options]
 
 Arguments:
-  version       The version (tag or branch) to install (default: v0.2.514)
+  version       The version (tag or branch) to install (default: v0.2.515)
 
 Options:
   --help        Show this help message
@@ -87,7 +87,7 @@ EOF
 }
 
 main() {
-  local version="v0.2.514"
+  local version="v0.2.515"
   local version_set=0
   local minimal=0
   local provision="${DOTFILES_PROVISION:-0}"
@@ -117,7 +117,7 @@ main() {
         # like `foobar` doesn't trigger a 30s+ network download attempt.
         # Caught by the install.sh fuzz harness (#881).
         if [[ ! "$arg" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+([-+][a-zA-Z0-9.-]+)?$ ]]; then
-          error "Unrecognized positional argument '$arg' — expected a semver version (e.g. v0.2.514)."
+          error "Unrecognized positional argument '$arg' — expected a semver version (e.g. v0.2.515)."
         fi
         version="$arg"
         version_set=1
@@ -369,7 +369,7 @@ main() {
   # 6. Initialize & Apply
   step "Applying Configuration..."
 
-  # ── Auto-migration for v0.2.514 reorg ─────────────────────────────────
+  # ── Auto-migration for v0.2.515 reorg ─────────────────────────────────
   # If the user is upgrading from a pre-0.2.503 install, run the
   # migration script BEFORE `chezmoi apply` so the reorg's source-
   # path moves don't cause chezmoi to delete deployed files.
@@ -378,7 +378,7 @@ main() {
   for migrate_src in "$SOURCE_DIR" "$LEGACY_SOURCE_DIR"; do
     migrate_script="$migrate_src/install/migrate/migrate-v0_2-to-v0_2_503.sh"
     if [[ -x "$migrate_script" ]]; then
-      echo "   Running v0.2.514 migration (idempotent; safe on fresh installs)..."
+      echo "   Running v0.2.515 migration (idempotent; safe on fresh installs)..."
       "$migrate_script" || echo "   migration exited non-zero — continuing apply"
       break
     fi

--- a/lib/dot/bento.sh
+++ b/lib/dot/bento.sh
@@ -33,7 +33,7 @@ _dotfiles_bento_render() {
 
   # Render a fixed-width card (42 cols) so output aligns in any terminal width
   printf "\n"
-  printf "  ${c_cyan}${c_bold}💎  D O T F I L E S${c_reset}  ${c_slate}[v0.2.514]${c_reset}\n"
+  printf "  ${c_cyan}${c_bold}💎  D O T F I L E S${c_reset}  ${c_slate}[v0.2.515]${c_reset}\n"
   printf "  ${c_slate}──────────────────────────────────────────${c_reset}\n"
 
   # Key system properties at a glance — answers "is my env healthy?" in 1 second

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sebastienrousseau/dotfiles",
-  "version": "0.2.514",
+  "version": "0.2.515",
   "description": "The Trusted Shell Platform — Universal dotfiles managed by Chezmoi. Features Bash & Zsh for macOS, Linux & WSL. Rust modern tooling & enterprise-grade security.",
   "main": "install.sh",
   "bin": {

--- a/scripts/git-hooks/pre-commit-audit.sh
+++ b/scripts/git-hooks/pre-commit-audit.sh
@@ -141,6 +141,6 @@ if [[ $FAILED -eq 1 ]]; then
   printf '%b\\n' "   (Use --no-verify to bypass if absolutely necessary)"
   exit 1
 else
-  printf '%b\n' "${GREEN}${BOLD}✅ Audit passed.${NC} v0.2.514 standards maintained."
+  printf '%b\n' "${GREEN}${BOLD}✅ Audit passed.${NC} v0.2.515 standards maintained."
   exit 0
 fi

--- a/share/man/man1/dot.1
+++ b/share/man/man1/dot.1
@@ -1,4 +1,4 @@
-.TH DOT 1 "May 2026" "dotfiles v0.2.514" "User Commands"
+.TH DOT 1 "May 2026" "dotfiles v0.2.515" "User Commands"
 .SH NAME
 dot \- dotfiles management CLI
 .SH SYNOPSIS

--- a/tests/unit/ci/test_release_signing_contract.sh
+++ b/tests/unit/ci/test_release_signing_contract.sh
@@ -36,6 +36,14 @@ assert_file_contains \
 assert_output_not_contains \
   "generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a" \
   "cat '$SEC'"
+assert_file_contains \
+  "$SEC" \
+  "needs: [sbom, provenance]" \
+  "signed manifest waits for provenance upload"
+assert_file_contains \
+  "$SEC" \
+  "RELEASE_TAG: \${{ inputs.release_tag || github.event.release.tag_name }}" \
+  "dispatch integrity check targets the requested release"
 
 test_start "release_provenance_attestation"
 assert_file_exists "$PKG" "release-package workflow exists"


### PR DESCRIPTION
## Summary

- serialize signed-manifest generation after SLSA provenance upload
- verify provenance presence during manual release-repair dispatches
- add regression contracts and bump the patch version to 0.2.515

## Verification

- focused release-signing contract: 14 assertions passed
- reusable-workflow pin tests and lint passed
- structural actionlint passed
- ShellCheck and version consistency passed
- live v0.2.513 inspection confirmed the pre-fix manifest omitted the provenance asset

---
THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co
