### PR TITLE
fix(release): make attestation bundle atomic

### DIFF
--- a/.github/workflows/security-release.yml
+++ b/.github/workflows/security-release.yml
@@ -2,12 +2,10 @@ name: Release / Security Attestation
 
 on:
   release:
-    # `created` fires once when the release first appears (covers the
-    # SBOM + provenance generated from source). `published` fires when
-    # a human edits a draft → public, by which point asset-uploading
-    # workflows (manual-publish.yml etc.) have finished — that's when
-    # we sign the full asset manifest. Both runs are idempotent.
-    types: [created, published]
+    # A single published-event run owns SBOM, provenance, and manifest
+    # generation. Running on both created and published lets two runs
+    # overwrite one another's signed assets in an indeterminate order.
+    types: [published]
   workflow_dispatch:
     inputs:
       release_tag:
@@ -21,13 +19,8 @@ on:
 permissions:
   contents: read
 
-# Serialize the `created` and `published` runs for a given release. The
-# `sbom` job runs on both events (the `published`-only manifest job needs
-# its same-run artifact), so without this they execute concurrently and
-# race while clobbering/verifying the same SBOM blobs on the release —
-# which previously failed the "Verify SBOM signature" step. cancel-in-progress
-# is false so both runs still complete (created → SBOM + provenance,
-# published → signed manifest), just one after the other.
+# Serialize release events and manual repair dispatches for a given tag so
+# operators cannot race a repair against normal publication.
 concurrency:
   group: security-release-${{ github.event.release.tag_name || inputs.release_tag || github.ref }}
   cancel-in-progress: false
@@ -129,11 +122,8 @@ jobs:
 
   manifest:
     name: Release / Signed Asset Manifest
-    # Runs on `published` (after asset-uploaders have finished) to
-    # build ALL_SHA256SUMS over every release asset and Cosign-sign
-    # it. The result: one signed file covers every artefact on the
-    # release, so downstream verifiers don't need to enumerate.
-    if: github.event_name == 'workflow_dispatch' || github.event.action == 'published'
+    # Build ALL_SHA256SUMS only after provenance and every independently
+    # published release asset are present.
     runs-on: ubuntu-latest
     # Provenance is itself a release asset, so the manifest must wait until
     # the generator uploads it. Running these jobs in parallel leaves the
@@ -152,20 +142,56 @@ jobs:
         with:
           ref: ${{ inputs.release_tag || github.ref }}
 
-      - name: Download every release asset
+      - name: Wait for complete release asset set and download
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ github.event.release.tag_name || inputs.release_tag }}
         run: |
           set -euo pipefail
+          version="${RELEASE_TAG#v}"
+          required=(
+            "dot-${version}.tar.gz"
+            "dot-${version}.zip"
+            "SHA256SUMS"
+            "dotfiles-md.tar.gz"
+            "dotfiles.html.gz"
+            "dotfiles.epub"
+            "dotfiles.pdf"
+            "dotfiles.txt.gz"
+            "html.tar.gz"
+            "dotfiles-sbom.spdx.json"
+            "dotfiles-sbom.spdx.json.sig"
+            "dotfiles-sbom.spdx.json.pem"
+            "dotfiles-sbom.spdx.json.intoto.jsonl"
+          )
+
+          for attempt in $(seq 1 20); do
+            mapfile -t present < <(
+              gh release view "$RELEASE_TAG" --json assets --jq '.assets[].name'
+            )
+            missing=()
+            for expected in "${required[@]}"; do
+              found=0
+              for asset in "${present[@]}"; do
+                [[ "$asset" == "$expected" ]] && { found=1; break; }
+              done
+              [[ "$found" -eq 0 ]] && missing+=("$expected")
+            done
+            if [[ "${#missing[@]}" -eq 0 ]]; then
+              echo "All ${#required[@]} prerequisite release assets are present."
+              break
+            fi
+            if [[ "$attempt" -eq 20 ]]; then
+              echo "::error::Timed out waiting for prerequisite release assets: ${missing[*]}"
+              exit 1
+            fi
+            echo "Waiting for release assets (attempt ${attempt}/20): ${missing[*]}"
+            sleep 15
+          done
+
           mkdir -p assets
