### PR TITLE
feat(mise): install corralctl on every machine from the base layer

### DIFF
--- a/defaults/dot_config/mise/conf.d/00-dotfiles.toml
+++ b/defaults/dot_config/mise/conf.d/00-dotfiles.toml
@@ -52,6 +52,14 @@ zig = "latest"
 atuin = "latest"
 bat = "latest"
 codex = "latest"
+# corralctl (bulk clone/organise GitHub repos). Not in mise's tool registry,
+# so the backend is explicit. Must be `github:` and not `ubi:`: the repo is
+# named `corral` but the binary inside the archive is `corralctl`, and ubi
+# names the extracted binary after the *repo*, so it installs a `corral`
+# binary and `corralctl` is never on PATH. The github: backend unpacks the
+# release tarball as-is and yields the real `corralctl`. Verified against
+# v0.0.18 assets (corralctl_Darwin_arm64.tar.gz et al).
+"github:sebastienrousseau/corral" = "latest"
 eza = "latest"
 gping = "latest"
 ripgrep = "latest"


### PR DESCRIPTION
`corralctl` was pinned in `~/.config/mise/config.toml`, which is deliberately chezmoi-ignored (see `.chezmoiignore:71`) so mise's own version writes cannot drift the source. That meant it was installed on **one** machine and absent everywhere else.

Moves it into the chezmoi-managed `conf.d` base layer at `latest`, so a fresh machine gets it from `mise install` with no manual step. The now-redundant `0.0.18` pin was removed from `config.toml` so the managed `latest` actually applies.

## Why `github:` and not `ubi:`

Both backends install without error, which is misleading — only one produces a usable binary:

| backend | installs | `corralctl` on PATH? |
| :--- | :--- | :--- |
| `ubi:sebastienrousseau/corral` | `…/0.0.18/corral` | **no** |
| `github:sebastienrousseau/corral` | `…/0.0.18/corralctl` | **yes** |

The repo is named `corral` but the binary inside the release archive is `corralctl`, and `ubi` names the extracted binary after the *repo*. So ubi installs a `corral` binary and `corralctl` never appears.

Worth noting how this was nearly missed: `mise x <spec> -- corralctl --version` reported success for **both**, because it fell through to the `corralctl` already on PATH. Only running the installed binaries by absolute path showed that ubi's install contains no `corralctl` at all.

Verified against the v0.0.18 release assets (`corralctl_Darwin_arm64.tar.gz` et al). corral is not in mise's tool registry, so an explicit backend is required either way.

## Scope

One file, 8 added lines. Unrelated in-flight work in the tree (`.chezmoidata.toml` theme switch, regenerated `themes.toml`) was deliberately left uncommitted and is untouched.

After this lands: `chezmoi update && mise install` on the other machines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co
