### PR TITLE
chore(release): prepare v0.2.518

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@
 
 ## Project Overview
 
-Chezmoi-managed dotfiles for macOS, Linux, WSL, and PowerShell 7.5+. Version `0.2.517`.
+Chezmoi-managed dotfiles for macOS, Linux, WSL, and PowerShell 7.5+. Version `0.2.518`.
 
 ## Key Commands
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 This file documents all notable changes to this project.
 
+## v0.2.518 — 2026-08-13
+
+### Changed
+
+- Added binary-aware cached initialization for mise and zoxide in PowerShell,
+  bringing PowerShell startup behavior in line with Bash, Fish, Nushell, and
+  Zsh.
+- Activated the existing PowerShell 7.5.2 mise installation in the managed
+  workstation tool configuration, preventing an unresolved `pwsh` shim.
+- Pruned duplicate and nonexistent PATH entries after deferred mise hydration
+  so tool upgrades resolve through the current mise environment.
+
+### Fixed
+
+- Normalized chezmoi source paths ending in `defaults` in both Nerd Font hooks.
+  This prevents a verified `dot apply` from failing to locate
+  `lib/dot/verified-download.sh` after the v0.2.503 repository reorganization.
+- Updated workstation diagnostics to recognize the PowerShell cached-init
+  implementation instead of reporting a false shell-coverage warning.
+
 ## v0.2.517 — 2026-08-12
 
 ### Changed
@@ -447,7 +467,7 @@ verified by `dot lint` + the existing test matrix.
 - **`dot_config/shell/00-core-paths.sh.tmpl`** — system paths added via `path_prepend` (which removes duplicates first) instead of `PATH="...:${PATH}"`, eliminating the duplicate-system-path bloat that accumulates when the parent shell already had those entries (macOS launchd default).
 - **`dot_config/zsh/dot_zshrc.tmpl`** — re-apply `typeset -U path` after `_dotfiles_async_init` runs cached `export PATH=...` from mise/atuin/etc, since those bypass zsh's `-U` flag on the `path` array.
 - **`scripts/diagnostics/doctor.sh`** — only flag tools that actually emit shell-init eval and are not already lazy-loaded; raise PATH-length thresholds (60 ok / 120 warn) to match a populated mise-managed dev machine; skip `nu` when `cached_eval.nu` is present.
-- **`dot_config/git/hooks/executable_commit-msg`** — replaced hardcoded `/Users/seb` path with `${HOME}` so the hook is portable across hosts.
+- **`dot_config/git/hooks/executable_commit-msg`** — replaced a hardcoded user-home path with `${HOME}` so the hook is portable across hosts.
 - **`dot_config/fish/conf.d/{direnv,mise-activate}.fish`** — empty shadow files that override Homebrew `vendor_conf.d` to prevent eager init. fish dedupes `conf.d/` by basename, user wins. Saves ~140ms on every fish shell start; both tools are loaded lazily via `_cached_eval` in `init.fish`.
 - **`.devcontainer/Dockerfile`** — chezmoi install now goes through `tools/ci/install-chezmoi-verified.sh` (SHA256-verified) instead of the unverified `curl -fsSL https://get.chezmoi.io` fallback. Closes R4 §8.3 P3 / mirrors R1 H6 fix in `install.sh`.
 - **`typos.toml`** — extended file exclusions (`**/*.asc`, `**/*.pgp`, `**/*.gpg`, `**/*.sig`) to skip armored cryptographic blobs; added `fpr` / `FPR` to the allow-list (GPG `--with-colons` fingerprint column label).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@
 
 ## Project Overview
 
-Chezmoi-managed dotfiles for macOS, Linux, WSL, and PowerShell 7.5+. Version `0.2.517`.
+Chezmoi-managed dotfiles for macOS, Linux, WSL, and PowerShell 7.5+. Version `0.2.518`.
 
 ## Key Commands
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 <p align="center">
   <a href="https://github.com/sebastienrousseau/dotfiles/actions"><img src="https://img.shields.io/github/actions/workflow/status/sebastienrousseau/dotfiles/ci.yml?style=for-the-badge&logo=githubactions&logoColor=white" alt="Build" /></a>