-          cd assets
-          # Pull everything attached to the release at this moment.
-          # Re-running the job after additional assets land will pick
-          # them up; the upload step uses --clobber so the manifest
-          # tracks current state.
-          gh release download "$RELEASE_TAG" --dir . || true
-          ls -la
+          gh release download "$RELEASE_TAG" --dir assets
+          ls -la assets
 
       - name: Build ALL_SHA256SUMS (excludes manifest's own .sig/.pem/itself)
         run: |
@@ -260,7 +286,7 @@ jobs:
   verify-release-integrity:
     name: Release / Verify Integrity
     runs-on: ubuntu-latest
-    needs: [sbom, provenance]
+    needs: [sbom, provenance, manifest]
     permissions:
       contents: read
     steps:
@@ -345,3 +371,27 @@ jobs:
             --certificate-oidc-issuer https://token.actions.githubusercontent.com \
             dotfiles-sbom.spdx.json
           echo "SBOM Cosign signature verified"
+
+      - name: Download release assets for manifest verification
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.release_tag || github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          mkdir -p release-assets
+          gh release download "$RELEASE_TAG" --dir release-assets
+
+      - name: Verify signed manifest and every covered asset
+        env:
+          REPO: ${{ github.repository }}
+        working-directory: release-assets
+        run: |
+          set -euo pipefail
+          cosign verify-blob \
+            --certificate ALL_SHA256SUMS.pem \
+            --signature ALL_SHA256SUMS.sig \
+            --certificate-identity-regexp "^https://github.com/${REPO}/" \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+            ALL_SHA256SUMS
+          sha256sum -c ALL_SHA256SUMS
+          echo "Signed release manifest and all covered asset digests verified"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@
 
 ## Project Overview
 
-Chezmoi-managed dotfiles for macOS, Linux, WSL, and PowerShell 7.5+. Version `0.2.515`.
+Chezmoi-managed dotfiles for macOS, Linux, WSL, and PowerShell 7.5+. Version `0.2.516`.
 
 ## Key Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@
 
 ## Project Overview
 
-Chezmoi-managed dotfiles for macOS, Linux, WSL, and PowerShell 7.5+. Version `0.2.515`.
+Chezmoi-managed dotfiles for macOS, Linux, WSL, and PowerShell 7.5+. Version `0.2.516`.
 
 ## Key Commands
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 <p align="center">
   <a href="https://github.com/sebastienrousseau/dotfiles/actions"><img src="https://img.shields.io/github/actions/workflow/status/sebastienrousseau/dotfiles/ci.yml?style=for-the-badge&logo=githubactions&logoColor=white" alt="Build" /></a>
-  <a href="https://github.com/sebastienrousseau/dotfiles/releases/latest"><img src="https://img.shields.io/badge/Version-v0.2.515-blue?style=for-the-badge&logo=semanticrelease&logoColor=white" alt="Version" /></a>
+  <a href="https://github.com/sebastienrousseau/dotfiles/releases/latest"><img src="https://img.shields.io/badge/Version-v0.2.516-blue?style=for-the-badge&logo=semanticrelease&logoColor=white" alt="Version" /></a>
   <a href="https://github.com/sebastienrousseau/dotfiles/releases"><img src="https://img.shields.io/github/downloads/sebastienrousseau/dotfiles/total?style=for-the-badge&logo=github&logoColor=white" alt="Downloads" /></a>
   <a href="https://codespaces.new/sebastienrousseau/dotfiles"><img src="https://img.shields.io/badge/Open%20in-Codespaces-blue?style=for-the-badge&logo=github&logoColor=white" alt="Open in GitHub Codespaces" /></a>
   <a href="https://scorecard.dev/viewer/?uri=github.com/sebastienrousseau/dotfiles"><img src="https://img.shields.io/ossf-scorecard/github.com/sebastienrousseau/dotfiles?style=for-the-badge&logo=linuxfoundation&logoColor=white&label=OpenSSF%20Scorecard" alt="OpenSSF Scorecard" /></a>
@@ -52,7 +52,7 @@
 
 ```bash
 curl -fsSL -o /tmp/dotfiles-install.sh \
-  https://raw.githubusercontent.com/sebastienrousseau/dotfiles/v0.2.515/install.sh
+  https://raw.githubusercontent.com/sebastienrousseau/dotfiles/v0.2.516/install.sh
 echo "d5a04c5e2813a93a63c8ecce9655cf3d107f6068862c6eba84a92cf22f801c7e  /tmp/dotfiles-install.sh" \
   | shasum -a 256 -c
 bash /tmp/dotfiles-install.sh

--- a/bin/dot
+++ b/bin/dot
@@ -4,7 +4,7 @@
 # Copyright (c) 2015-2026 Sebastien Rousseau
 set -euo pipefail
 
-# Dotfiles CLI Entry Point - v0.2.515
+# Dotfiles CLI Entry Point - v0.2.516
 
 # Ensure XDG Base Directory variables are set
 export XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"
@@ -22,7 +22,7 @@ if [ -e "${HOME}/.nix-profile/etc/profile.d/nix.sh" ]; then
   . "${HOME}/.nix-profile/etc/profile.d/nix.sh"
 fi
 
-VERSION="0.2.515"
+VERSION="0.2.516"
 
 COMMAND="${1:-}"
 if [ -n "${1:-}" ]; then
@@ -38,8 +38,8 @@ _resolve_source_dir() {
 
   if script_path="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd 2>/dev/null)"; then
     script_dir="$script_path"
-    # Post-v0.2.515: the canonical dispatcher lives at <repo>/bin/dot, so
-    # $script_dir/.. is the repo root. Pre-v0.2.515 (and chezmoi-deployed
+    # Post-v0.2.516: the canonical dispatcher lives at <repo>/bin/dot, so
+    # $script_dir/.. is the repo root. Pre-v0.2.516 (and chezmoi-deployed
     # wrapper invocations that still exec the canonical) the dispatcher
     # was at <repo>/dot_local/bin/executable_dot, so $script_dir/../..
     # was the repo. Probe both to cover the transition.

--- a/defaults/.chezmoidata.toml
+++ b/defaults/.chezmoidata.toml
@@ -1,5 +1,5 @@
 # Active profile - change this to switch configurations
-dotfiles_version = "0.2.515"
+dotfiles_version = "0.2.516"
 profile = "laptop"
 
 # Machine preset — set per-host in ~/.config/chezmoi/chezmoi.toml:

--- a/defaults/.chezmoitemplates/README.md
+++ b/defaults/.chezmoitemplates/README.md
@@ -5,7 +5,7 @@
   align="right"
 />
 
-# Chezmoi Templates (v0.2.515)
+# Chezmoi Templates (v0.2.516)
 
 Modular shell configuration managed by Chezmoi
 

--- a/defaults/.chezmoitemplates/aliases/README.md
+++ b/defaults/.chezmoitemplates/aliases/README.md
@@ -5,7 +5,7 @@
   align="right"
 />
 
-# Dotfiles Aliases (v0.2.515)
+# Dotfiles Aliases (v0.2.516)
 
 Modular alias definitions managed by Chezmoi
 

--- a/defaults/.chezmoitemplates/functions/README.md
+++ b/defaults/.chezmoitemplates/functions/README.md
@@ -5,7 +5,7 @@
   align="right"
 />
 
-# Dotfiles Functions (v0.2.515)
+# Dotfiles Functions (v0.2.516)
 
 > Modular shell utilities managed by Chezmoi
 

--- a/defaults/dot_config/shell/README.md
+++ b/defaults/dot_config/shell/README.md
@@ -27,7 +27,7 @@ Welcome to your universally compatible, high-performance dotfiles configuration,
 To install these dotfiles on a new machine, run:
 
 ```bash
-bash -c "$(curl -fsSL https://raw.githubusercontent.com/sebastienrousseau/dotfiles/v0.2.515/install.sh)"
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/sebastienrousseau/dotfiles/v0.2.516/install.sh)"
 ```
 
 This command will:

--- a/docs/COPYRIGHT
+++ b/docs/COPYRIGHT
@@ -1,5 +1,5 @@
 /*
-* 🅳🅾🆃🅵🅸🅻🅴🆂 (v0.2.515) - <https://github.com/sebastienrousseau/dotfiles>
+* 🅳🅾🆃🅵🅸🅻🅴🆂 (v0.2.516) - <https://github.com/sebastienrousseau/dotfiles>
 * Made With ❤️ in London, United Kingdom
 * Designed by
 * Copyright (c) 2015-2026. All rights reserved.

--- a/docs/manual/00-introduction.md
+++ b/docs/manual/00-introduction.md
@@ -4,7 +4,7 @@ render_with_liquid: false
 
 # Introduction
 
-This manual describes `.dotfiles` v0.2.515 — a trusted agent workstation baseline for macOS, Linux, and WSL.
+This manual describes `.dotfiles` v0.2.516 — a trusted agent workstation baseline for macOS, Linux, and WSL.
 
 The repository is more than a personal dotfiles collection. It ships as workstation infrastructure: signed, attested, multi-platform, AI-aware, and self-healing. Chezmoi handles templating and platform differences. The `dot` CLI sits on top and coordinates lifecycle operations.
 

--- a/docs/operations/RELEASE_PIPELINE.md
+++ b/docs/operations/RELEASE_PIPELINE.md
@@ -8,9 +8,10 @@ date: 2026-05-24
 End-to-end flow from `git tag v0.2.503 && git push --tags` to a fully
 signed, distributed release on GitHub + Homebrew + Scoop + AUR.
 
-Five workflows are involved, each scoped to one job and triggered off
-either `release.created` or `release.published`. They run in parallel
-where dependencies allow.
+Release workflows are triggered by either `release.created` or
+`release.published`. Packaging starts at creation; distribution and the
+single security chain start at publication and run in parallel where
+dependencies allow.
 
 ```
             git push --tags                       (you)
