### PR TITLE
fix(install): resolve font verifier during apply

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@
 
 ## Project Overview
 
-Chezmoi-managed dotfiles for macOS, Linux, WSL, and PowerShell 7.5+. Version `0.2.518`.
+Chezmoi-managed dotfiles for macOS, Linux, WSL, and PowerShell 7.5+. Version `0.2.519`.
 
 ## Key Commands
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 This file documents all notable changes to this project.
 
+## v0.2.519 — 2026-08-13
+
+### Fixed
+
+- Rendered the Nerd Font check as a chezmoi template so its verified-download
+  dependency is resolved before an apply begins. This avoids an unreliable
+  nested `chezmoi source-path` call while chezmoi is executing the hook.
+- Added a real-apply regression test for the font hook's source resolution.
+
 ## v0.2.518 — 2026-08-13
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@
 
 ## Project Overview
 
-Chezmoi-managed dotfiles for macOS, Linux, WSL, and PowerShell 7.5+. Version `0.2.518`.
+Chezmoi-managed dotfiles for macOS, Linux, WSL, and PowerShell 7.5+. Version `0.2.519`.
 
 ## Key Commands
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 <p align="center">
   <a href="https://github.com/sebastienrousseau/dotfiles/actions"><img src="https://img.shields.io/github/actions/workflow/status/sebastienrousseau/dotfiles/ci.yml?style=for-the-badge&logo=githubactions&logoColor=white" alt="Build" /></a>
-  <a href="https://github.com/sebastienrousseau/dotfiles/releases/latest"><img src="https://img.shields.io/badge/Version-v0.2.518-blue?style=for-the-badge&logo=semanticrelease&logoColor=white" alt="Version" /></a>
+  <a href="https://github.com/sebastienrousseau/dotfiles/releases/latest"><img src="https://img.shields.io/badge/Version-v0.2.519-blue?style=for-the-badge&logo=semanticrelease&logoColor=white" alt="Version" /></a>
   <a href="https://github.com/sebastienrousseau/dotfiles/releases"><img src="https://img.shields.io/github/downloads/sebastienrousseau/dotfiles/total?style=for-the-badge&logo=github&logoColor=white" alt="Downloads" /></a>
   <a href="https://codespaces.new/sebastienrousseau/dotfiles"><img src="https://img.shields.io/badge/Open%20in-Codespaces-blue?style=for-the-badge&logo=github&logoColor=white" alt="Open in GitHub Codespaces" /></a>
   <a href="https://scorecard.dev/viewer/?uri=github.com/sebastienrousseau/dotfiles"><img src="https://img.shields.io/ossf-scorecard/github.com/sebastienrousseau/dotfiles?style=for-the-badge&logo=linuxfoundation&logoColor=white&label=OpenSSF%20Scorecard" alt="OpenSSF Scorecard" /></a>
@@ -52,8 +52,8 @@
 
 ```bash
 curl -fsSL -o /tmp/dotfiles-install.sh \
-  https://raw.githubusercontent.com/sebastienrousseau/dotfiles/v0.2.518/install.sh
-echo "1f8ef5b5ca0de42002269461ded3acc9d30cadc4f77e04d0abfd008d5690c0c5  /tmp/dotfiles-install.sh" \
+  https://raw.githubusercontent.com/sebastienrousseau/dotfiles/v0.2.519/install.sh
+echo "3b5d1332fb07a1261da117e53f69acc0097c3d9bd676fc9f53a000257b72978e  /tmp/dotfiles-install.sh" \
   | shasum -a 256 -c
 bash /tmp/dotfiles-install.sh
 ```

--- a/bin/dot
+++ b/bin/dot
@@ -4,7 +4,7 @@
 # Copyright (c) 2015-2026 Sebastien Rousseau
 set -euo pipefail
 
-# Dotfiles CLI Entry Point - v0.2.518
+# Dotfiles CLI Entry Point - v0.2.519
 
 # Ensure XDG Base Directory variables are set
 export XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"
@@ -22,7 +22,7 @@ if [ -e "${HOME}/.nix-profile/etc/profile.d/nix.sh" ]; then
   . "${HOME}/.nix-profile/etc/profile.d/nix.sh"
 fi
 
-VERSION="0.2.518"
+VERSION="0.2.519"
 
 COMMAND="${1:-}"
 if [ -n "${1:-}" ]; then
