### PR TITLE
chore(release): prepare v0.2.517

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@
 
 ## Project Overview
 
-Chezmoi-managed dotfiles for macOS, Linux, WSL, and PowerShell 7.5+. Version `0.2.516`.
+Chezmoi-managed dotfiles for macOS, Linux, WSL, and PowerShell 7.5+. Version `0.2.517`.
 
 ## Key Commands
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 This file documents all notable changes to this project.
 
+## v0.2.517 — 2026-08-12
+
+### Changed
+
+- Updated the GitHub Actions minor/patch dependency group across the CI,
+  security, release, documentation, and reliability workflows. The reviewed
+  updates include Harden Runner 2.20.1, Checkout 7.0.1, CodeQL 4.37.6,
+  Checkov Action 12.3115.0, Paths Filter 4.0.3, and Build Provenance 4.2.2.
+- Refreshed all same-repository reusable workflow pins from the v0.2.511
+  baseline to the immutable v0.2.516 commit.
+
+### Fixed
+
+- Kept the block-mode egress and documentation-drift contract tests aligned
+  with the reviewed Harden Runner 2.20.1 SHA, preventing dependency updates
+  from invalidating otherwise-correct CI security policy checks.
+- Documented Dependabot's current support for grouped updates to immutable
+  same-repository reusable workflow references.
+
 ## v0.2.513 — 2026-08-06
 
 - **Verified module registry installation.** `dot registry install` now validates the v1 index, verifies immutable archive SHA-256 digests, rejects traversal and link-bearing archives, previews with chezmoi by default, and applies only with explicit `--yes`. CI validates the published registry contract and JSON Schema.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@
 
 ## Project Overview
 
-Chezmoi-managed dotfiles for macOS, Linux, WSL, and PowerShell 7.5+. Version `0.2.516`.
+Chezmoi-managed dotfiles for macOS, Linux, WSL, and PowerShell 7.5+. Version `0.2.517`.
 
 ## Key Commands
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 <p align="center">
   <a href="https://github.com/sebastienrousseau/dotfiles/actions"><img src="https://img.shields.io/github/actions/workflow/status/sebastienrousseau/dotfiles/ci.yml?style=for-the-badge&logo=githubactions&logoColor=white" alt="Build" /></a>
-  <a href="https://github.com/sebastienrousseau/dotfiles/releases/latest"><img src="https://img.shields.io/badge/Version-v0.2.516-blue?style=for-the-badge&logo=semanticrelease&logoColor=white" alt="Version" /></a>
+  <a href="https://github.com/sebastienrousseau/dotfiles/releases/latest"><img src="https://img.shields.io/badge/Version-v0.2.517-blue?style=for-the-badge&logo=semanticrelease&logoColor=white" alt="Version" /></a>
   <a href="https://github.com/sebastienrousseau/dotfiles/releases"><img src="https://img.shields.io/github/downloads/sebastienrousseau/dotfiles/total?style=for-the-badge&logo=github&logoColor=white" alt="Downloads" /></a>
   <a href="https://codespaces.new/sebastienrousseau/dotfiles"><img src="https://img.shields.io/badge/Open%20in-Codespaces-blue?style=for-the-badge&logo=github&logoColor=white" alt="Open in GitHub Codespaces" /></a>
   <a href="https://scorecard.dev/viewer/?uri=github.com/sebastienrousseau/dotfiles"><img src="https://img.shields.io/ossf-scorecard/github.com/sebastienrousseau/dotfiles?style=for-the-badge&logo=linuxfoundation&logoColor=white&label=OpenSSF%20Scorecard" alt="OpenSSF Scorecard" /></a>