@@ -19,26 +20,20 @@ where dependencies allow.
        ┌────────────────────────────┐
        │  GitHub creates Release    │ (auto, from tag)
        └─┬──────────────────────────┘
-         │ on: release.created
-         ▼
-   ┌─────────────────────────────┐   ┌─────────────────────────────┐
-   │  release-package-dot.yml    │   │  security-release.yml (sbom)│
-   │  → dot-VERSION.tar.gz       │   │  → SBOM + cosign sig + cert │
-   │  → dot-VERSION.zip          │   │  → SLSA L3 provenance       │
-   └─────────────┬───────────────┘   └──────────────┬──────────────┘
-                 │ uploaded to release              │
-                 │                                  │
-                 │ on: release.published            │ on: release.published
-                 │ (after human "publish" click,    │ (same trigger)
-                 │  or auto if Release was created  │
-                 │  with assets+published in one)   │
+         ├── on: release.created
+         │       └── release-package-dot.yml
+         │           → dot-VERSION.tar.gz + .zip
+         │
+         └── on: release.published
+                 │
+                 ├──────────────────────────────────┐
                  ▼                                  ▼
    ┌─────────────────────────────┐   ┌─────────────────────────────┐
    │  release-distribute-*.yml   │   │  security-release.yml       │
-   │  ┌─────────────────────┐    │   │  (manifest job)             │
+   │  ┌─────────────────────┐    │   │  → SBOM + provenance        │
    │  │ homebrew → tap PR   │    │   │  → ALL_SHA256SUMS           │
    │  │ scoop    → bucket PR│    │   │  → cosign sig + cert        │