-  <a href="https://github.com/sebastienrousseau/dotfiles/releases/latest"><img src="https://img.shields.io/badge/Version-v0.2.517-blue?style=for-the-badge&logo=semanticrelease&logoColor=white" alt="Version" /></a>
+  <a href="https://github.com/sebastienrousseau/dotfiles/releases/latest"><img src="https://img.shields.io/badge/Version-v0.2.518-blue?style=for-the-badge&logo=semanticrelease&logoColor=white" alt="Version" /></a>
   <a href="https://github.com/sebastienrousseau/dotfiles/releases"><img src="https://img.shields.io/github/downloads/sebastienrousseau/dotfiles/total?style=for-the-badge&logo=github&logoColor=white" alt="Downloads" /></a>
   <a href="https://codespaces.new/sebastienrousseau/dotfiles"><img src="https://img.shields.io/badge/Open%20in-Codespaces-blue?style=for-the-badge&logo=github&logoColor=white" alt="Open in GitHub Codespaces" /></a>
   <a href="https://scorecard.dev/viewer/?uri=github.com/sebastienrousseau/dotfiles"><img src="https://img.shields.io/ossf-scorecard/github.com/sebastienrousseau/dotfiles?style=for-the-badge&logo=linuxfoundation&logoColor=white&label=OpenSSF%20Scorecard" alt="OpenSSF Scorecard" /></a>
@@ -52,8 +52,8 @@
 
 ```bash
 curl -fsSL -o /tmp/dotfiles-install.sh \
-  https://raw.githubusercontent.com/sebastienrousseau/dotfiles/v0.2.517/install.sh
-echo "a105e3c204aa8b71aac101dc9be2e74ca20159053326183b6d0f5f6649588380  /tmp/dotfiles-install.sh" \
+  https://raw.githubusercontent.com/sebastienrousseau/dotfiles/v0.2.518/install.sh
+echo "1f8ef5b5ca0de42002269461ded3acc9d30cadc4f77e04d0abfd008d5690c0c5  /tmp/dotfiles-install.sh" \
   | shasum -a 256 -c
 bash /tmp/dotfiles-install.sh
 ```

--- a/bin/dot
+++ b/bin/dot
@@ -4,7 +4,7 @@
 # Copyright (c) 2015-2026 Sebastien Rousseau
 set -euo pipefail
 
-# Dotfiles CLI Entry Point - v0.2.517
+# Dotfiles CLI Entry Point - v0.2.518
 
 # Ensure XDG Base Directory variables are set
 export XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"
@@ -22,7 +22,7 @@ if [ -e "${HOME}/.nix-profile/etc/profile.d/nix.sh" ]; then
   . "${HOME}/.nix-profile/etc/profile.d/nix.sh"
 fi
 
-VERSION="0.2.517"
+VERSION="0.2.518"
 
 COMMAND="${1:-}"
 if [ -n "${1:-}" ]; then
