### PR TITLE
fix(theme): invalidate the theme cache when the generator changes

### DIFF
--- a/scripts/theme/rebuild-themes.sh
+++ b/scripts/theme/rebuild-themes.sh
@@ -277,6 +277,45 @@ fi
 
 mkdir -p "$CACHE_DIR"
 
+# ---------------------------------------------------------------------------
+# Invalidate the cache when the generator itself changes
+#
+# A cache entry is only valid for the extract-theme.py that produced it, but
+# the freshness check below compares the entry against its *wallpaper* alone.
+# So a wallpaper that never changes keeps serving whatever the generator
+# emitted the first time, indefinitely — while every other theme silently
+# moves on.
+#
+# That is not hypothetical: catalina and sonoma shipped in themes.toml with
+# blocks generated in June/July, months after the rest. They carried an
+# absolute /Users/<name>/ wallpaper path (predating the `~/` normalisation)
+# and a c15 of #181818 in a *light* theme (predating the structural-ramp fix),
+# which failed the WCAG AAA gate in CI. Two real defects, both invisible here
+# because those two wallpapers had simply not been touched since.
+#
+# Keyed on the generator's CONTENT, not its mtime: `git checkout` rewrites
+# mtimes without changing behaviour, and mtime alone would force a full
+# rebuild of every theme on each checkout.
+generator_digest() {
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | awk '{print $1}'
+  elif command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  else
+    # No digest tool: fall back to always regenerating rather than risk
+    # serving stale blocks. Correctness over speed.
+    echo "no-digest-tool-$(date +%s)"
+  fi
+}
+
+GENERATOR_STAMP="$CACHE_DIR/.extract-theme.sha256"
+GENERATOR_HASH="$(generator_digest "$EXTRACT_SCRIPT")"
+GENERATOR_STALE=false
+if [[ ! -f "$GENERATOR_STAMP" || "$(cat "$GENERATOR_STAMP")" != "$GENERATOR_HASH" ]]; then
+  GENERATOR_STALE=true
+  echo "Generator changed since the cache was written — rebuilding all themes."
+fi
+
 # Clean orphaned cache files (wallpapers that no longer exist)
 for cache_file in "$CACHE_DIR"/*.toml; do
   [[ -f "$cache_file" ]] || continue
@@ -328,7 +367,8 @@ for name in $(printf '%s\n' "${!WALLPAPERS[@]}" | sort); do
   wp_path="${WALLPAPERS[$name]}"
   cache_file="$CACHE_DIR/${name}.toml"
 
-  if [[ "$FORCE" != "true" && -f "$cache_file" && "$cache_file" -nt "$wp_path" ]]; then
+  if [[ "$FORCE" != "true" && "$GENERATOR_STALE" != "true" &&
+    -f "$cache_file" && "$cache_file" -nt "$wp_path" ]]; then
     CACHED=$((CACHED + 1))
     continue
   fi
@@ -540,5 +580,10 @@ FALLBACK
 # subsections (which inflated the tally ~4x).
 theme_count=$(grep -cE '^\[themes\.[a-z0-9-]+\]$' "$THEMES_FILE")
 echo "  Written: $THEMES_FILE ($theme_count themes)"
+
+# Record which generator produced this cache. Written only now, after the file
+# has been assembled: stamping earlier would mark the cache current even if the
+# run died partway, so the next run would trust half-regenerated blocks.
+printf '%s\n' "$GENERATOR_HASH" >"$GENERATOR_STAMP"
 echo ""
 echo "Done. Run 'dot theme list' to see available themes."

--- a/tests/unit/theme/test_themes_toml.sh
+++ b/tests/unit/theme/test_themes_toml.sh
@@ -245,4 +245,28 @@ while IFS= read -r line; do
 done < "$THEMES_FILE"
 assert_equals "$bad" "0" "all color values must be valid 6-digit hex"
 
+# --- Wallpaper paths must not carry one machine's home directory ---
+#
+# themes.toml is committed and read on every machine, so a wallpaper path under
+# /Users/<name>/ or /home/<name>/ is broken everywhere except the host that
+# generated it. extract-theme.py rewrites home-relative paths to `~/` for
+# exactly this reason; system paths (/System/..., /usr/share/...) are identical
+# on every host and stay absolute.
+#
+# This is a real regression, not a hypothetical: catalina and sonoma shipped
+# with /Users/seb/... paths from a cache entry generated months earlier, and
+# nothing caught it. The WCAG gate caught their colour defect; their path
+# defect had no test at all.
+test_start "wallpaper_paths_are_not_machine_specific"
+machine_paths="$(grep -E '^wallpaper = "(/Users/|/home/)' "$THEMES_FILE" || true)"
+if [[ -z "$machine_paths" ]]; then
+  ((TESTS_PASSED++)) || true
+  printf '%b\n' "  ${GREEN}✓${NC} $CURRENT_TEST: no wallpaper path hardcodes a home directory"
+else
+  ((TESTS_FAILED++)) || true
+  printf '%b\n' "  ${RED}✗${NC} $CURRENT_TEST: wallpaper paths hardcode a home directory"
+  printf '%s\n' "$machine_paths" | sed 's/^/    /'
+  printf '%b\n' "    ${YELLOW:-}fix: run 'dot theme rebuild' so extract-theme.py re-emits them as ~/${NC}"
+fi
+
 echo "RESULTS:$TESTS_RUN:$TESTS_PASSED:$TESTS_FAILED"


### PR DESCRIPTION
## The symptom

catalina and sonoma kept shipping defects every other theme had long since
outgrown. #1001 had to revert their regenerated blocks, because they carried:

- an absolute `/Users/seb/Pictures/Wallpapers/catalina.heic` path instead of the
  `~/`-relative form the other 186 themes use — machine-specific data in a file
  every machine reads; and
- `c15 = #181818` on `catalina-light` / `sonoma-light` — a near-black in the
  **bright white** slot of a **light** theme, failing the WCAG AAA `c15 >= c7`
  gate on all three runners.

## The generator was never at fault

Both defects were fixed in `extract-theme.py` months ago. Running it today on
those exact wallpapers produces `~/`-relative paths and passing contrast:

```
catalina-light   c7=#6f6d67 c15=#979693  PASS
sonoma-light     c7=#6f6d67 c15=#979693  PASS
```

The blocks were coming from **cache**.

## The actual bug

`rebuild-themes.sh` decided cache freshness by comparing an entry against its
*wallpaper* alone:

```bash
[[ -f "$cache_file" && "$cache_file" -nt "$wp_path" ]]
```

Nothing referenced `extract-theme.py`. So a wallpaper that never changes keeps
serving whatever the generator emitted the first time — **forever** — while
every other theme moves on. The evidence is in the mtimes:

| cache entry | written |
| --- | --- |
| `sonoma-*.toml` | **2 Jun** |
| `catalina-*.toml` | **2 Jul** |
| everything else | 30 Jul – 11 Aug |

Those two families were never touched again, so they stayed frozen either side
of the two fixes.

## The fix

The cache is now also invalidated when `extract-theme.py`'s **content** changes,
tracked by a sha256 stamp beside the entries.

Content, not mtime: `git checkout` rewrites mtimes without changing behaviour,
and an mtime test would force a full rebuild of all 190 themes on every
checkout.

The stamp is written **only after** `themes.toml` is assembled, so a run that
dies partway leaves the cache untrusted rather than half-valid. Verified by
interrupting a real run: no stamp was written, `themes.toml` was untouched, and
the partially-regenerated entries stayed distrusted.

## The missing test

The WCAG gate caught the colour half of this in CI. The machine-specific path
had **no test at all** — I found it by eye, which is not a control.

`wallpaper_paths_are_not_machine_specific` rejects both `/Users/` and `/home/`
paths. Mutation-verified against the exact paths that shipped:

| file state | result |
| --- | --- |
| current tree | PASS |
| `/Users/seb/...` reintroduced (macOS form) | FAIL, names the line |
| `/home/seb/...` reintroduced (Linux form) | FAIL, names the line |

## Cost, stated plainly

Editing `extract-theme.py` now forces a full rebuild — roughly **two hours** for
190 wallpapers. That is paid only on generator edits, and it is the price of not
shipping output from a generator two fixes out of date.

`themes.toml` is unchanged here: #1001 already restored those four blocks to
good values. The next `dot theme rebuild` will regenerate them properly.

## Verification

All 18 files in `tests/unit/theme` pass with zero failures; `test_themes_toml.sh`
goes 11 → 12 assertions. Shell preamble clean, copyright clean (933 files),
shellcheck and shfmt clean.

THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co