-   │  │ aur      → AUR push │    │   │                             │
+   │  │ aur      → AUR push │    │   │  → verify full bundle       │
    │  └─────────────────────┘    │   └─────────────────────────────┘
    └─────────────────────────────┘
                  │
@@ -54,30 +49,33 @@ where dependencies allow.
 | Workflow | Trigger | Owns | Outputs |
 |---|---|---|---|
 | `release-package-dot.yml` | `release.created`, dispatch | Build deterministic `dot-VERSION.{tar.gz,zip}` from `bin/`, `lib/`, `share/`, completions. | Two release assets. |
-| `security-release.yml` (sbom job) | `release.created`, dispatch | Generate SPDX SBOM via anchore/sbom-action. Cosign keyless sign the SBOM. | `dotfiles-sbom.spdx.json` + `.sig` + `.pem`. |
+| `security-release.yml` (sbom job) | `release.published`, dispatch | Generate SPDX SBOM via anchore/sbom-action. Cosign keyless sign the SBOM. | `dotfiles-sbom.spdx.json` + `.sig` + `.pem`. |
 | `security-release.yml` (provenance job) | needs sbom | SLSA L3 provenance via slsa-framework/slsa-github-generator. | `dotfiles-sbom.spdx.json.intoto.jsonl`. |
