### PR TITLE
fix(diagnostics): gate startup on min, and correct two wrong thresholds

### DIFF
--- a/scripts/diagnostics/doctor.sh
+++ b/scripts/diagnostics/doctor.sh
@@ -548,8 +548,10 @@ for tool in mise starship zoxide atuin fzf direnv; do
   done
 done
 if [[ $stale_caches -eq 0 ]]; then
+  caches_fresh="fresh"
   _ok "shell caches" "fresh"
 else
+  caches_fresh="stale"
   _warn "shell caches" "stale ($stale_tools) — run dot prewarm"
 fi
 
@@ -618,8 +620,22 @@ fi
 # A mise-managed 2026 dev machine routinely adds 60-90 entries (one per
 # installed tool version + per-shim path), so the warn/fail thresholds
 # reflect that baseline rather than a lean default (~40).
+#
+# The OK ceiling was 75, which contradicted the 60-90 baseline stated right
+# above it and warned on every healthy mise machine. Worse, the implied remedy
+# was backwards: those per-tool entries are what let a command resolve to the
+# real binary instead of falling through to a mise shim. Measured 2026-08-20,
+# 20 invocations of ripgrep --version:
+#
+#     via shim            2741ms   (137ms per call)
+#     direct install dir    62ms   (3.1ms per call)
+#
+# ~44x. "Pruning" those entries to satisfy a length check would trade
+# microseconds of PATH scan for ~134ms on every single tool invocation. The
+# ceiling now matches the documented baseline; >90 still warns, because past
+# that the entries are worth auditing for tools you no longer use.
 path_count=$(printf '%s' "${PATH:-}" | tr ':' '\n' | grep -c . || true)
-if [[ "$path_count" -le 75 ]]; then
+if [[ "$path_count" -le 90 ]]; then
   _ok "PATH length" "$path_count entries"
 elif [[ "$path_count" -le 120 ]]; then
   _warn "PATH length" "$path_count entries — consider pruning"
@@ -669,7 +685,15 @@ if command -v hyperfine >/dev/null 2>&1; then
   if bash "$SCRIPT_DIR/../../tests/performance/bench.sh" 2>/dev/null; then
     _ok "startup latency" "within target thresholds"
   else
-    _warn "startup latency" "threshold exceeded (run dot prewarm)"
+    # Only suggest prewarm when it could actually help. The caches were
+    # already reported fresh above in the common case, and telling someone to
+    # re-run a no-op sends them in a circle — as it did on 2026-08-20, where
+    # prewarm changed nothing because nothing was cold.
+    if [[ "${caches_fresh:-unknown}" == "fresh" ]]; then
+      _warn "startup latency" "threshold exceeded (caches already fresh — profile with 'dot benchmark')"
+    else
+      _warn "startup latency" "threshold exceeded (run dot prewarm)"
+    fi
   fi
 else
   _warn "hyperfine" "missing (benchmark skipped)"

--- a/tests/performance/bench.sh
+++ b/tests/performance/bench.sh
@@ -20,7 +20,13 @@ set -euo pipefail
 THRESHOLD_MS_BASH=75
 THRESHOLD_MS_ZSH=90
 THRESHOLD_MS_FISH=200
-THRESHOLD_MS_NU=60
+# nu raised from 60 on 2026-08-20. Not config bloat and not goalpost-moving:
+# nushell 0.114.1 takes 136ms to start with --no-config-file, so the old 60ms
+# gate could not pass on an empty config. The dotfiles layer adds ~38ms on top
+# (174ms measured with config), which is in line with what the other shells
+# spend. Re-measure `nu --no-config-file -c exit` before lowering this again;
+# if upstream gets its floor back down, this should follow it down.
+THRESHOLD_MS_NU=200
 
 if ! command -v hyperfine >/dev/null 2>&1; then
   echo "hyperfine not found."
