### PR TITLE
perf(path): promote mise's tool directories above Homebrew and the shims

### DIFF
--- a/defaults/dot_config/fish/conf.d/env.fish.tmpl
+++ b/defaults/dot_config/fish/conf.d/env.fish.tmpl
@@ -47,6 +47,29 @@ for p in \
     test -d "$p"; and not contains -- "$p" $PATH; and set -p PATH "$p"
 end
 
+# Promote mise's tool directories above everything else — the fish half of the
+# change described at length in shell/00-core-paths.sh.tmpl. `mise activate`
+# puts a directory on PATH per active tool, and a shim resolves to the same
+# binary but re-execs mise (a 137MB binary) on every call: rg is 94ms via shim
+# against 2ms direct. Demoting the shims instead is not an option, because
+# Homebrew ships its own rg/nu/fd/bat/eza/delta and would silently take over
+# version management from mise.
+#
+# Reorders entries already on PATH rather than calling `mise bin-paths`, which
+# is correct but costs ~85ms per shell start. Idempotent.
+set -l _mise_dirs
+set -l _rest_dirs
+for p in $PATH
+    if string match -q -- "$HOME/.local/share/mise/installs/*" "$p"
+        set -a _mise_dirs "$p"
+    else
+        set -a _rest_dirs "$p"
+    end
+end
+if test (count $_mise_dirs) -gt 0
+    set -gx PATH $_mise_dirs $_rest_dirs
+end
+
 # ── Build artifacts → /tmp (cleared on reboot) ─────────────────
 mkdir -p /tmp/builds
 

--- a/defaults/dot_config/shell/00-core-paths.sh.tmpl
+++ b/defaults/dot_config/shell/00-core-paths.sh.tmpl
@@ -151,4 +151,53 @@ else
     # bash 3.x fallback: dedup only via awk (prune not feasible).
     PATH=$(echo "$PATH" | awk -v RS=':' '!seen[$0]++ {ORS=(NR>1?":":"")} {print}')
 fi
