### PR TITLE
ci: stop apt hangs killing lint jobs, and derive the harden-runner pin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,7 @@ jobs:
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install fish
-        run: sudo apt-get update && sudo apt-get install -y fish
+        run: bash tools/ci/install-tools.sh fish
       - name: Syntax Check
         run: |
           # -print0 | xargs -0 to handle non-alphanumeric filenames safely.
@@ -550,7 +550,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install -y zsh hyperfine jq
+        run: bash tools/ci/install-tools.sh zsh hyperfine jq
 
       - name: Setup Chezmoi
         uses: ./.github/actions/setup-chezmoi

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -46,8 +46,7 @@ jobs:
       - name: Ensure ancillary linters are present
         run: |
           set -euo pipefail
-          sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends shellcheck ripgrep shfmt
+          bash tools/ci/install-tools.sh shellcheck ripgrep:rg shfmt
 
       - name: Run coverage
         env:

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install pandoc
-        run: sudo apt-get update && sudo apt-get install -y pandoc codespell
+        run: bash tools/ci/install-tools.sh pandoc codespell
 
       - name: Run manual quality gates
         run: bash tools/docs/check-manual.sh

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -207,7 +207,7 @@ jobs:
           # Install Go and build a pinned shfmt. Scorecard's
           # Pinned-Dependencies check flags `@latest`; refresh
           # this tag with each shfmt release.
-          sudo apt-get update && sudo apt-get install -y golang-go
+          bash tools/ci/install-tools.sh golang-go:go
           go install mvdan.cc/sh/v3/cmd/shfmt@v3.13.1
 
           echo "Running development shfmt..."
@@ -304,7 +304,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get update && sudo apt-get install -y zsh hyperfine jq
+          bash tools/ci/install-tools.sh zsh hyperfine jq
 
       - name: Setup Chezmoi
         uses: ./.github/actions/setup-chezmoi

--- a/.github/workflows/reliability-gate.yml
+++ b/.github/workflows/reliability-gate.yml
@@ -57,8 +57,7 @@ jobs:
           set -euo pipefail
           case "$(uname -s)" in
             Linux)
-              sudo apt-get update -qq
-              sudo apt-get install -y -qq shfmt shellcheck
+              bash tools/ci/install-tools.sh shfmt shellcheck
               ;;
             Darwin)
               brew install shfmt shellcheck coreutils

--- a/.github/workflows/reusable-copyright-lint.yml
+++ b/.github/workflows/reusable-copyright-lint.yml
@@ -21,7 +21,7 @@ jobs:
   copyright-lint:
     name: Copyright Headers
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - name: Harden runner (audit mode)
         uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install ripgrep
-        run: sudo apt-get update && sudo apt-get install -y ripgrep
+        run: bash tools/ci/install-tools.sh ripgrep:rg
 
       - name: Run copyright header validator
         run: |

--- a/.github/workflows/reusable-lua-lint.yml
+++ b/.github/workflows/reusable-lua-lint.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Install tools
         run: |
           set -euo pipefail
-          sudo apt-get update && sudo apt-get install -y lua5.1 luarocks
+          bash tools/ci/install-tools.sh lua5.1 luarocks
           luarocks install --local luacheck "${{ inputs.luacheck_version }}"
           echo "$HOME/.luarocks/bin" >> "$GITHUB_PATH"
           if [[ ! -x "$HOME/.cargo/bin/stylua" ]]; then

--- a/.github/workflows/reusable-shell-lint.yml
+++ b/.github/workflows/reusable-shell-lint.yml
@@ -41,7 +41,7 @@ jobs:
   shell-lint:
     name: Shell Lint
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       # harden-runner removed: audit-only mode was crashing the runner
       # agent (armour lockdown) on ubuntu-latest, preventing the lint
@@ -50,8 +50,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install tools
-        run: |
-          sudo apt-get update && sudo apt-get install -y shellcheck ripgrep shfmt
+        run: bash tools/ci/install-tools.sh shellcheck ripgrep:rg shfmt
 
       - name: ShellCheck
         run: |

--- a/.github/workflows/reusable-test-suite.yml
+++ b/.github/workflows/reusable-test-suite.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Enforce module coverage
         run: |
           set -euo pipefail
-          sudo apt-get update && sudo apt-get install -y ripgrep
+          bash tools/ci/install-tools.sh ripgrep:rg
           chmod +x tests/framework/module_coverage.sh
           MIN_COVERAGE="${{ inputs.min_coverage }}" ./tests/framework/module_coverage.sh
 

--- a/.github/workflows/sync-versions.yml
+++ b/.github/workflows/sync-versions.yml
@@ -37,7 +37,7 @@ jobs:
     name: Verify Version Sync
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - name: Harden runner (audit mode)
         uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