-| `security-release.yml` (manifest job) | `release.published`, dispatch | Build `ALL_SHA256SUMS` over every release asset, Cosign-sign it. | `ALL_SHA256SUMS` + `.sig` + `.pem`. |
+| `security-release.yml` (manifest job) | needs provenance + complete asset set | Build `ALL_SHA256SUMS` over every release asset, Cosign-sign it, and verify its signature and digests. | `ALL_SHA256SUMS` + `.sig` + `.pem`. |
 | `release-distribute-homebrew.yml` | `release.published`, dispatch | Hash `dot-VERSION.tar.gz`, regenerate `install/homebrew/dot.rb`, push branch + PR to `sebastienrousseau/homebrew-tap`. | One PR on the tap repo. |
 | `release-distribute-scoop.yml` | `release.published`, dispatch | Hash `dot-VERSION.zip`, rewrite `install/scoop/dot.json` via jq (both 64bit + arm64 point at same zip), PR to `sebastienrousseau/scoop-bucket`. | One PR on the bucket repo. |
 | `release-distribute-aur.yml` | `release.published`, dispatch | Hash `dot-VERSION.tar.gz`, rewrite `pkgver` + `sha256sums` in `install/aur/PKGBUILD`, regenerate `.SRCINFO` via dockerised `makepkg`, push to `ssh://aur@aur.archlinux.org/dot-cli-git.git`. | One commit on AUR. |
 | `release-attestation-check.yml` | weekly cron + dispatch | Verify the latest release carries the full attestation bundle (SBOM + sig + cert + intoto + manifest + sig + cert). | Opens or comments on a tracking issue. |
 
-## Why `created` vs `published`
+## Event ownership and readiness
 
 GitHub fires `release.created` the moment a Release record exists.
-That covers SBOM + SLSA + the packaging step: those depend only on
-source bytes at the tag and don't need other assets to be present.
+That starts the packaging step, which depends only on source bytes at
+the tag and does not need other assets to be present.
 
 `release.published` fires later, when a human flips the Release from
 draft to public (or when a Release is created already-public, the
-events fire together). The manifest job and the three distribution
-jobs wait for that because they enumerate *all* assets on the release;
-running them earlier would miss the manual / docs artefacts uploaded
-by `manual-publish.yml` and the packaging step's tarball + zip.
+events fire together). Distribution and the security chain start from
+this event. Publication does not mean independently triggered asset
+publishers have finished, so the manifest job waits for all 13 required
+package, documentation, SBOM, signature, and provenance assets before
+it downloads or signs the bundle. The final integrity job then verifies
+the manifest's Cosign identity and every recorded digest.
 
-Both arms of `security-release.yml` are idempotent: re-running the
-manifest job after late asset uploads picks up the new state and the
-`--clobber` flag overwrites the previous manifest sig + cert.
+Both release and dispatch paths of `security-release.yml` are
+idempotent: re-running the manifest job after late asset uploads picks
+up the new state and the `--clobber` flag overwrites the previous
+manifest sig + cert.
 
 ## Secrets used
 

