### PR TITLE
fix(qa): stop the examples gate timing out, and correct the AI trailer

### DIFF
--- a/defaults/dot_config/git/hooks/executable_commit-msg
+++ b/defaults/dot_config/git/hooks/executable_commit-msg
@@ -9,11 +9,19 @@ set -euo pipefail
 # Format:    Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
 
 detect_ai_agent() {
-  # Default model when running under Claude Code. Override at any time
-  # without editing this hook by exporting CLAUDE_MODEL in your shell
-  # rc, e.g. `export CLAUDE_MODEL=claude-opus-4-7`. Kept current with
-  # the latest generally-available Opus at time of last hook update.
-  local claude_default="${CLAUDE_MODEL:-claude-opus-4-7}"
+  # Default model when running under Claude Code.
+  #
+  # This has to be hardcoded: Claude Code exports CLAUDECODE,
+  # CLAUDE_CODE_ENTRYPOINT, CLAUDE_CODE_SESSION_ID and friends, but no
+  # variable carrying the model, and ~/.claude/settings.json has no `model`
+  # key unless the user pins one. So there is nothing to read it from, and
+  # the default goes stale whenever a new Opus ships — it was still
+  # claude-opus-4-7 while sessions were running on Opus 5, quietly
+  # misattributing every commit.
+  #
+  # Override per session without editing this hook:
+  #   export CLAUDE_MODEL=claude-sonnet-5
+  local claude_default="${CLAUDE_MODEL:-claude-opus-5}"
 
   # Claude Code (Anthropic). The CLI actually sets CLAUDECODE=1 (no
   # underscore); the other vars are kept as historical aliases and for

--- a/examples/example-coverage-gate.sh
+++ b/examples/example-coverage-gate.sh
@@ -1,8 +1,52 @@
 #!/usr/bin/env bash
 # Copyright (c) 2015-2026 Dotfiles. All rights reserved.
+#
+# Demonstrates the module coverage gate.
+#
+# By default this runs the real tests/framework/module_coverage.sh against a
+# small, self-contained fixture rather than against this repository. Running it
+# over the whole repo took ~91s — more than every other example combined by a
+# factor of thirteen, and enough on its own to blow the 60s per-script budget
+# that scripts/qa/validate-examples.sh runs examples under. The examples suite
+# is a smoke test that examples work; re-running the full CI coverage sweep
+# inside it duplicated a gate the test workflows already run.
+#
+# Set EXAMPLE_COVERAGE_FULL_REPO=1 to run the gate against this repository
+# instead, which is the invocation CI uses.
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_root"
 
-MIN_COVERAGE="${MIN_COVERAGE:-100}" ./tests/framework/module_coverage.sh
+if [ "${EXAMPLE_COVERAGE_FULL_REPO:-0}" = "1" ]; then
+  printf 'Running the coverage gate against this repository (slow)...\n'
+  MIN_COVERAGE="${MIN_COVERAGE:-100}" ./tests/framework/module_coverage.sh
+  exit $?
+fi
+
+fixture="$(mktemp -d "${TMPDIR:-/tmp}/example-coverage-gate.XXXXXX")"
+cleanup() { rm -rf "$fixture"; }
+trap cleanup EXIT
+
+# The gate discovers modules under scripts/, the chezmoi function templates and
+# defaults/dot_local/bin, then checks each is referenced by a test. Create one
+# module of each kind and a test that covers them, so the fixture exercises the
+# real discovery and matching logic rather than an empty tree.
+mkdir -p "$fixture/scripts" \
+         "$fixture/defaults/.chezmoitemplates/functions" \
+         "$fixture/defaults/dot_local/bin" \
+         "$fixture/tests/unit"
+
+printf '#!/usr/bin/env bash\necho demo\n' > "$fixture/scripts/demo.sh"
+printf '#!/usr/bin/env bash\ndemo_fn() { :; }\n' > "$fixture/defaults/.chezmoitemplates/functions/demo.sh"
+cat > "$fixture/tests/unit/test_demo.sh" <<'FIXTURE'
+#!/usr/bin/env bash
+# Covers: scripts:demo functions:demo
+FIXTURE
+
+printf 'Running example: module coverage gate over a fixture\n'
+MIN_COVERAGE=100 REPO_ROOT="$fixture" TESTS_DIR="$fixture/tests" \
+  ./tests/framework/module_coverage.sh
+
+printf 'Coverage gate example passed.\n'
+printf 'Re-run with EXAMPLE_COVERAGE_FULL_REPO=1 to gate this repository.\n'

--- a/scripts/qa/validate-examples.sh
+++ b/scripts/qa/validate-examples.sh
@@ -7,20 +7,83 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 EXAMPLES_DIR="$REPO_ROOT/examples"
 
+# Per-example wall-clock budget. Bounding each example individually means one
+# slow or hanging example is reported by name instead of silently consuming the
+# whole script's budget and surfacing as an opaque rc=124 from the caller.
+EXAMPLE_TIMEOUT="${EXAMPLE_TIMEOUT:-60}"
+
+usage() {
+  cat <<'USAGE'
+Usage: validate-examples.sh [--help]
+
+Runs every executable example in examples/ and fails if any of them fails or
+exceeds the per-example timeout.
+
+Environment:
+  EXAMPLE_TIMEOUT   Per-example timeout in seconds (default: 60). Set to 0 to
+                    disable the timeout.
+USAGE
+}
+
+# Parse arguments before doing any work. Previously this script ignored its
+# arguments entirely, so `--help` silently executed the whole examples suite —
+# which meant asking for help ran a multi-minute job.
+case "${1:-}" in
+  -h | --help)
+    usage
+    exit 0
+    ;;
+  "") ;;
+  *)
+    printf 'Unknown option: %s\n\n' "$1" >&2
+    usage >&2
+    exit 2
+    ;;
+esac
+
 if [ ! -d "$EXAMPLES_DIR" ]; then
   echo "No examples directory found: $EXAMPLES_DIR" >&2
   exit 1
 fi
 