@@ -52,8 +52,8 @@
 
 ```bash
 curl -fsSL -o /tmp/dotfiles-install.sh \
-  https://raw.githubusercontent.com/sebastienrousseau/dotfiles/v0.2.516/install.sh
-echo "d5a04c5e2813a93a63c8ecce9655cf3d107f6068862c6eba84a92cf22f801c7e  /tmp/dotfiles-install.sh" \
+  https://raw.githubusercontent.com/sebastienrousseau/dotfiles/v0.2.517/install.sh
+echo "a105e3c204aa8b71aac101dc9be2e74ca20159053326183b6d0f5f6649588380  /tmp/dotfiles-install.sh" \
   | shasum -a 256 -c
 bash /tmp/dotfiles-install.sh
 ```

--- a/bin/dot
+++ b/bin/dot
@@ -4,7 +4,7 @@
 # Copyright (c) 2015-2026 Sebastien Rousseau
 set -euo pipefail
 
-# Dotfiles CLI Entry Point - v0.2.516
+# Dotfiles CLI Entry Point - v0.2.517
 
 # Ensure XDG Base Directory variables are set
 export XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"
@@ -22,7 +22,7 @@ if [ -e "${HOME}/.nix-profile/etc/profile.d/nix.sh" ]; then
   . "${HOME}/.nix-profile/etc/profile.d/nix.sh"
 fi
 
-VERSION="0.2.516"
+VERSION="0.2.517"
 
 COMMAND="${1:-}"
 if [ -n "${1:-}" ]; then
