### PR TITLE
ci: bump reusable workflow pins so #999's fixes take effect

### DIFF
--- a/.github/workflows/ci-enforced.yml
+++ b/.github/workflows/ci-enforced.yml
@@ -33,7 +33,7 @@ jobs:
   # ============================================================================
   lint-shell:
     name: Lint / Shell (Zero Warnings)
-    uses: sebastienrousseau/dotfiles/.github/workflows/reusable-shell-lint.yml@1f7213b1de6922447d19cd29a8c09c0db98de83e # main
+    uses: sebastienrousseau/dotfiles/.github/workflows/reusable-shell-lint.yml@b2d31a02f18ef89137edff7501c05eb59ff28b8f # main
     with:
       include_tests: false
       shellcheck_severity: error
@@ -44,7 +44,7 @@ jobs:
 
   lint-lua:
     name: Lint / Lua (Zero Warnings)
-    uses: sebastienrousseau/dotfiles/.github/workflows/reusable-lua-lint.yml@1f7213b1de6922447d19cd29a8c09c0db98de83e # main
+    uses: sebastienrousseau/dotfiles/.github/workflows/reusable-lua-lint.yml@b2d31a02f18ef89137edff7501c05eb59ff28b8f # main
     with:
       target: defaults/dot_config/nvim
       strict: true
@@ -58,7 +58,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: sebastienrousseau/dotfiles/.github/workflows/reusable-nix-lint.yml@1f7213b1de6922447d19cd29a8c09c0db98de83e # main
+    uses: sebastienrousseau/dotfiles/.github/workflows/reusable-nix-lint.yml@000168c95cf69685a99eb5cf976445eed19b37c5 # main
     with:
       flake_dir: nix
       run_fmt_check: true
@@ -67,7 +67,7 @@ jobs:
 
   lint-copyright:
     name: Lint / Copyright Headers (Zero Tolerance)
-    uses: sebastienrousseau/dotfiles/.github/workflows/reusable-copyright-lint.yml@1f7213b1de6922447d19cd29a8c09c0db98de83e # main
+    uses: sebastienrousseau/dotfiles/.github/workflows/reusable-copyright-lint.yml@b2d31a02f18ef89137edff7501c05eb59ff28b8f # main
 
   # ============================================================================
   # STAGE 2: SECURITY (Mandatory - No bypass allowed)
@@ -193,7 +193,7 @@ jobs:
 
   test-unit:
     name: Test / Unit Tests
-    uses: sebastienrousseau/dotfiles/.github/workflows/reusable-test-suite.yml@1f7213b1de6922447d19cd29a8c09c0db98de83e # main
+    uses: sebastienrousseau/dotfiles/.github/workflows/reusable-test-suite.yml@b2d31a02f18ef89137edff7501c05eb59ff28b8f # main
     with:
       min_coverage: "100"
       run_integration: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
     name: Lint / Shell
     needs: changes
     if: needs.changes.outputs.shell == 'true' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    uses: sebastienrousseau/dotfiles/.github/workflows/reusable-shell-lint.yml@1f7213b1de6922447d19cd29a8c09c0db98de83e # main
+    uses: sebastienrousseau/dotfiles/.github/workflows/reusable-shell-lint.yml@b2d31a02f18ef89137edff7501c05eb59ff28b8f # main
     with:
       include_tests: false
       shellcheck_severity: error
@@ -117,7 +117,7 @@ jobs:
     name: Lint / Lua
     needs: changes
     if: needs.changes.outputs.lua == 'true' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    uses: sebastienrousseau/dotfiles/.github/workflows/reusable-lua-lint.yml@1f7213b1de6922447d19cd29a8c09c0db98de83e # main
+    uses: sebastienrousseau/dotfiles/.github/workflows/reusable-lua-lint.yml@b2d31a02f18ef89137edff7501c05eb59ff28b8f # main
     with:
       target: defaults/dot_config/nvim
       strict: false
@@ -173,7 +173,7 @@ jobs:
       || needs.changes.outputs.nix == 'true'
       || github.event_name == 'schedule'
       || github.event_name == 'workflow_dispatch'
-    uses: sebastienrousseau/dotfiles/.github/workflows/reusable-copyright-lint.yml@1f7213b1de6922447d19cd29a8c09c0db98de83e # main
+    uses: sebastienrousseau/dotfiles/.github/workflows/reusable-copyright-lint.yml@b2d31a02f18ef89137edff7501c05eb59ff28b8f # main
 
   lint-reusable-pins:
     name: Lint / Reusable Workflow Pins
@@ -231,7 +231,7 @@ jobs:
   # ============================================================================
   security-secrets:
     name: Security / Secrets Scan
-    uses: sebastienrousseau/dotfiles/.github/workflows/reusable-secrets-scan.yml@1f7213b1de6922447d19cd29a8c09c0db98de83e # main
+    uses: sebastienrousseau/dotfiles/.github/workflows/reusable-secrets-scan.yml@000168c95cf69685a99eb5cf976445eed19b37c5 # main
     with:
       run_guard: true
       run_additional_patterns: true
@@ -240,7 +240,7 @@ jobs:
 
   security-dependencies:
     name: Security / Dependency Audit