+# Resolve a timeout binary. GNU coreutils ships `timeout`; on macOS it is
+# `gtimeout` when coreutils is installed. Without either, run unbounded rather
+# than failing outright.
+timeout_cmd=()
+if [ "$EXAMPLE_TIMEOUT" != "0" ]; then
+  if command -v timeout >/dev/null 2>&1; then
+    timeout_cmd=(timeout --kill-after=5 "$EXAMPLE_TIMEOUT")
+  elif command -v gtimeout >/dev/null 2>&1; then
+    timeout_cmd=(gtimeout --kill-after=5 "$EXAMPLE_TIMEOUT")
+  else
+    printf 'warning: no timeout binary found; examples run unbounded\n' >&2
+  fi
+fi
+
 found=0
+failed=0
 while IFS= read -r -d '' example; do
   found=1
-  printf 'Running example: %s\n' "$(basename "$example")"
-  bash "$example"
+  name="$(basename "$example")"
+  printf 'Running example: %s\n' "$name"
+  rc=0
+  "${timeout_cmd[@]+"${timeout_cmd[@]}"}" bash "$example" </dev/null || rc=$?
+  if [ "$rc" -eq 124 ]; then
+    printf 'FAIL: %s exceeded the %ss timeout\n' "$name" "$EXAMPLE_TIMEOUT" >&2
+    failed=$((failed + 1))
+  elif [ "$rc" -ne 0 ]; then
+    printf 'FAIL: %s exited %s\n' "$name" "$rc" >&2
+    failed=$((failed + 1))
+  fi
 done < <(find "$EXAMPLES_DIR" -maxdepth 1 -type f -name "*.sh" -print0 | sort -z)
 
 if [ "$found" -eq 0 ]; then
   echo "No executable examples found in $EXAMPLES_DIR" >&2
+  exit 1
+fi
+
+if [ "$failed" -ne 0 ]; then
+  printf '%s example(s) failed.\n' "$failed" >&2
   exit 1
 fi
 


### PR DESCRIPTION
Two unrelated defects, both surfaced while landing #997. Neither was caused by that PR.

## 1. `Reliability / macos-latest` timing out

The gate failed on `validate-examples_no_arg_executes: unexpected rc=124`. **This was not a flake** — rc=124 is a timeout, the harness allows each script 60s, and `scripts/qa/validate-examples.sh` measured **~115s locally**.

One example accounted for almost all of it:

| example | time |
| :--- | ---: |
| **example-coverage-gate.sh** | **91.4s** |
| example-cli-utilities.sh | 2.3s |
| example-qa.sh | 1.3s |
| *…15 others* | ~3s total |

`example-coverage-gate.sh` ran the full module coverage sweep over this repository — an examples smoke test re-running a CI gate the test workflows already run.

**Fix:** it now runs the real `tests/framework/module_coverage.sh` against a small self-contained fixture (one script module, one function module, one test covering both), so it still exercises the gate's discovery and matching logic end to end — in **0.4s instead of 91.4s**. `EXAMPLE_COVERAGE_FULL_REPO=1` restores the whole-repo run.

`validate-examples.sh` is hardened so this cannot recur silently:
- each example runs under its own timeout (`EXAMPLE_TIMEOUT`, default 60s), and a breach **names the offending example** instead of surfacing as an opaque rc=124 from the caller
- `--help` is handled and unknown flags are rejected — previously the script ignored its arguments entirely, so **asking for help executed the whole multi-minute suite**

**Whole suite: 115s → 3.4s.**

## 2. Wrong model in the `Assisted-by:` trailer

The commit-msg hook stamped `Assisted-by: Claude:claude-opus-4-7` on sessions running Opus 5, quietly misattributing every commit. Default corrected to `claude-opus-5`.

The comment now explains why this is hardcoded rather than detected: Claude Code exports `CLAUDECODE`, `CLAUDE_CODE_ENTRYPOINT`, `CLAUDE_CODE_SESSION_ID` and others, but **nothing carrying the model**, and `~/.claude/settings.json` has no `model` key unless pinned — so there is no source to read from. `CLAUDE_MODEL` remains the per-session override.

## Verification

- `shellcheck` clean on all three files
- `--help` returns 0 immediately; unknown flag returns 2
- full examples run returns 0 in 3.4s
- coverage-gate example reports `Module coverage: 2/2 (100.00%)` against its fixture

## Note on #997

#997 (the mise/corralctl entry) is red for exactly this reason and nothing else — 5502 of 5503 tests passed there. Once this merges, #997 needs a rebase to pick up the fix and should go green. Unrelated in-flight work in the tree (`.chezmoidata.toml` theme switch, regenerated `themes.toml`) was left uncommitted and untouched.

---
THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co