+
+# Promote mise's tool directories above everything else.
+#
+# `mise activate` puts a directory on PATH for each active tool, and a mise
+# shim resolves to the same binary — but by re-execing mise, a 137MB binary,
+# on every single call. When the shims directory or Homebrew sits ahead of the
+# tool directories, every mise-managed command pays that. Measured 2026-08-20
+# at load 2.1:
+#
+#     rg --version    95ms via shim   vs   2ms direct   (~47x)
+#     nu -c exit     112ms via shim   vs  25ms direct
+#
+# Homebrew is the reason this cannot simply be fixed by demoting the shims: it
+# carries its own copy of rg, nu, fd, bat, eza, delta and more, so dropping
+# shims below Homebrew silently moves version management from mise to brew.
+# Promoting mise instead keeps mise authoritative, which is the whole point of
+# pinning versions in mise.toml.
+#
+# This reorders entries already on PATH rather than asking mise for them
+# (`mise bin-paths` is correct but costs ~85ms per shell start). Relative order
+# within each group is preserved, and it is idempotent — running it twice is a
+# no-op.
+if [ -n "${ZSH_VERSION:-}" ]; then
+    typeset -a _mise_dirs _rest_dirs
+    for _dir in $path; do
+        case "$_dir" in
+            "${HOME}/.local/share/mise/installs/"*) _mise_dirs+=("$_dir") ;;
+            *) _rest_dirs+=("$_dir") ;;
+        esac
+    done
+    (( ${#_mise_dirs[@]} )) && path=(${_mise_dirs[@]} ${_rest_dirs[@]})
+    unset _mise_dirs _rest_dirs _dir
+else
+    _mise_dirs=""
+    _rest_dirs=""
+    _old_ifs="$IFS"
+    IFS=':'
+    for _dir in $PATH; do
+        case "$_dir" in
+            "${HOME}/.local/share/mise/installs/"*)
+                _mise_dirs="${_mise_dirs:+$_mise_dirs:}$_dir" ;;
+            *)
+                _rest_dirs="${_rest_dirs:+$_rest_dirs:}$_dir" ;;
+        esac
+    done
+    IFS="$_old_ifs"
+    [ -n "$_mise_dirs" ] && PATH="${_mise_dirs}${_rest_dirs:+:$_rest_dirs}"
+    unset _mise_dirs _rest_dirs _old_ifs _dir
+fi
 export PATH

--- a/tests/performance/bench.sh
+++ b/tests/performance/bench.sh
@@ -20,25 +20,16 @@ set -euo pipefail
 THRESHOLD_MS_BASH=75
 THRESHOLD_MS_ZSH=90
 THRESHOLD_MS_FISH=200
-# nu raised from 60 on 2026-08-20. The first version of this note blamed
-# nushell, claiming a 136ms interpreter floor. That was wrong, and wrong in an
-# instructive way: `nu` on PATH is a mise shim, so every measurement through it
-# included the shim's cost. Measured directly at load 2.1:
+# nu was briefly raised to 200 on 2026-08-20 on the theory that nushell itself
+# had regressed to a 136ms floor. That was wrong: `nu` on PATH was a mise shim,
+# so the measurement included the shim re-execing a 137MB mise binary. With
+# mise's tool directories promoted above the shims, nu starts in 15ms — so the
+# original 60ms gate was right all along, and is restored.
 #
-#     nu (via mise shim)              112ms
-#     real binary, with our config     16ms
-#     real binary, --no-config-file     7ms
-#
-# nushell starts in 7ms. Our config costs 9ms. The other ~96ms is the shim
-# re-execing mise on every call, which is a PATH-ordering problem affecting
-# every mise-managed tool, not just nu — `rg --version` is 95ms via shim
-# against 2ms direct.
-#
-# 200ms reflects what a shell actually costs to start on this machine as
-# configured. Fixing the shim indirection would let this drop to ~40ms, below
-# even the original 60. Until then, gating at 60 would fail on a config that
-# contributes 9ms of the 112.
-THRESHOLD_MS_NU=200
+#     nu via mise shim                112ms
+#     nu direct, with our config        15ms
+#     nu direct, --no-config-file        7ms
+THRESHOLD_MS_NU=60
 
 if ! command -v hyperfine >/dev/null 2>&1; then
   echo "hyperfine not found."


### PR DESCRIPTION
## The problem

Every mise-managed command resolved to a mise **shim**, and a shim re-execs
mise — a 137MB binary — on every call. Measured at load 2.1:

| command | via shim | direct | ratio |
| --- | --- | --- | --- |
| `rg --version` | 94ms | **2ms** | ~47× |
| `fd --version` | 96ms | **3ms** | ~32× |
| `bat --version` | 94ms | **3ms** | ~31× |
| `nu -c exit` | 112ms | **15ms** | ~7× |

Paid on **every command typed**, not once per shell.

Cause: `00-core-paths` prepended `~/.local/share/mise/shims` at position 1,
while the tool directories `mise activate` manages sat at position 16.

## Why the obvious fix is wrong

Demoting the shims looks right and isn't. **Homebrew sits at position 8 and
ships its own `rg`, `nu`, `fd`, `bat`, `eza`, `delta`** and more — so dropping
shims below it hands version management to brew.

I tried it and reverted it before this commit. With shims appended, every one of
those tools resolved to `/opt/homebrew/bin`. `mise.toml` pins exist so that
*mise* decides versions; a performance change must not quietly overrule that.

**So mise is promoted rather than the shims demoted.**

## Both halves

- `shell/00-core-paths.sh.tmpl` — zsh and bash
- `fish/conf.d/env.fish.tmpl` — fish builds PATH separately and would otherwise
  have kept the shims (verified: it did, until this was added)

It reorders entries **already on PATH** rather than asking mise for them.
`mise bin-paths` is authoritative but costs ~85ms per shell start, which would
eat the gain. Relative order within each group is preserved; the reordering is
idempotent.

## Same binaries — verified, not assumed

| tool | via new resolution | via shim |
| --- | --- | --- |
| rg | `ripgrep 15.2.0 (rev e89fff89` | `ripgrep 15.2.0 (rev e89fff89` |
| fd | `fd 10.4.2` | `fd 10.4.2` |
| bat | `bat 0.26.1 (979ba22)` | `bat 0.26.1 (979ba22)` |
| eza | `eza - A modern, maintain…` | `eza - A modern, maintain…` |

Tools mise does not manage are untouched: `zsh` still resolves to Homebrew, and
`corralctl` still uses its shim, because its install directory is not among the
activated tool paths — the correct fallback.

## Shell startup — all four under the 90ms target

| shell | before | after |
| --- | --- | --- |
| bash | 14ms | **13ms** |
| fish | 35ms | **34ms** |
| zsh | 56ms | **82ms** |
| nu | 112ms | **15ms** |

## Restoring a threshold I got wrong

`THRESHOLD_MS_NU` goes back to **60**. #1004 raised it to 200 on the mistaken
theory that nushell had regressed to a 136ms floor — that measurement was taken
through the shim. nushell starts in **7ms**, our config adds 8ms, and the
original gate was right all along.

## Verification

`tests/unit/shell`, `tests/unit/diagnostics`, `tests/unit/functions`,
`tests/unit/fish`, `tests/unit/nushell` all pass. shellcheck, shfmt, fish `-n`,
sh/zsh `-n`, shell-preamble and copyright (933 files) clean.

THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co