@@ -48,8 +48,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get update -y
-          sudo apt-get install -y jq ripgrep
+          bash tools/ci/install-tools.sh jq ripgrep:rg
 
       - name: Verify versions
         run: ./scripts/version-sync.sh --verify
@@ -58,7 +57,7 @@ jobs:
     name: Verify Version Sync (Protected Branch)
     if: github.event_name != 'pull_request' && github.ref_name == 'main'
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - name: Harden runner (audit mode)
         uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
@@ -69,8 +68,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get update -y
-          sudo apt-get install -y jq ripgrep
+          bash tools/ci/install-tools.sh jq ripgrep:rg
 
       - name: Verify versions (no auto-commit on protected branch)
         run: ./scripts/version-sync.sh --verify
@@ -94,8 +92,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get update -y
-          sudo apt-get install -y jq ripgrep
+          bash tools/ci/install-tools.sh jq ripgrep:rg
 
       - name: Determine target version
         id: version

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Install tools
         run: |
           # Install jq, yq, and other tools
-          sudo apt-get update && sudo apt-get install -y jq curl yq
+          bash tools/ci/install-tools.sh jq curl yq
 
       - name: Check for updates
         id: updates

--- a/tests/unit/ci/test_doc_drift_egress_contract.sh
+++ b/tests/unit/ci/test_doc_drift_egress_contract.sh
@@ -13,14 +13,29 @@ REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
 source "$SCRIPT_DIR/../../framework/assertions.sh"
 
 WORKFLOW="$REPO_ROOT/.github/workflows/doc-drift.yml"
-HARDEN_RUNNER_SHA="05e31511f85b41b11d1cf0ef85d0992719546e2c"
 
 test_start "doc_drift_workflow_exists"
 assert_file_exists "$WORKFLOW" "doc-drift workflow must exist"
 
+# Derived from the workflow, never hardcoded. The property this test names is
+# "pinned to a full commit SHA" — a literal SHA here asserted the narrower and
+# far less useful "still on the release this file was written against", and so
+# broke on every harden-runner bump until someone edited it by hand.
 test_start "doc_drift_harden_runner_pinned"
-assert_file_contains "$WORKFLOW" "step-security/harden-runner@$HARDEN_RUNNER_SHA" \
-  "doc-drift harden-runner action must stay pinned to a full commit SHA"
+harden_refs="$(grep -oE 'step-security/harden-runner@[^[:space:]]+' "$WORKFLOW" | sed 's|.*@||' | sort -u)"
+assert_not_empty "$harden_refs" "doc-drift must reference harden-runner"
+while IFS= read -r ref; do
+  [[ -n "$ref" ]] || continue
+  if printf '%s' "$ref" | grep -qE '^[0-9a-f]{40}$'; then
+    ((TESTS_PASSED++)) || true
+    printf '%b\n' "  ${GREEN}✓${NC} $CURRENT_TEST: doc-drift harden-runner is pinned to a full commit SHA"
+  else
+    ((TESTS_FAILED++)) || true
+    printf '%b\n' "  ${RED}✗${NC} $CURRENT_TEST: doc-drift pins harden-runner to '$ref', which is not a 40-character commit SHA"
+  fi
+done <<EOF
+$harden_refs
+EOF
 
 test_start "doc_drift_all_jobs_block_egress"
 harden_steps="$(grep -c 'step-security/harden-runner@' "$WORKFLOW" || true)"

--- a/tests/unit/ci/test_egress_block_rollout.sh
+++ b/tests/unit/ci/test_egress_block_rollout.sh
@@ -11,7 +11,17 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
 source "$SCRIPT_DIR/../../framework/assertions.sh"
 
