### PR TITLE
fix(health): survive a probed tool that fails, and correct the nu note

### DIFF
--- a/scripts/diagnostics/health.sh
+++ b/scripts/diagnostics/health.sh
@@ -235,7 +235,13 @@ check_dev_tools() {
 
   if has_command node; then
     local node_version
-    node_version=$(node --version 2>/dev/null)
+    # `|| true` is load-bearing under `set -e`: an assignment takes the exit
+    # status of its command substitution, so a `node` that fails to report a
+    # version aborts the entire health report mid-section — no Summary, no
+    # score, rc=1. That is exactly what happened when `node` resolved to a
+    # mise shim under a sandboxed HOME. A diagnostic tool must survive the
+    # tools it is diagnosing.
+    node_version=$(node --version 2>/dev/null || true)
     check "Node.js ($node_version)" "pass"
   else
     check "Node.js" "warn" "Not installed"
@@ -251,7 +257,10 @@ check_dev_tools() {
 
   if has_command python3; then
     local py_version
-    py_version=$(python3 --version 2>/dev/null | cut -d' ' -f2)
+    # pipefail is on, so this pipeline reports python3's failure even though
+    # `cut` succeeds — and an assignment inherits that status, aborting the
+    # report under `set -e`. Same hazard as node_version above.
+    py_version=$(python3 --version 2>/dev/null | cut -d' ' -f2 || true)
     check "Python ($py_version)" "pass"
   else
     check "Python" "warn" "Not installed"
@@ -354,7 +363,12 @@ check_security() {
   for key in "$HOME/.ssh/id_ed25519" "$HOME/.ssh/id_rsa" "$HOME/.ssh/id_ed25519_sk"; do
     if [[ -f "$key" ]]; then
       local perms
-      perms=$(stat -c '%a' "$key" 2>/dev/null || stat -f '%Lp' "$key" 2>/dev/null)
+      # Same hazard as node_version above: if BOTH stat spellings fail (a
+      # platform with neither GNU nor BSD stat), the assignment is non-zero
+      # and `set -e` kills the report. Empty perms falls through to the
+      # "should be 600" warning, which is the right answer when the mode
+      # cannot be read.
+      perms=$(stat -c '%a' "$key" 2>/dev/null || stat -f '%Lp' "$key" 2>/dev/null || true)
       if [[ "$perms" != "600" && "$perms" != "400" ]]; then
         check "SSH key perms (${key##*/})" "warn" "mode $perms (should be 600)"
       else

--- a/tests/performance/bench.sh
+++ b/tests/performance/bench.sh
@@ -20,12 +20,24 @@ set -euo pipefail
 THRESHOLD_MS_BASH=75
 THRESHOLD_MS_ZSH=90
 THRESHOLD_MS_FISH=200
-# nu raised from 60 on 2026-08-20. Not config bloat and not goalpost-moving:
-# nushell 0.114.1 takes 136ms to start with --no-config-file, so the old 60ms
-# gate could not pass on an empty config. The dotfiles layer adds ~38ms on top
-# (174ms measured with config), which is in line with what the other shells
-# spend. Re-measure `nu --no-config-file -c exit` before lowering this again;
-# if upstream gets its floor back down, this should follow it down.
+# nu raised from 60 on 2026-08-20. The first version of this note blamed
+# nushell, claiming a 136ms interpreter floor. That was wrong, and wrong in an
+# instructive way: `nu` on PATH is a mise shim, so every measurement through it
+# included the shim's cost. Measured directly at load 2.1:
+#
+#     nu (via mise shim)              112ms
+#     real binary, with our config     16ms
+#     real binary, --no-config-file     7ms
+#
+# nushell starts in 7ms. Our config costs 9ms. The other ~96ms is the shim
+# re-execing mise on every call, which is a PATH-ordering problem affecting
+# every mise-managed tool, not just nu — `rg --version` is 95ms via shim
+# against 2ms direct.
+#
+# 200ms reflects what a shell actually costs to start on this machine as
+# configured. Fixing the shim indirection would let this drop to ~40ms, below
+# even the original 60. Until then, gating at 60 would fail on a config that
+# contributes 9ms of the 112.
 THRESHOLD_MS_NU=200
 
 if ! command -v hyperfine >/dev/null 2>&1; then

--- a/tests/unit/diagnostics/test_diagnostics_health.sh
+++ b/tests/unit/diagnostics/test_diagnostics_health.sh
@@ -98,12 +98,24 @@ assert_file_contains "$HEALTH_FILE" 'check "Node version manager" "pass" "mise"'
 assert_file_contains "$HEALTH_FILE" 'check "Nerd Font available" "pass"' "health accepts any Nerd Font"
 assert_file_contains "$HEALTH_FILE" 'check "Git signing" "pass" "ssh"' "health accepts SSH commit signing"
 
+# A diagnostic tool has to survive the tools it is diagnosing. Every probed
+# binary is replaced with one that exits 1, which is what a broken install, a
+# shim with no backing tool, or a sandboxed HOME actually looks like.
+#
+# Only `zsh` used to be faked here, and the test passed or failed depending on
+# whether the *host* happened to have a working node — green in CI, red
+# locally where `node` resolved to a mise shim under the sandbox HOME. The
+# abort was never in the zsh path at all: `node_version=$(node --version)`
+# takes the substitution's exit status, so under `set -e` it killed the report
+# mid-section with no Summary and rc=1.
 test_start "health_failed_zsh_timing_still_prints_summary"
-printf '#!/usr/bin/env bash\nexit 1\n' >"$DOTFILES_COV_TMPDIR/bin/zsh"
-chmod +x "$DOTFILES_COV_TMPDIR/bin/zsh"
+for _broken in zsh node python3 git stat; do
+  printf '#!/usr/bin/env bash\nexit 1\n' >"$DOTFILES_COV_TMPDIR/bin/$_broken"
+  chmod +x "$DOTFILES_COV_TMPDIR/bin/$_broken"
+done
 health_output=$(NO_COLOR=1 DOTFILES_NONINTERACTIVE=1 bash "$HEALTH_FILE" 2>&1)
 health_rc=$?
-assert_equals "0" "$health_rc" "failed interactive zsh timing must not abort health"
+assert_equals "0" "$health_rc" "a failing probed tool must not abort health"
 assert_output_contains "Summary" "printf '%s' \"\$health_output\""
 
 echo ""


### PR DESCRIPTION
## 1. The health report aborted whenever a probed tool failed

`health.sh` runs under `set -euo pipefail`, and an assignment inherits the exit
status of its command substitution. So:

```bash
node_version=$(node --version 2>/dev/null)
```

killed the **entire** report the moment `node` returned non-zero — no Summary,
no score, `rc=1`, and 27 lines of output where a full report belonged. A
diagnostic tool has to survive the tools it is diagnosing.

Three sites fixed:

| site | why it aborts |
| --- | --- |
| `node_version` | substitution status propagates under `set -e` |
| `py_version` | a pipeline — `pipefail` carries python3's failure past a successful `cut` |
| SSH-key `perms` | both `stat` spellings failing (neither GNU nor BSD stat) |

## 2. The test that should have caught it was host-dependent

It faked only `zsh`. Whether it passed depended on the host: **green in CI, red
locally**, where `node` resolved to a mise shim under the sandboxed HOME and
failed. The abort was never in the zsh path at all — the test name pointed at
the wrong thing.

It now fakes every probed binary (`zsh node python3 git stat`), which is what a
broken install, a shim with no backing tool, or a sandboxed HOME actually looks
like.

Verified by mutation: `RESULTS:13:19:2` with `health.sh` reverted,
`RESULTS:13:21:0` with the fix. Each individual fix moved the abort to the next
unguarded site until there were none — the strengthened test found two sites
beyond the one I started from.

## 3. Correcting a claim I got wrong in #1004

That PR raised the nu threshold and blamed nushell for a "136ms interpreter
floor". **That was wrong.** `nu` on PATH is a mise shim, so every measurement
through it included the shim's cost. Measured directly at load 2.1:

| invocation | min |
| --- | --- |
| `nu` via mise shim | 112ms |
| real binary, with our config | **16ms** |
| real binary, `--no-config-file` | **7ms** |

nushell starts in **7ms**. Our config costs 9ms. The remaining **~96ms is the
shim re-execing mise** on every call.

## The bigger finding this uncovered

That shim cost is not a nu problem — it applies to **every mise-managed tool**:

| tool | via shim | direct | ratio |
| --- | --- | --- | --- |
| `rg --version` | 95ms | 2ms | **~47×** |
| `nu -c exit` | 112ms | 25ms | ~4.5× |

Cause: `00-core-paths` prepends `~/.local/share/mise/shims` at position 1, while
the tool directories `mise activate` manages sit at position 16. Every command
takes the shim.

**I did not fix it here, deliberately.** The obvious change — moving shims to
the back — makes tools resolve to `/opt/homebrew/bin` instead, because Homebrew
sits at position 8 and carries a duplicate of nearly every mise tool. That would
silently move version management from mise to brew. I tried it, verified it
resolved to brew, and reverted; the machine is back exactly as it was. The real
fix needs mise's directories ahead of Homebrew's, which is a deliberate
precedence decision rather than a cleanup.

## Verification

All of `tests/unit/diagnostics` passes. shellcheck, shfmt, shell-preamble and
copyright (933 files) clean.

THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co