@@ -37,17 +43,29 @@ run_bench() {
   local result
   local bench_json
   bench_json=$(umask 077 && mktemp)
+  # Gate on the MINIMUM, not the mean.
+  #
+  # This is a regression gate for *our* init code, and the mean measures the
+  # machine's spare capacity as much as the shell. Timed on 2026-08-20 while a
+  # Rust build was running (load 6.08 on 6 cores), fish reported mean=428ms
+  # against min=73ms — 5.9x apart, and a red gate for a config that had not
+  # changed. zsh reported mean=129ms / min=82ms, failing its 90ms threshold on
+  # the mean and passing on the min.
+  #
+  # The minimum of ten runs approximates the uncontended cost, which is the
+  # thing a regression gate is actually asking about. It cannot mask a real
+  # regression: work added to an rc file raises the floor too.
   result=$(hyperfine -N -i --warmup 3 --runs 10 "$shell_cmd" --export-json "$bench_json" >/dev/null 2>&1 &&
-    jq -r '.results[0].mean * 1000' "$bench_json")
+    jq -r '.results[0].min * 1000' "$bench_json")
   rm -f "$bench_json"
 
-  local mean_ms
-  mean_ms=$(printf "%.0f" "$result")
+  local min_ms
+  min_ms=$(printf "%.0f" "$result")
 
-  if [[ $mean_ms -le $threshold ]]; then
-    printf '  \033[38;5;42m✓\033[0m %-12s %dms\n' "$label" "$mean_ms"
+  if [[ $min_ms -le $threshold ]]; then
+    printf '  \033[38;5;42m✓\033[0m %-12s %dms\n' "$label" "$min_ms"
   else
-    printf '  \033[38;5;196m✗\033[0m %-12s %dms (> %dms)\n' "$label" "$mean_ms" "$threshold"
+    printf '  \033[38;5;196m✗\033[0m %-12s %dms (> %dms)\n' "$label" "$min_ms" "$threshold"
     FAILED=1
   fi
 }


### PR DESCRIPTION
## What

Three `dot doctor` warnings that were reporting the checks' own defects rather
than anything wrong with the machine.

## 1. The PATH check argued against itself

It warned above **75** entries — three lines below its own comment saying a
mise-managed machine "routinely adds 60-90". So it warned on every healthy
install.

Worse, the implied remedy was backwards. Those per-tool entries are what let a
command resolve to the real binary instead of falling through to a mise shim.
Twenty invocations of `ripgrep --version`:

| resolution | 20 calls | per call |
| --- | --- | --- |
| via shim | 2741ms | **137ms** |
| direct install dir | 62ms | **3.1ms** |

**~44×.** "Pruning" PATH to satisfy a length check would trade microseconds of
scan for ~134ms on every single tool invocation. The ceiling now matches the
documented baseline; >90 still warns, because past that the entries are worth
auditing for tools you no longer use.

## 2. The startup gate measured the machine, not the shell

It gated on hyperfine's **mean**. Timed during a Rust build (load 6.08 on 6
cores):

| shell | mean | min | spread |
| --- | --- | --- | --- |
| fish | 428ms | **73ms** | **5.9×** |
| zsh | 129ms | **82ms** | 1.6× |
| bash | 21ms | 19ms | 1.1× |

fish was a red gate for a config nobody had touched. zsh failed on the mean and
passed on the min against the same 90ms threshold.

It now gates on the **minimum of ten runs**, which approximates the uncontended
cost — the thing a regression gate is actually asking about. It cannot hide a
real regression: work added to an rc file raises the floor too. The switch took
fish from 428ms to 86ms on the same machine under *heavier* load.

## 3. The nu threshold predated a 5× upstream regression

60ms, set from a 2026-07 measurement of ~25ms. nushell 0.114.1 now takes
**136ms with `--no-config-file`** — the gate could not pass on an *empty*
config. The dotfiles layer adds ~38ms on top, in line with the other shells.

Raised to 200ms, with the method to re-derive it recorded in the comment so it
follows upstream back down rather than becoming another stale number.

## Also

`dot doctor` no longer tells you to run `dot prewarm` when it has already
reported the caches fresh. Following that advice does nothing and sends you in a
circle — which is exactly what happened here: prewarm ran, changed nothing, and
the warning stayed.

## Caveat, stated plainly

This machine has been under a heavy Rust build throughout (load 6–11 on 6
cores), so the 200ms nu threshold is derived from contended measurements and is
deliberately generous. Re-run `nu --no-config-file -c exit` on an idle machine
and tighten it.

## Verification

shellcheck, shfmt, shell-preamble and copyright gates all clean.
`tests/unit/diagnostics` passes except `test_diagnostics_health.sh`, which fails
**identically at HEAD without these changes** (`RESULTS:13:19:2`, verified in a
clean worktree) and is green in CI — pre-existing and environment-dependent, not
introduced here.

THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co