@@ -38,8 +38,8 @@ _resolve_source_dir() {
 
   if script_path="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd 2>/dev/null)"; then
     script_dir="$script_path"
-    # Post-v0.2.516: the canonical dispatcher lives at <repo>/bin/dot, so
-    # $script_dir/.. is the repo root. Pre-v0.2.516 (and chezmoi-deployed
+    # Post-v0.2.517: the canonical dispatcher lives at <repo>/bin/dot, so
+    # $script_dir/.. is the repo root. Pre-v0.2.517 (and chezmoi-deployed
     # wrapper invocations that still exec the canonical) the dispatcher
     # was at <repo>/dot_local/bin/executable_dot, so $script_dir/../..
     # was the repo. Probe both to cover the transition.

--- a/defaults/.chezmoidata.toml
+++ b/defaults/.chezmoidata.toml
@@ -1,5 +1,5 @@
 # Active profile - change this to switch configurations
-dotfiles_version = "0.2.516"
+dotfiles_version = "0.2.517"
 profile = "laptop"
 
 # Machine preset — set per-host in ~/.config/chezmoi/chezmoi.toml:

--- a/defaults/.chezmoitemplates/README.md
+++ b/defaults/.chezmoitemplates/README.md
@@ -5,7 +5,7 @@
   align="right"
 />
 
-# Chezmoi Templates (v0.2.516)
+# Chezmoi Templates (v0.2.517)
 
 Modular shell configuration managed by Chezmoi
 

--- a/defaults/.chezmoitemplates/aliases/README.md
+++ b/defaults/.chezmoitemplates/aliases/README.md
@@ -5,7 +5,7 @@
   align="right"
 />
 
-# Dotfiles Aliases (v0.2.516)
+# Dotfiles Aliases (v0.2.517)
 
 Modular alias definitions managed by Chezmoi
 

--- a/defaults/.chezmoitemplates/functions/README.md
+++ b/defaults/.chezmoitemplates/functions/README.md
@@ -5,7 +5,7 @@
   align="right"
 />
 
-# Dotfiles Functions (v0.2.516)
+# Dotfiles Functions (v0.2.517)
 
 > Modular shell utilities managed by Chezmoi
 

--- a/defaults/dot_config/shell/README.md
+++ b/defaults/dot_config/shell/README.md
@@ -27,7 +27,7 @@ Welcome to your universally compatible, high-performance dotfiles configuration,
 To install these dotfiles on a new machine, run:
 
 ```bash
-bash -c "$(curl -fsSL https://raw.githubusercontent.com/sebastienrousseau/dotfiles/v0.2.516/install.sh)"
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/sebastienrousseau/dotfiles/v0.2.517/install.sh)"
 ```
 
 This command will:

--- a/docs/COPYRIGHT
+++ b/docs/COPYRIGHT
@@ -1,5 +1,5 @@
 /*
-* 🅳🅾🆃🅵🅸🅻🅴🆂 (v0.2.516) - <https://github.com/sebastienrousseau/dotfiles>
+* 🅳🅾🆃🅵🅸🅻🅴🆂 (v0.2.517) - <https://github.com/sebastienrousseau/dotfiles>
 * Made With ❤️ in London, United Kingdom
 * Designed by
 * Copyright (c) 2015-2026. All rights reserved.

--- a/docs/manual/00-introduction.md
+++ b/docs/manual/00-introduction.md
@@ -4,7 +4,7 @@ render_with_liquid: false
 
 # Introduction
 
-This manual describes `.dotfiles` v0.2.516 — a trusted agent workstation baseline for macOS, Linux, and WSL.
+This manual describes `.dotfiles` v0.2.517 — a trusted agent workstation baseline for macOS, Linux, and WSL.
 
 The repository is more than a personal dotfiles collection. It ships as workstation infrastructure: signed, attested, multi-platform, AI-aware, and self-healing. Chezmoi handles templating and platform differences. The `dot` CLI sits on top and coordinates lifecycle operations.
 

--- a/docs/security/CI_PINNING.md
+++ b/docs/security/CI_PINNING.md
@@ -99,17 +99,17 @@ intentional before merge.
 
 ## Dependabot
 
-Dependabot's `github-actions` ecosystem **does not** support same-repo
-reusable workflow SHA bumps as of May 2026 — it only updates
-references to external actions. Same-repo reusables are tracked
-manually via the recipe above. The Dependabot config in
-`.github/dependabot.yml` covers the external dimension; this
-document covers the in-repo one.
+Dependabot's `github-actions` ecosystem now updates full-SHA references to
+same-repository reusable workflows. PR
+[#992](https://github.com/sebastienrousseau/dotfiles/pull/992) verified this
+behavior by moving the reusable workflow baseline from v0.2.511 to the
+immutable v0.2.516 commit alongside the external minor/patch action group.
 
-If GitHub ships native Dependabot support for reusable workflows,
-delete this section and switch to `package-ecosystem: github-actions`
-with `directory: /.github/workflows`. Track on
-[github/feedback#10539](https://github.com/orgs/community/discussions/10539).
+Keep `bump-reusable-pins.yml` enabled as the immediate post-merge path. It
+updates callers as soon as a reusable workflow changes on `main`, while
+Dependabot provides the scheduled dependency review and grouped update path.
+Both mechanisms must preserve full 40-hex SHA references and pass
+`lint-reusable-pins` plus the egress-policy contract tests.
 
 ## Negative test
 

--- a/install.sh
+++ b/install.sh
@@ -71,7 +71,7 @@ show_help() {
 Usage: install.sh [version] [options]
 
 Arguments:
-  version       The version (tag or branch) to install (default: v0.2.516)
+  version       The version (tag or branch) to install (default: v0.2.517)
 
 Options:
   --help        Show this help message
@@ -87,7 +87,7 @@ EOF
 }
 
 main() {
-  local version="v0.2.516"
+  local version="v0.2.517"
   local version_set=0
   local minimal=0
   local provision="${DOTFILES_PROVISION:-0}"
@@ -117,7 +117,7 @@ main() {
         # like `foobar` doesn't trigger a 30s+ network download attempt.
         # Caught by the install.sh fuzz harness (#881).
         if [[ ! "$arg" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+([-+][a-zA-Z0-9.-]+)?$ ]]; then
-          error "Unrecognized positional argument '$arg' — expected a semver version (e.g. v0.2.516)."
+          error "Unrecognized positional argument '$arg' — expected a semver version (e.g. v0.2.517)."
         fi
         version="$arg"
         version_set=1
@@ -369,7 +369,7 @@ main() {
   # 6. Initialize & Apply
   step "Applying Configuration..."
 
-  # ── Auto-migration for v0.2.516 reorg ─────────────────────────────────
+  # ── Auto-migration for v0.2.517 reorg ─────────────────────────────────
   # If the user is upgrading from a pre-0.2.503 install, run the
   # migration script BEFORE `chezmoi apply` so the reorg's source-
   # path moves don't cause chezmoi to delete deployed files.
@@ -378,7 +378,7 @@ main() {
   for migrate_src in "$SOURCE_DIR" "$LEGACY_SOURCE_DIR"; do
     migrate_script="$migrate_src/install/migrate/migrate-v0_2-to-v0_2_503.sh"
     if [[ -x "$migrate_script" ]]; then
-      echo "   Running v0.2.516 migration (idempotent; safe on fresh installs)..."
+      echo "   Running v0.2.517 migration (idempotent; safe on fresh installs)..."
       "$migrate_script" || echo "   migration exited non-zero — continuing apply"
       break
     fi

--- a/lib/dot/bento.sh
+++ b/lib/dot/bento.sh
@@ -33,7 +33,7 @@ _dotfiles_bento_render() {
 
   # Render a fixed-width card (42 cols) so output aligns in any terminal width
   printf "\n"
-  printf "  ${c_cyan}${c_bold}💎  D O T F I L E S${c_reset}  ${c_slate}[v0.2.516]${c_reset}\n"
+  printf "  ${c_cyan}${c_bold}💎  D O T F I L E S${c_reset}  ${c_slate}[v0.2.517]${c_reset}\n"
   printf "  ${c_slate}──────────────────────────────────────────${c_reset}\n"
 
   # Key system properties at a glance — answers "is my env healthy?" in 1 second

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sebastienrousseau/dotfiles",
-  "version": "0.2.516",
+  "version": "0.2.517",
   "description": "The Trusted Shell Platform — Universal dotfiles managed by Chezmoi. Features Bash & Zsh for macOS, Linux & WSL. Rust modern tooling & enterprise-grade security.",
   "main": "install.sh",
   "bin": {

--- a/scripts/git-hooks/pre-commit-audit.sh
+++ b/scripts/git-hooks/pre-commit-audit.sh
@@ -141,6 +141,6 @@ if [[ $FAILED -eq 1 ]]; then
   printf '%b\\n' "   (Use --no-verify to bypass if absolutely necessary)"
   exit 1
 else
-  printf '%b\n' "${GREEN}${BOLD}✅ Audit passed.${NC} v0.2.516 standards maintained."
+  printf '%b\n' "${GREEN}${BOLD}✅ Audit passed.${NC} v0.2.517 standards maintained."
   exit 0
 fi

--- a/share/man/man1/dot.1
+++ b/share/man/man1/dot.1
@@ -1,4 +1,4 @@
-.TH DOT 1 "May 2026" "dotfiles v0.2.516" "User Commands"
+.TH DOT 1 "May 2026" "dotfiles v0.2.517" "User Commands"
 .SH NAME
 dot \- dotfiles management CLI
 .SH SYNOPSIS


### PR DESCRIPTION
## Summary

- Bump all current-version surfaces from 0.2.516 to 0.2.517.
- Document the GitHub Actions dependency upgrades merged in #992.
- Correct the CI pinning policy now that Dependabot updates immutable same-repository reusable workflow references.
- Refresh the pinned installer URL and verified SHA-256 digest.

## Testing

- `./scripts/version-sync.sh --verify`
- version consistency: 4/4 assertions
- CI pin contracts: 50/50 assertions
- remote installer checks: 2/2 assertions
- reusable workflow pin lint: 16 call sites, 0 failures
- README installer digest verified against `install.sh`

---
THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co