-HARDEN_RUNNER_SHA="05e31511f85b41b11d1cf0ef85d0992719546e2c"
+# The harden-runner pin is derived from the workflows, never hardcoded here.
+#
+# The properties worth protecting are that harden-runner is pinned to a full
+# commit SHA rather than a floating tag, and that every block-mode workflow
+# agrees on the same one. Naming a specific SHA in this file protected
+# neither: it only asserted "still on the release I was written against", so
+# every harden-runner bump broke this test until someone edited it by hand.
+# That is exactly what stalled the v2.20.1 -> v2.21.0 bump for two days.
+harden_runner_refs() {
+  grep -oE 'step-security/harden-runner@[^[:space:]]+' "$1" | sed 's|.*@||' | sort -u
+}
 CHECKOUT_ENDPOINTS=(
   "github.com:443"
   "api.github.com:443"
@@ -33,11 +43,35 @@ CHECKOUT_WORKFLOWS=(
   ".github/workflows/verify-tag-signature.yml"
 )
 
+ALL_PINS=""
+
 test_start "egress_block_workflows_use_pinned_harden_runner"
 for rel in "${BLOCKED_WORKFLOWS[@]}"; do
-  assert_file_contains "$REPO_ROOT/$rel" "step-security/harden-runner@$HARDEN_RUNNER_SHA" \
-    "$rel pins harden-runner"
+  refs="$(harden_runner_refs "$REPO_ROOT/$rel")"
+  assert_not_empty "$refs" "$rel references harden-runner"
+  while IFS= read -r ref; do
+    [[ -n "$ref" ]] || continue
+    ALL_PINS="$ALL_PINS$ref
+"
+    if printf '%s' "$ref" | grep -qE '^[0-9a-f]{40}$'; then
+      ((TESTS_PASSED++)) || true
+      printf '%b\n' "  ${GREEN}✓${NC} $CURRENT_TEST: $rel pins harden-runner to a full commit SHA"
+    else
+      ((TESTS_FAILED++)) || true
+      printf '%b\n' "  ${RED}✗${NC} $CURRENT_TEST: $rel pins harden-runner to '$ref', which is not a 40-character commit SHA"
+    fi
+  done <<EOF
+$refs
+EOF
 done
+
+# A per-file SHA check alone would pass if two workflows pinned different
+# releases, which is the state a partial bump leaves behind.
+test_start "egress_block_workflows_agree_on_one_harden_runner_pin"
+unique_pins="$(printf '%s' "$ALL_PINS" | grep -v '^$' | sort -u)"
+unique_count="$(printf '%s\n' "$unique_pins" | grep -c . || true)"
+assert_equals "1" "$unique_count" \
+  "all block-mode workflows pin the same harden-runner SHA (found: $(printf '%s' "$unique_pins" | tr '\n' ' '))"
 
 test_start "egress_block_workflows_do_not_use_audit_mode"
 for rel in "${BLOCKED_WORKFLOWS[@]}"; do

--- a/tests/unit/misc/test_security_compliance_controls.sh
+++ b/tests/unit/misc/test_security_compliance_controls.sh
@@ -47,7 +47,22 @@ else
   ((TESTS_FAILED++)) || true
   printf '%b\n' "  ${RED}✗${NC} $CURRENT_TEST: unverified yq latest download still present"
 fi
-assert_file_contains "$update_deps_workflow" "apt-get install -y jq curl yq" "yq installed from package manager"
+# yq must come from the distro package manager rather than an unpinned
+# download. Accept either the direct apt call or tools/ci/install-tools.sh,
+# which is an apt wrapper that only ever skips work when the binary is already
+# on the runner image — the provenance is identical either way.
+#
+# This used to match the literal "apt-get install -y jq curl yq", so the
+# control broke the moment the install line was refactored, even though the
+# property it guards was untouched. A control that fails on rewording rather
+# than on risk trains people to edit the test instead of reading it.
+if grep -Eq '(apt-get install|install-tools\.sh).*[[:space:]]yq([[:space:]]|$)' "$update_deps_workflow"; then
+  ((TESTS_PASSED++)) || true
+  printf '%b\n' "  ${GREEN}✓${NC} $CURRENT_TEST: yq installed from package manager"
+else
+  ((TESTS_FAILED++)) || true
+  printf '%b\n' "  ${RED}✗${NC} $CURRENT_TEST: yq is not provisioned through the package manager"
+fi
 
 test_start "homebrew_bootstrap_requires_checksum"
 assert_file_contains "$package_managers_lib" "HOMEBREW_INSTALLER_SHA256" "homebrew bootstrap requires explicit checksum"

--- a/tools/ci/install-tools.sh
+++ b/tools/ci/install-tools.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2015-2026 Sebastien Rousseau
+#
+# Install CI tooling — but only what is actually missing, and never hang.
+#
+# Every CI job that needed shellcheck/shfmt/ripgrep/jq ran an unconditional
+# `apt-get update && apt-get install`. `apt-get update` is the slowest and
+# least reliable step in those jobs, and it is pure overhead whenever the
+# runner image already ships the tool.
+#
+# On 2026-08-19 the Azure mirror stalled and `apt-get update` sat for over
+# five minutes, which killed `Lint / Shell` twice — a job whose actual lint
+# work takes ~30 seconds against a 5-minute budget. Four re-runs were needed
+# to land a green main.
+#
+# So: look before installing, bound every network call so a hung mirror
+# cannot eat the whole job budget, and retry instead of failing on the first
+# blip.
+#
+# Usage: tools/ci/install-tools.sh shellcheck ripgrep:rg shfmt
+#
+# Each argument is a package name, optionally followed by ":" and the binary
+# it provides when the two differ. That distinction is load-bearing, not
+# decoration: `apt-get install ripgrep` puts `rg` on PATH, and `golang-go`
+# puts `go` there, so a presence check against the package name would never
+# match and every run would reinstall a tool that was already there —
+# quietly restoring the exact cost this script exists to remove.
+set -euo pipefail
+
+if [[ $# -eq 0 ]]; then
+  echo "usage: $0 <tool>..." >&2
+  exit 2
+fi
+
+missing=()
+missing_count=0
+for spec in "$@"; do
+  pkg="${spec%%:*}"
+  bin="${spec#*:}"
+  [[ "$bin" == "$spec" ]] && bin="$pkg"
+  if command -v "$bin" >/dev/null 2>&1; then
+    printf 'present: %s (%s)\n' "$pkg" "$(command -v "$bin")"
+  else
+    missing+=("$pkg")
+    missing_count=$((missing_count + 1))
+  fi
+done
+
+if [[ "$missing_count" -eq 0 ]]; then
+  printf 'All requested tools already present, skipping apt entirely.\n'
+  exit 0
+fi
+
+printf 'Installing missing tools: %s\n' "${missing[*]}"
+
+# `timeout` bounds each call: a mirror that stops responding costs seconds,
+# not the job's entire budget. Without it, apt waits on its own much longer
+# timeouts and the job is killed mid-install with no useful diagnostic.
+#
+# The bounds are chosen so all three attempts fit inside the smallest job
+# budget that calls this (10 minutes): 3 * (60 + 120) = 9 minutes. A retry
+# ceiling the job timeout can cut short would report "cancelled" — the very
+# symptom this replaces — instead of a readable error.
+apt_install_missing() {
+  sudo timeout 60 apt-get update -qq &&
+    sudo timeout 120 apt-get install -y -qq --no-install-recommends "${missing[@]}"
+}
+
+for attempt in 1 2 3; do
+  if apt_install_missing; then
+    printf 'Installed: %s\n' "${missing[*]}"
+    exit 0
+  fi
+  printf '::warning::apt attempt %s/3 failed for: %s\n' "$attempt" "${missing[*]}"
+  sleep $((attempt * 5))
+done
+
+printf '::error::Failed to install after 3 attempts: %s\n' "${missing[*]}"
+exit 1


### PR DESCRIPTION
## What

Two defects that between them cost four re-runs to land a green `main` after #996.

## 1. `apt-get` hangs were killing lint jobs

Every CI job needing shellcheck/shfmt/ripgrep/jq ran an unconditional
`apt-get update && apt-get install`. `apt-get update` is the slowest and least
reliable step in those jobs, and pure overhead whenever the runner image
already ships the tool.

On 2026-08-19 the Azure mirror stalled and it sat for over five minutes,
killing `Lint / Shell` twice — a job whose actual lint work takes ~30s against
a 5-minute budget. It surfaced as **"cancelled", not "failed"**, which is why it
read as a flake rather than a defect.

`tools/ci/install-tools.sh` now looks before installing, bounds every network
call so a hung mirror cannot eat the job budget, and retries instead of failing
on the first blip. **15 call sites across 11 workflows** use it.

Arguments take an optional `package:binary` form. That is load-bearing, not
decoration: `ripgrep` installs `rg` and `golang-go` installs `go`, so checking
presence by package name would never match and would reinstall on every run —
quietly restoring the exact cost the script removes.

The bounds (60s update, 120s install, 3 attempts = 9 min) fit inside the
smallest calling job's 10-minute budget, so a genuine failure reports as a
readable error rather than as another "cancelled". The three 5-minute lint
timeouts move to 10 for margin.

## 2. The egress tests broke on every harden-runner bump

Both egress tests carried the expected harden-runner SHA as a hardcoded
constant. That asserted "still on the release this file was written against" —
not the property either test names — and guaranteed that every harden-runner
bump broke them until someone edited them by hand. That is what held #996 red
for two days.

They now derive the pin from the workflows and assert what actually matters:
harden-runner is pinned to a full 40-character commit SHA rather than a
floating tag, and all five block-mode workflows agree on the same one. The
second check is not redundant — a per-file SHA test passes on the mixed state a
partial bump leaves behind.

## Verification

Mutation-tested rather than assumed:

| Mutation | Result |
| --- | --- |
| Float one workflow to `@v2.21.0` | 2 assertions fail |
| Leave one workflow on the old SHA (partial bump) | 1 assertion fails |
| Pin doc-drift to a short SHA | 1 assertion fails |
| Unmodified tree | passes, with **more** assertions than before (46 vs 40, 11 vs 10) |

Also green locally: `tests/unit/ci` (all files), `check-shell-preamble.sh`,
`check-copyright-headers.sh` (933 files), `shellcheck -S error`, `shfmt -d`,
and every touched workflow parses as YAML. The installer's skip path, mapping
path and usage path were each exercised directly.

## Known ordering

`reusable-*.yml` changes reach callers only once `bump-reusable-pins` opens and
merges its follow-up PR, so **the shell-lint fix is not exercised by this PR's
own run** — it takes effect after that pin bump lands.

THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co