-    uses: sebastienrousseau/dotfiles/.github/workflows/reusable-security-baseline.yml@1f7213b1de6922447d19cd29a8c09c0db98de83e # main
+    uses: sebastienrousseau/dotfiles/.github/workflows/reusable-security-baseline.yml@000168c95cf69685a99eb5cf976445eed19b37c5 # main
     with:
       run_dependency_audit: true
       run_supply_chain_checks: true
@@ -473,7 +473,7 @@ jobs:
   test-unit:
     name: Test / Unit
     needs: changes
-    uses: sebastienrousseau/dotfiles/.github/workflows/reusable-test-suite.yml@1f7213b1de6922447d19cd29a8c09c0db98de83e # main
+    uses: sebastienrousseau/dotfiles/.github/workflows/reusable-test-suite.yml@b2d31a02f18ef89137edff7501c05eb59ff28b8f # main
     with:
       min_coverage: "95"
       run_integration: true
@@ -524,7 +524,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: sebastienrousseau/dotfiles/.github/workflows/reusable-nix-lint.yml@1f7213b1de6922447d19cd29a8c09c0db98de83e # main
+    uses: sebastienrousseau/dotfiles/.github/workflows/reusable-nix-lint.yml@000168c95cf69685a99eb5cf976445eed19b37c5 # main
     with:
       flake_dir: nix
       run_fmt_check: false

--- a/.github/workflows/compliance-guard.yml
+++ b/.github/workflows/compliance-guard.yml
@@ -260,7 +260,7 @@ jobs:
   # ============================================================================
   portability-shell-lint:
     name: Portability Shell Lint
-    uses: sebastienrousseau/dotfiles/.github/workflows/reusable-shell-lint.yml@1f7213b1de6922447d19cd29a8c09c0db98de83e # main
+    uses: sebastienrousseau/dotfiles/.github/workflows/reusable-shell-lint.yml@b2d31a02f18ef89137edff7501c05eb59ff28b8f # main
     with:
       include_tests: false
       # Severity widened to `warning` and the gate flipped to hard-fail

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -107,7 +107,7 @@ jobs:
 
   nightly-test-suite:
     name: Nightly / Test Suite
-    uses: sebastienrousseau/dotfiles/.github/workflows/reusable-test-suite.yml@1f7213b1de6922447d19cd29a8c09c0db98de83e # main
+    uses: sebastienrousseau/dotfiles/.github/workflows/reusable-test-suite.yml@b2d31a02f18ef89137edff7501c05eb59ff28b8f # main
     with:
       min_coverage: "95"
       run_integration: false

--- a/.github/workflows/security-enhanced.yml
+++ b/.github/workflows/security-enhanced.yml
@@ -59,7 +59,7 @@ jobs:
 
   secrets-scan:
     name: Security / Secrets Detection
-    uses: sebastienrousseau/dotfiles/.github/workflows/reusable-secrets-scan.yml@1f7213b1de6922447d19cd29a8c09c0db98de83e # main
+    uses: sebastienrousseau/dotfiles/.github/workflows/reusable-secrets-scan.yml@000168c95cf69685a99eb5cf976445eed19b37c5 # main
     with:
       run_guard: true
       run_additional_patterns: false
@@ -220,7 +220,7 @@ jobs:
 
   policy-enforcement:
     name: Security / Policy Enforcement
-    uses: sebastienrousseau/dotfiles/.github/workflows/reusable-security-baseline.yml@1f7213b1de6922447d19cd29a8c09c0db98de83e # main
+    uses: sebastienrousseau/dotfiles/.github/workflows/reusable-security-baseline.yml@000168c95cf69685a99eb5cf976445eed19b37c5 # main
     needs: [secrets-scan]
     # Only run on PRs to catch issues before merge
     if: github.event_name == 'pull_request'


### PR DESCRIPTION
## What

Bumps the 16 reusable-workflow pins across 5 caller workflows to `b2d31a02`.
Nothing else changes — every modified line is a `reusable-*.yml@<sha>` pin.

## Why this is needed by hand

Callers pin in-repo reusable workflows by SHA, so #999's fixes to
`reusable-shell-lint.yml`, `reusable-copyright-lint.yml`,
`reusable-test-suite.yml` and `reusable-lua-lint.yml` are **inert** until the
callers point at the commit carrying them. Until this lands, the apt-hang fix
that #999 exists to deliver is not actually running.

## The automation that should have done this has never worked

`bump-reusable-pins.yml` exists to close exactly this loop. It detects every
stale pin correctly — and then skips:

```
::warning::WORKFLOW_PIN_BUMP_TOKEN not set — cannot push workflow-file pin
bumps with GITHUB_TOKEN. Skipping the bump PR.
```

`GITHUB_TOKEN` is not permitted to push `.github/workflows/*`, so the workflow
needs a PAT with the `workflow` scope in `WORKFLOW_PIN_BUMP_TOKEN`. That secret
is not configured, so the job warns and **exits green**. A green tick is why
this went unnoticed, and why callers were still on `1f7213b1` several merges
later.

## Action needed

Until a PAT is added as `WORKFLOW_PIN_BUMP_TOKEN`, every future
`reusable-*.yml` change needs a manual pin bump exactly like this one. Adding
the secret makes the existing workflow start working with no code change.

## Verification

Applied precisely what `bump-reusable-pins.yml` computed: for each
`reusable-*.yml`, the SHA of the most recent commit touching it. A follow-up
scan reports **0 stale pins remaining**. `tests/unit/ci` and the security
compliance controls pass locally.

THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co