@@ -38,8 +38,8 @@ _resolve_source_dir() {
 
   if script_path="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd 2>/dev/null)"; then
     script_dir="$script_path"
-    # Post-v0.2.518: the canonical dispatcher lives at <repo>/bin/dot, so
-    # $script_dir/.. is the repo root. Pre-v0.2.518 (and chezmoi-deployed
+    # Post-v0.2.519: the canonical dispatcher lives at <repo>/bin/dot, so
+    # $script_dir/.. is the repo root. Pre-v0.2.519 (and chezmoi-deployed
     # wrapper invocations that still exec the canonical) the dispatcher
     # was at <repo>/dot_local/bin/executable_dot, so $script_dir/../..
     # was the repo. Probe both to cover the transition.

--- a/defaults/.chezmoidata.toml
+++ b/defaults/.chezmoidata.toml
@@ -1,5 +1,5 @@
 # Active profile - change this to switch configurations
-dotfiles_version = "0.2.518"
+dotfiles_version = "0.2.519"
 profile = "laptop"
 
 # Machine preset — set per-host in ~/.config/chezmoi/chezmoi.toml:

--- a/defaults/.chezmoitemplates/README.md
+++ b/defaults/.chezmoitemplates/README.md
@@ -5,7 +5,7 @@
   align="right"
 />
 
-# Chezmoi Templates (v0.2.518)
+# Chezmoi Templates (v0.2.519)
 
 Modular shell configuration managed by Chezmoi
 

--- a/defaults/.chezmoitemplates/aliases/README.md
+++ b/defaults/.chezmoitemplates/aliases/README.md
@@ -5,7 +5,7 @@
   align="right"
 />
 
-# Dotfiles Aliases (v0.2.518)
+# Dotfiles Aliases (v0.2.519)
 
 Modular alias definitions managed by Chezmoi
 

--- a/defaults/.chezmoitemplates/functions/README.md
+++ b/defaults/.chezmoitemplates/functions/README.md
@@ -5,7 +5,7 @@
   align="right"
 />
 
-# Dotfiles Functions (v0.2.518)
+# Dotfiles Functions (v0.2.519)
 
 > Modular shell utilities managed by Chezmoi
 

--- a/defaults/dot_config/shell/README.md
+++ b/defaults/dot_config/shell/README.md
@@ -27,7 +27,7 @@ Welcome to your universally compatible, high-performance dotfiles configuration,
 To install these dotfiles on a new machine, run:
 
 ```bash
-bash -c "$(curl -fsSL https://raw.githubusercontent.com/sebastienrousseau/dotfiles/v0.2.518/install.sh)"
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/sebastienrousseau/dotfiles/v0.2.519/install.sh)"
 ```
 
 This command will:

--- a/defaults/run_onchange_after_fonts.sh.tmpl
+++ b/defaults/run_onchange_after_fonts.sh.tmpl
@@ -5,12 +5,9 @@
 
 set -euo pipefail
 
-SOURCE_ROOT="${DOTFILES_SOURCE_DIR:-}"
-[[ -n "$SOURCE_ROOT" && "$(basename "$SOURCE_ROOT")" == "defaults" ]] && SOURCE_ROOT="$(dirname "$SOURCE_ROOT")"
-if [[ -z "$SOURCE_ROOT" ]] && command -v chezmoi >/dev/null 2>&1; then
-  SOURCE_ROOT="$(chezmoi source-path 2>/dev/null || true)"
-  [[ "$(basename "$SOURCE_ROOT")" == "defaults" ]] && SOURCE_ROOT="$(dirname "$SOURCE_ROOT")"
-fi
+SOURCE_ROOT={{ .chezmoi.sourceDir | quote }}
+[[ -n "${DOTFILES_SOURCE_DIR:-}" ]] && SOURCE_ROOT="$DOTFILES_SOURCE_DIR"
+[[ "$(basename "$SOURCE_ROOT")" == "defaults" ]] && SOURCE_ROOT="$(dirname "$SOURCE_ROOT")"
 if [[ -z "$SOURCE_ROOT" || ! -r "$SOURCE_ROOT/lib/dot/verified-download.sh" ]]; then
   printf 'Font Check: verified-download.sh unavailable; refusing unverified install\n' >&2
   exit 1

--- a/docs/COPYRIGHT
+++ b/docs/COPYRIGHT
@@ -1,5 +1,5 @@
 /*
-* 🅳🅾🆃🅵🅸🅻🅴🆂 (v0.2.518) - <https://github.com/sebastienrousseau/dotfiles>
+* 🅳🅾🆃🅵🅸🅻🅴🆂 (v0.2.519) - <https://github.com/sebastienrousseau/dotfiles>
 * Made With ❤️ in London, United Kingdom
 * Designed by
 * Copyright (c) 2015-2026. All rights reserved.

--- a/docs/architecture/REPO_LAYOUT.md
+++ b/docs/architecture/REPO_LAYOUT.md
@@ -72,7 +72,7 @@ convention in [`../NAMING_CONVENTIONS.md`](../NAMING_CONVENTIONS.md):
 
 - `run_onchange_20-ghostty-config.sh.tmpl` — re-renders Ghostty config
 - `run_onchange_21-topgrade-config.sh.tmpl` — refreshes topgrade config
-- `run_onchange_after_fonts.sh` — post-deploy font cache refresh
+- `run_onchange_after_fonts.sh.tmpl` — post-deploy font cache refresh
 
 ---
 

--- a/docs/manual/00-introduction.md
+++ b/docs/manual/00-introduction.md
@@ -4,7 +4,7 @@ render_with_liquid: false
 
 # Introduction
 
-This manual describes `.dotfiles` v0.2.518 — a trusted agent workstation baseline for macOS, Linux, and WSL.
+This manual describes `.dotfiles` v0.2.519 — a trusted agent workstation baseline for macOS, Linux, and WSL.
 
 The repository is more than a personal dotfiles collection. It ships as workstation infrastructure: signed, attested, multi-platform, AI-aware, and self-healing. Chezmoi handles templating and platform differences. The `dot` CLI sits on top and coordinates lifecycle operations.
 

--- a/install.sh
+++ b/install.sh
@@ -71,7 +71,7 @@ show_help() {
 Usage: install.sh [version] [options]
 
 Arguments:
-  version       The version (tag or branch) to install (default: v0.2.518)
+  version       The version (tag or branch) to install (default: v0.2.519)
 
 Options:
   --help        Show this help message
@@ -87,7 +87,7 @@ EOF
 }
 
 main() {
-  local version="v0.2.518"
+  local version="v0.2.519"
   local version_set=0
   local minimal=0
   local provision="${DOTFILES_PROVISION:-0}"
@@ -117,7 +117,7 @@ main() {
         # like `foobar` doesn't trigger a 30s+ network download attempt.
         # Caught by the install.sh fuzz harness (#881).
         if [[ ! "$arg" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+([-+][a-zA-Z0-9.-]+)?$ ]]; then
-          error "Unrecognized positional argument '$arg' — expected a semver version (e.g. v0.2.518)."
+          error "Unrecognized positional argument '$arg' — expected a semver version (e.g. v0.2.519)."
         fi
         version="$arg"
         version_set=1
@@ -369,7 +369,7 @@ main() {
   # 6. Initialize & Apply
   step "Applying Configuration..."
 
-  # ── Auto-migration for v0.2.518 reorg ─────────────────────────────────
+  # ── Auto-migration for v0.2.519 reorg ─────────────────────────────────
   # If the user is upgrading from a pre-0.2.503 install, run the
   # migration script BEFORE `chezmoi apply` so the reorg's source-
   # path moves don't cause chezmoi to delete deployed files.
@@ -378,7 +378,7 @@ main() {
   for migrate_src in "$SOURCE_DIR" "$LEGACY_SOURCE_DIR"; do
     migrate_script="$migrate_src/install/migrate/migrate-v0_2-to-v0_2_503.sh"
     if [[ -x "$migrate_script" ]]; then
-      echo "   Running v0.2.518 migration (idempotent; safe on fresh installs)..."
+      echo "   Running v0.2.519 migration (idempotent; safe on fresh installs)..."
       "$migrate_script" || echo "   migration exited non-zero — continuing apply"
       break
     fi

--- a/lib/dot/bento.sh
+++ b/lib/dot/bento.sh
@@ -33,7 +33,7 @@ _dotfiles_bento_render() {
 
   # Render a fixed-width card (42 cols) so output aligns in any terminal width
   printf "\n"
-  printf "  ${c_cyan}${c_bold}💎  D O T F I L E S${c_reset}  ${c_slate}[v0.2.518]${c_reset}\n"
+  printf "  ${c_cyan}${c_bold}💎  D O T F I L E S${c_reset}  ${c_slate}[v0.2.519]${c_reset}\n"
   printf "  ${c_slate}──────────────────────────────────────────${c_reset}\n"
 
   # Key system properties at a glance — answers "is my env healthy?" in 1 second

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sebastienrousseau/dotfiles",
-  "version": "0.2.518",
+  "version": "0.2.519",
   "description": "The Trusted Shell Platform — Universal dotfiles managed by Chezmoi. Features Bash & Zsh for macOS, Linux & WSL. Rust modern tooling & enterprise-grade security.",
   "main": "install.sh",
   "bin": {

--- a/scripts/git-hooks/pre-commit-audit.sh
+++ b/scripts/git-hooks/pre-commit-audit.sh
@@ -141,6 +141,6 @@ if [[ $FAILED -eq 1 ]]; then
   printf '%b\\n' "   (Use --no-verify to bypass if absolutely necessary)"
   exit 1
 else
-  printf '%b\n' "${GREEN}${BOLD}✅ Audit passed.${NC} v0.2.518 standards maintained."
+  printf '%b\n' "${GREEN}${BOLD}✅ Audit passed.${NC} v0.2.519 standards maintained."
   exit 0
 fi

--- a/share/man/man1/dot.1
+++ b/share/man/man1/dot.1
@@ -1,4 +1,4 @@
-.TH DOT 1 "May 2026" "dotfiles v0.2.518" "User Commands"
+.TH DOT 1 "May 2026" "dotfiles v0.2.519" "User Commands"
 .SH NAME
 dot \- dotfiles management CLI
 .SH SYNOPSIS

--- a/tests/unit/install/test_install_idempotency.sh
+++ b/tests/unit/install/test_install_idempotency.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 FONT_INSTALL_SCRIPT="$REPO_ROOT/install/provision/run_onchange_50-install-fonts.sh"
-FONT_CHECK_SCRIPT="$REPO_ROOT/defaults/run_onchange_after_fonts.sh"
+FONT_CHECK_TEMPLATE="$REPO_ROOT/defaults/run_onchange_after_fonts.sh.tmpl"
 
 # Load test framework
 source "$REPO_ROOT/tests/framework/assertions.sh"
@@ -17,8 +17,25 @@ source "$REPO_ROOT/tests/framework/assertions.sh"
 test_start "font_hooks_normalize_chezmoi_defaults_source"
 assert_file_contains "$FONT_INSTALL_SCRIPT" 'basename "$SOURCE_ROOT")" == "defaults"' \
   "font installer should normalize a chezmoi defaults source path"
-assert_file_contains "$FONT_CHECK_SCRIPT" 'basename "$SOURCE_ROOT")" == "defaults"' \
+assert_file_contains "$FONT_CHECK_TEMPLATE" 'basename "$SOURCE_ROOT")" == "defaults"' \
   "font checker should normalize a chezmoi defaults source path"
+
+test_start "font_checker_embeds_chezmoi_source"
+assert_file_contains "$FONT_CHECK_TEMPLATE" 'SOURCE_ROOT={{ .chezmoi.sourceDir | quote }}' \
+  "font checker should embed the source path before an apply starts"
+assert_equals "0" "$(grep -c 'chezmoi source-path' "$FONT_CHECK_TEMPLATE" || true)" \
+  "font checker should not invoke chezmoi recursively during apply"
+
+if command -v chezmoi >/dev/null 2>&1; then
+  test_start "font_checker_runs_during_real_apply"
+  APPLY_DESTINATION="$(mktemp -d)"
+  apply_status=0
+  chezmoi --source "$REPO_ROOT/defaults" --destination "$APPLY_DESTINATION" \
+    apply --force "$APPLY_DESTINATION/fonts.sh" >/dev/null 2>&1 || apply_status=$?
+  assert_equals "0" "$apply_status" \
+    "font checker should resolve the verifier while chezmoi is applying"
+  rm -rf "$APPLY_DESTINATION"
+fi
 
 test_start "font_idempotency"
 


### PR DESCRIPTION
## Summary
- render the Nerd Font hook as a chezmoi template so its source path is embedded before apply
- remove the nested chezmoi invocation from the active apply hook
- add a real-apply regression test and prepare v0.2.519

## Validation
- `make test` (5,580 unit/regression assertions; reliability audit passed)
- `./scripts/git-hooks/pre-commit-audit.sh`
- `./scripts/version-sync.sh --verify`

Signed-off-by: Sebastien Rousseau <sebastian.rousseau@gmail.com>

---
THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co