@@ -38,8 +38,8 @@ _resolve_source_dir() {
 
   if script_path="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd 2>/dev/null)"; then
     script_dir="$script_path"
-    # Post-v0.2.517: the canonical dispatcher lives at <repo>/bin/dot, so
-    # $script_dir/.. is the repo root. Pre-v0.2.517 (and chezmoi-deployed
+    # Post-v0.2.518: the canonical dispatcher lives at <repo>/bin/dot, so
+    # $script_dir/.. is the repo root. Pre-v0.2.518 (and chezmoi-deployed
     # wrapper invocations that still exec the canonical) the dispatcher
     # was at <repo>/dot_local/bin/executable_dot, so $script_dir/../..
     # was the repo. Probe both to cover the transition.

--- a/defaults/.chezmoidata.toml
+++ b/defaults/.chezmoidata.toml
@@ -1,5 +1,5 @@
 # Active profile - change this to switch configurations
-dotfiles_version = "0.2.517"
+dotfiles_version = "0.2.518"
 profile = "laptop"
 
 # Machine preset — set per-host in ~/.config/chezmoi/chezmoi.toml:

--- a/defaults/.chezmoitemplates/README.md
+++ b/defaults/.chezmoitemplates/README.md
@@ -5,7 +5,7 @@
   align="right"
 />
 
-# Chezmoi Templates (v0.2.517)
+# Chezmoi Templates (v0.2.518)
 
 Modular shell configuration managed by Chezmoi
 

--- a/defaults/.chezmoitemplates/aliases/README.md
+++ b/defaults/.chezmoitemplates/aliases/README.md
@@ -5,7 +5,7 @@
   align="right"
 />
 
-# Dotfiles Aliases (v0.2.517)
+# Dotfiles Aliases (v0.2.518)
 
 Modular alias definitions managed by Chezmoi
 

--- a/defaults/.chezmoitemplates/functions/README.md
+++ b/defaults/.chezmoitemplates/functions/README.md
@@ -5,7 +5,7 @@
   align="right"
 />
 
-# Dotfiles Functions (v0.2.517)
+# Dotfiles Functions (v0.2.518)
 
 > Modular shell utilities managed by Chezmoi
 

--- a/defaults/dot_config/mise/conf.d/00-dotfiles.toml
+++ b/defaults/dot_config/mise/conf.d/00-dotfiles.toml
@@ -116,6 +116,7 @@ just = "latest"
 # mise's tool registry; the aqua: backend resolves it from the official
 # release tarballs.
 "aqua:nushell/nushell" = "0.114.1"
+"aqua:PowerShell/PowerShell" = "7.5.2"
 
 [env]
 # Environment variables to set

--- a/defaults/dot_config/powershell/Microsoft.PowerShell_profile.ps1.tmpl
+++ b/defaults/dot_config/powershell/Microsoft.PowerShell_profile.ps1.tmpl
@@ -8,6 +8,42 @@ $env:XDG_CONFIG_HOME = if ($env:XDG_CONFIG_HOME) { $env:XDG_CONFIG_HOME } else {
 $env:XDG_CACHE_HOME = if ($env:XDG_CACHE_HOME) { $env:XDG_CACHE_HOME } else { Join-Path $HOME ".cache" }
 $env:XDG_DATA_HOME = if ($env:XDG_DATA_HOME) { $env:XDG_DATA_HOME } else { Join-Path $HOME ".local/share" }
 
+function Get-DotfilesCachedInit {
+    param(
+        [Parameter(Mandatory = $true)][string]$Label,
+        [Parameter(Mandatory = $true)][string]$Command,
+        [string[]]$Arguments = @()
+    )
+
+    $commandInfo = Get-Command $Command -ErrorAction SilentlyContinue
+    if (-not $commandInfo) { return $null }
+
+    $cacheDir = Join-Path $env:XDG_CACHE_HOME "dotfiles/evalcache/pwsh"
+    New-Item -ItemType Directory -Force -Path $cacheDir | Out-Null
+    $source = if ($commandInfo.Source) { $commandInfo.Source } else { $commandInfo.Path }
+    $mtime = if ($source -and (Test-Path $source)) {
+        (Get-Item $source).LastWriteTimeUtc.Ticks
+    } else {
+        0
+    }
+    $fingerprint = "$source|$mtime|$($Arguments -join '|')"
+    $hashBytes = [System.Security.Cryptography.SHA256]::HashData(
+        [System.Text.Encoding]::UTF8.GetBytes($fingerprint)
+    )
+    $hash = [Convert]::ToHexString($hashBytes).ToLowerInvariant().Substring(0, 16)
+    $cachePath = Join-Path $cacheDir "$Label-$hash.ps1"
+
+    if (-not (Test-Path $cachePath)) {
+        Get-ChildItem -Path $cacheDir -Filter "$Label-*.ps1" -ErrorAction SilentlyContinue |
+            Remove-Item -Force -ErrorAction SilentlyContinue
+        $content = & $Command @Arguments | Out-String
+        if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($content)) { return $null }
+        [IO.File]::WriteAllText($cachePath, $content, [Text.UTF8Encoding]::new($false))
+    }
+
+    return $cachePath
+}
+
 $KimiCodeBin = Join-Path $HOME ".kimi-code/bin"
 if ((Test-Path $KimiCodeBin) -and (($env:PATH -split [IO.Path]::PathSeparator) -notcontains $KimiCodeBin)) {
     $env:PATH = "$KimiCodeBin$([IO.Path]::PathSeparator)$env:PATH"
@@ -65,6 +101,8 @@ function cat {
 Set-Alias -Name open -Value Invoke-Item -Option AllScope
 
 if (Get-Command mise -ErrorAction SilentlyContinue) {
+    $miseInit = Get-DotfilesCachedInit -Label "mise-init" -Command "mise" -Arguments @("activate", "pwsh")
+    if ($miseInit) { . $miseInit }
     function ms { & mise @args }
 }
 
@@ -85,5 +123,6 @@ if (Get-Command podman -ErrorAction SilentlyContinue) {
 }
 
 if (Get-Command zoxide -ErrorAction SilentlyContinue) {
-    Invoke-Expression (& { (zoxide init powershell | Out-String) })
+    $zoxideInit = Get-DotfilesCachedInit -Label "zoxide-init" -Command "zoxide" -Arguments @("init", "powershell")
+    if ($zoxideInit) { . $zoxideInit }
 }

--- a/defaults/dot_config/shell/README.md
+++ b/defaults/dot_config/shell/README.md
@@ -27,7 +27,7 @@ Welcome to your universally compatible, high-performance dotfiles configuration,
 To install these dotfiles on a new machine, run:
 
 ```bash
-bash -c "$(curl -fsSL https://raw.githubusercontent.com/sebastienrousseau/dotfiles/v0.2.517/install.sh)"
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/sebastienrousseau/dotfiles/v0.2.518/install.sh)"
 ```
 
 This command will:

--- a/defaults/dot_config/zsh/dot_zshrc.tmpl
+++ b/defaults/dot_config/zsh/dot_zshrc.tmpl
@@ -656,6 +656,16 @@ _dotfiles_async_init() {
   # into the cached output (e.g. system paths inherited from a dirty
   # parent shell).
   typeset -U path
+  local -a _hydrated_path
+  local -A _hydrated_seen
+  local _hydrated_dir
+  for _hydrated_dir in $path; do
+    if [[ -n "$_hydrated_dir" && -d "$_hydrated_dir" && -z "${_hydrated_seen[$_hydrated_dir]:-}" ]]; then
+      _hydrated_seen[$_hydrated_dir]=1
+      _hydrated_path+=("$_hydrated_dir")
+    fi
+  done
+  path=("${_hydrated_path[@]}")
 }
 
 # Deferred Hydration for Zero-Jank Experience

--- a/defaults/run_onchange_after_fonts.sh
+++ b/defaults/run_onchange_after_fonts.sh
@@ -6,6 +6,7 @@
 set -euo pipefail
 
 SOURCE_ROOT="${DOTFILES_SOURCE_DIR:-}"
+[[ -n "$SOURCE_ROOT" && "$(basename "$SOURCE_ROOT")" == "defaults" ]] && SOURCE_ROOT="$(dirname "$SOURCE_ROOT")"
 if [[ -z "$SOURCE_ROOT" ]] && command -v chezmoi >/dev/null 2>&1; then
   SOURCE_ROOT="$(chezmoi source-path 2>/dev/null || true)"
   [[ "$(basename "$SOURCE_ROOT")" == "defaults" ]] && SOURCE_ROOT="$(dirname "$SOURCE_ROOT")"

--- a/docs/COPYRIGHT
+++ b/docs/COPYRIGHT
@@ -1,5 +1,5 @@
 /*
-* 🅳🅾🆃🅵🅸🅻🅴🆂 (v0.2.517) - <https://github.com/sebastienrousseau/dotfiles>
+* 🅳🅾🆃🅵🅸🅻🅴🆂 (v0.2.518) - <https://github.com/sebastienrousseau/dotfiles>
 * Made With ❤️ in London, United Kingdom
 * Designed by
 * Copyright (c) 2015-2026. All rights reserved.

--- a/docs/manual/00-introduction.md
+++ b/docs/manual/00-introduction.md
@@ -4,7 +4,7 @@ render_with_liquid: false
 
 # Introduction
 
-This manual describes `.dotfiles` v0.2.517 — a trusted agent workstation baseline for macOS, Linux, and WSL.
+This manual describes `.dotfiles` v0.2.518 — a trusted agent workstation baseline for macOS, Linux, and WSL.
 
 The repository is more than a personal dotfiles collection. It ships as workstation infrastructure: signed, attested, multi-platform, AI-aware, and self-healing. Chezmoi handles templating and platform differences. The `dot` CLI sits on top and coordinates lifecycle operations.
 

--- a/install.sh
+++ b/install.sh
@@ -71,7 +71,7 @@ show_help() {
 Usage: install.sh [version] [options]
 
 Arguments:
-  version       The version (tag or branch) to install (default: v0.2.517)
+  version       The version (tag or branch) to install (default: v0.2.518)
 
 Options:
   --help        Show this help message
@@ -87,7 +87,7 @@ EOF
 }
 
 main() {
-  local version="v0.2.517"
+  local version="v0.2.518"
   local version_set=0
   local minimal=0
   local provision="${DOTFILES_PROVISION:-0}"
@@ -117,7 +117,7 @@ main() {
         # like `foobar` doesn't trigger a 30s+ network download attempt.
         # Caught by the install.sh fuzz harness (#881).
         if [[ ! "$arg" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+([-+][a-zA-Z0-9.-]+)?$ ]]; then
-          error "Unrecognized positional argument '$arg' — expected a semver version (e.g. v0.2.517)."
+          error "Unrecognized positional argument '$arg' — expected a semver version (e.g. v0.2.518)."
         fi
         version="$arg"
         version_set=1
@@ -369,7 +369,7 @@ main() {
   # 6. Initialize & Apply
   step "Applying Configuration..."
 
-  # ── Auto-migration for v0.2.517 reorg ─────────────────────────────────
+  # ── Auto-migration for v0.2.518 reorg ─────────────────────────────────
   # If the user is upgrading from a pre-0.2.503 install, run the
   # migration script BEFORE `chezmoi apply` so the reorg's source-
   # path moves don't cause chezmoi to delete deployed files.
@@ -378,7 +378,7 @@ main() {
   for migrate_src in "$SOURCE_DIR" "$LEGACY_SOURCE_DIR"; do
     migrate_script="$migrate_src/install/migrate/migrate-v0_2-to-v0_2_503.sh"
     if [[ -x "$migrate_script" ]]; then
-      echo "   Running v0.2.517 migration (idempotent; safe on fresh installs)..."
+      echo "   Running v0.2.518 migration (idempotent; safe on fresh installs)..."
       "$migrate_script" || echo "   migration exited non-zero — continuing apply"
       break
     fi

--- a/install/provision/run_onchange_50-install-fonts.sh
+++ b/install/provision/run_onchange_50-install-fonts.sh
@@ -7,6 +7,7 @@
 set -euo pipefail
 
 SOURCE_ROOT="${DOTFILES_SOURCE_DIR:-}"
+[[ -n "$SOURCE_ROOT" && "$(basename "$SOURCE_ROOT")" == "defaults" ]] && SOURCE_ROOT="$(dirname "$SOURCE_ROOT")"
 if [[ -z "$SOURCE_ROOT" ]]; then
   SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
   [[ -r "$SCRIPT_ROOT/lib/dot/verified-download.sh" ]] && SOURCE_ROOT="$SCRIPT_ROOT"

--- a/lib/dot/bento.sh
+++ b/lib/dot/bento.sh
@@ -33,7 +33,7 @@ _dotfiles_bento_render() {
 
   # Render a fixed-width card (42 cols) so output aligns in any terminal width
   printf "\n"
-  printf "  ${c_cyan}${c_bold}💎  D O T F I L E S${c_reset}  ${c_slate}[v0.2.517]${c_reset}\n"
+  printf "  ${c_cyan}${c_bold}💎  D O T F I L E S${c_reset}  ${c_slate}[v0.2.518]${c_reset}\n"
   printf "  ${c_slate}──────────────────────────────────────────${c_reset}\n"
 
   # Key system properties at a glance — answers "is my env healthy?" in 1 second

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sebastienrousseau/dotfiles",
-  "version": "0.2.517",
+  "version": "0.2.518",
   "description": "The Trusted Shell Platform — Universal dotfiles managed by Chezmoi. Features Bash & Zsh for macOS, Linux & WSL. Rust modern tooling & enterprise-grade security.",
   "main": "install.sh",
   "bin": {

--- a/scripts/diagnostics/doctor.sh
+++ b/scripts/diagnostics/doctor.sh
@@ -628,14 +628,18 @@ else
 fi
 
 # 5. Shell coverage. Surface installed shells that the project's caching
-# infrastructure doesn't currently maintain caches for. zsh/bash/fish/nu
-# all have a `_cached_eval` analogue; pwsh does not.
+# infrastructure doesn't currently maintain caches for.
 shells_unmanaged=""
 for sh in nu pwsh; do
   command -v "$sh" >/dev/null 2>&1 || continue
   case "$sh" in
     nu)
       [[ -f "$HOME/.config/nushell/cached_eval.nu" ]] && continue
+      ;;
+    pwsh)
+      pwsh -NoLogo -NoProfile -NonInteractive -Command 'exit 0' >/dev/null 2>&1 || continue
+      pwsh_profile="$HOME/.config/powershell/Microsoft.PowerShell_profile.ps1"
+      [[ -f "$pwsh_profile" ]] && grep -q 'Get-DotfilesCachedInit' "$pwsh_profile" && continue
       ;;
   esac
   shells_unmanaged="${shells_unmanaged:+$shells_unmanaged, }$sh"

--- a/scripts/git-hooks/pre-commit-audit.sh
+++ b/scripts/git-hooks/pre-commit-audit.sh
@@ -141,6 +141,6 @@ if [[ $FAILED -eq 1 ]]; then
   printf '%b\\n' "   (Use --no-verify to bypass if absolutely necessary)"
   exit 1
 else
-  printf '%b\n' "${GREEN}${BOLD}✅ Audit passed.${NC} v0.2.517 standards maintained."
+  printf '%b\n' "${GREEN}${BOLD}✅ Audit passed.${NC} v0.2.518 standards maintained."
   exit 0
 fi

--- a/share/man/man1/dot.1
+++ b/share/man/man1/dot.1
@@ -1,4 +1,4 @@
-.TH DOT 1 "May 2026" "dotfiles v0.2.517" "User Commands"
+.TH DOT 1 "May 2026" "dotfiles v0.2.518" "User Commands"
 .SH NAME
 dot \- dotfiles management CLI
 .SH SYNOPSIS

--- a/tests/unit/diagnostics/test_diagnostics_doctor.sh
+++ b/tests/unit/diagnostics/test_diagnostics_doctor.sh
@@ -49,6 +49,10 @@ else
   printf '%b\n' "  ${RED}✗${NC} $CURRENT_TEST: should check system configuration"
 fi
 
+test_start "doctor_recognizes_powershell_cached_init"
+assert_file_contains "$DOCTOR_FILE" "Get-DotfilesCachedInit" \
+  "doctor should recognize the managed PowerShell cached-init helper"
+
 # Test: provides remediation suggestions
 test_start "doctor_provides_remediation"
 if grep -qE 'fix|suggest|recommend|try|run' "$DOCTOR_FILE" 2>/dev/null; then

--- a/tests/unit/install/test_install_idempotency.sh
+++ b/tests/unit/install/test_install_idempotency.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2015-2026 Sebastien Rousseau
+# shellcheck disable=SC1090,SC1091,SC2016
 # Idempotency Unit Test for Font Installation
 
 set -euo pipefail
@@ -8,9 +9,16 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 FONT_INSTALL_SCRIPT="$REPO_ROOT/install/provision/run_onchange_50-install-fonts.sh"
+FONT_CHECK_SCRIPT="$REPO_ROOT/defaults/run_onchange_after_fonts.sh"
 
 # Load test framework
 source "$REPO_ROOT/tests/framework/assertions.sh"
+
+test_start "font_hooks_normalize_chezmoi_defaults_source"
+assert_file_contains "$FONT_INSTALL_SCRIPT" 'basename "$SOURCE_ROOT")" == "defaults"' \
+  "font installer should normalize a chezmoi defaults source path"
+assert_file_contains "$FONT_CHECK_SCRIPT" 'basename "$SOURCE_ROOT")" == "defaults"' \
+  "font checker should normalize a chezmoi defaults source path"
 
 test_start "font_idempotency"
 
@@ -18,7 +26,7 @@ test_start "font_idempotency"
 MOCK_HOME=$(mktemp -d)
 export HOME="$MOCK_HOME"
 export DOTFILES_SILENT=1
-export DOTFILES_SOURCE_DIR="$REPO_ROOT"
+export DOTFILES_SOURCE_DIR="$REPO_ROOT/defaults"
 
 # Prepare mock font directory
 if [[ "$(uname)" == "Darwin" ]]; then

--- a/tests/unit/install/test_powershell_profile_syntax.sh
+++ b/tests/unit/install/test_powershell_profile_syntax.sh
@@ -45,6 +45,18 @@ test_start "profile_defines_xdg_env"
 assert_file_contains "$PROFILE" "XDG_CONFIG_HOME" \
   "profile must define XDG_CONFIG_HOME to match Unix shells"
 
+test_start "profile_caches_generated_init_scripts"
+assert_file_contains "$PROFILE" "Get-DotfilesCachedInit" \
+  "PowerShell profile should cache generated init scripts"
+
+test_start "profile_caches_mise_activation"
+assert_file_contains "$PROFILE" "mise-init" \
+  "PowerShell profile should cache mise activation"
+
+test_start "profile_caches_zoxide_initialization"
+assert_file_contains "$PROFILE" "zoxide-init" \
+  "PowerShell profile should cache zoxide initialization"
+
 test_start "profile_balanced_braces"
 opens=$(grep -c '{' "$PROFILE" || true)
 closes=$(grep -c '}' "$PROFILE" || true)


### PR DESCRIPTION
## Summary

- Bump all current-version surfaces from 0.2.517 to 0.2.518.
- Fix Nerd Font hooks when chezmoi exposes the post-reorganization `defaults` source directory.
- Add binary-aware cached mise and zoxide initialization for PowerShell and activate PowerShell 7.5.2 through mise.
- Prune duplicate and nonexistent PATH entries after deferred mise hydration and recognize PowerShell cache coverage in diagnostics.

## Testing

- Full test suite: 5,576/5,576 assertions passed.
- Focused font, PowerShell, diagnostics, version, and installer regressions passed.
- Full chezmoi dry run and rendered Zsh/PowerShell syntax checks passed.
- Staged pre-commit security, path, ShellCheck, formatting, and README signature audit passed.
- Startup benchmark: zsh 72 ms, fish 38 ms, bash 15 ms, Nushell 25 ms.

---
THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co