--- a/install.sh
+++ b/install.sh
@@ -71,7 +71,7 @@ show_help() {
 Usage: install.sh [version] [options]
 
 Arguments:
-  version       The version (tag or branch) to install (default: v0.2.515)
+  version       The version (tag or branch) to install (default: v0.2.516)
 
 Options:
   --help        Show this help message
@@ -87,7 +87,7 @@ EOF
 }
 
 main() {
-  local version="v0.2.515"
+  local version="v0.2.516"
   local version_set=0
   local minimal=0
   local provision="${DOTFILES_PROVISION:-0}"
@@ -117,7 +117,7 @@ main() {
         # like `foobar` doesn't trigger a 30s+ network download attempt.
         # Caught by the install.sh fuzz harness (#881).
         if [[ ! "$arg" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+([-+][a-zA-Z0-9.-]+)?$ ]]; then
-          error "Unrecognized positional argument '$arg' — expected a semver version (e.g. v0.2.515)."
+          error "Unrecognized positional argument '$arg' — expected a semver version (e.g. v0.2.516)."
         fi
         version="$arg"
         version_set=1
@@ -369,7 +369,7 @@ main() {
   # 6. Initialize & Apply
   step "Applying Configuration..."
 
-  # ── Auto-migration for v0.2.515 reorg ─────────────────────────────────
+  # ── Auto-migration for v0.2.516 reorg ─────────────────────────────────
   # If the user is upgrading from a pre-0.2.503 install, run the
   # migration script BEFORE `chezmoi apply` so the reorg's source-
   # path moves don't cause chezmoi to delete deployed files.
@@ -378,7 +378,7 @@ main() {
   for migrate_src in "$SOURCE_DIR" "$LEGACY_SOURCE_DIR"; do
     migrate_script="$migrate_src/install/migrate/migrate-v0_2-to-v0_2_503.sh"
     if [[ -x "$migrate_script" ]]; then
-      echo "   Running v0.2.515 migration (idempotent; safe on fresh installs)..."
+      echo "   Running v0.2.516 migration (idempotent; safe on fresh installs)..."
       "$migrate_script" || echo "   migration exited non-zero — continuing apply"
       break
     fi

--- a/lib/dot/bento.sh
+++ b/lib/dot/bento.sh
@@ -33,7 +33,7 @@ _dotfiles_bento_render() {
 
   # Render a fixed-width card (42 cols) so output aligns in any terminal width
   printf "\n"
-  printf "  ${c_cyan}${c_bold}💎  D O T F I L E S${c_reset}  ${c_slate}[v0.2.515]${c_reset}\n"
+  printf "  ${c_cyan}${c_bold}💎  D O T F I L E S${c_reset}  ${c_slate}[v0.2.516]${c_reset}\n"
   printf "  ${c_slate}──────────────────────────────────────────${c_reset}\n"
 
   # Key system properties at a glance — answers "is my env healthy?" in 1 second

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sebastienrousseau/dotfiles",
-  "version": "0.2.515",
+  "version": "0.2.516",
   "description": "The Trusted Shell Platform — Universal dotfiles managed by Chezmoi. Features Bash & Zsh for macOS, Linux & WSL. Rust modern tooling & enterprise-grade security.",
   "main": "install.sh",
   "bin": {

--- a/scripts/git-hooks/pre-commit-audit.sh
+++ b/scripts/git-hooks/pre-commit-audit.sh
@@ -141,6 +141,6 @@ if [[ $FAILED -eq 1 ]]; then
   printf '%b\\n' "   (Use --no-verify to bypass if absolutely necessary)"
   exit 1
 else
-  printf '%b\n' "${GREEN}${BOLD}✅ Audit passed.${NC} v0.2.515 standards maintained."
+  printf '%b\n' "${GREEN}${BOLD}✅ Audit passed.${NC} v0.2.516 standards maintained."
   exit 0
 fi

--- a/share/man/man1/dot.1
+++ b/share/man/man1/dot.1
@@ -1,4 +1,4 @@
-.TH DOT 1 "May 2026" "dotfiles v0.2.515" "User Commands"
+.TH DOT 1 "May 2026" "dotfiles v0.2.516" "User Commands"
 .SH NAME
 dot \- dotfiles management CLI
 .SH SYNOPSIS

--- a/tests/unit/ci/test_release_signing_contract.sh
+++ b/tests/unit/ci/test_release_signing_contract.sh
@@ -26,6 +26,10 @@ assert_file_contains "$SEC" "id-token: write" "OIDC token for keyless signing"
 
 test_start "release_signing_asset_manifest"
 assert_file_contains "$SEC" "ALL_SHA256SUMS" "builds a SHA256SUMS manifest over release assets"
+assert_file_contains "$SEC" "types: [published]" "uses one mutating security run per release"
+assert_file_contains "$SEC" "All \${#required[@]} prerequisite release assets are present." "waits for the complete release bundle"
+assert_file_contains "$SEC" "needs: [sbom, provenance, manifest]" "integrity verification waits for manifest upload"
+assert_file_contains "$SEC" "sha256sum -c ALL_SHA256SUMS" "verifies every manifest-covered release asset"
 
 # ── 2. SLSA build provenance for the release artefacts ──────────────────────
 test_start "release_slsa_generator_uses_required_tag_ref"


### PR DESCRIPTION
## Summary

- run one mutating security chain per published release
- wait for all 13 prerequisite assets before signing the unified manifest
- cryptographically verify the manifest and every covered digest before success
- document the corrected event ownership and bump to 0.2.516

## Verification

- release-signing contract: 18 assertions passed
- reusable-workflow pin tests and lint passed
- structural actionlint passed
- ShellCheck, version consistency, and diff checks passed
- live v0.2.515 verification reproduced stale SBOM/provenance hashes and missing late assets before this fix

---
THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co
