### PR TITLE
fix(corralctl): put mise's shims on the sync agent's PATH

### DIFF
--- a/defaults/dot_local/bin/executable_corralctl-sync.sh
+++ b/defaults/dot_local/bin/executable_corralctl-sync.sh
@@ -7,7 +7,18 @@ set -euo pipefail
 # Invoked by the launchd agent com.sebastienrousseau.corralctl (daily 00:00).
 # Logs every run; posts a macOS notification only when a run has failures.
 
-export PATH="/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+# The mise shims directory has to lead here, and this is the one place shims
+# are the right answer. launchd starts this with a bare environment and never
+# runs `mise activate`, so the tool directories an interactive shell gets do
+# not exist — a shim is how a non-interactive context reaches a mise-managed
+# binary at all.
+#
+# Without it this script had been failing every night since at least
+# 2026-08-15: `corralctl: command not found`, exit 127, synced=0, silently,
+# because the notification only fires on *reported* errors and a 127 never
+# gets that far. corralctl lives only under mise, so neither /opt/homebrew/bin
+# nor ~/.local/bin could ever have resolved it.
+export PATH="$HOME/.local/share/mise/shims:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin"
 
 OWNER="sebastienrousseau"
 LOG="$HOME/Library/Logs/corralctl.log"

--- a/tests/performance/bench.sh
+++ b/tests/performance/bench.sh
@@ -18,22 +18,21 @@ set -euo pipefail
 # Regression thresholds (ms). Measured 2026-07 medians: zsh ~66, bash ~51,
 # fish ~129, nu ~25 — thresholds sit above those with headroom for noise.
 THRESHOLD_MS_BASH=75
-# zsh raised from 90 to 110 on 2026-08-20, as the stated price of #1006.
+# zsh: 90 -> 110 -> 100 on 2026-08-20.
 #
-# Promoting mise's 65 tool directories to the front of PATH means every lookup
-# during rc that misses them stats through them first. Measured at load 3.4
-# with the identical loop, changing only the final ordering:
+# 110 was set while a Rust build was saturating the machine (load 6-13 on 6
+# cores) and readings ranged 82-131ms, so it was padded for noise rather than
+# derived. On a quiet machine the honest figure is tighter: 89ms at load 2.14,
+# 82-90ms across loads 2.0-3.4. 100 sits above that with real headroom and
+# still catches a regression 110 would have waved through.
 #
-#     mise directories last     58ms
-#     mise directories first    90-98ms
-#
-# That ~35ms is paid once per shell. It buys ~92ms on every mise-managed
-# command (rg: 94ms via shim against 2ms direct), paid per command. For any
-# shell in which more than one tool is run, the trade is heavily positive.
-#
-# This is a deliberate trade, not a stale number: if the promotion is ever
-# reverted, put this back to 90.
-THRESHOLD_MS_ZSH=110
+# The gap from the pre-#1006 58ms is the deliberate cost of promoting mise's
+# 65 tool directories to the front of PATH: every lookup that misses them
+# stats through them first. Measured with the identical loop, changing only
+# the final ordering: mise last 58ms, mise first 90ms. That ~32ms is paid once
+# per shell and buys ~92ms on every mise-managed command (rg: 94ms via shim
+# against 2ms direct). If the promotion is ever reverted, put this back to 90.
+THRESHOLD_MS_ZSH=100
 THRESHOLD_MS_FISH=200
 # nu was briefly raised to 200 on 2026-08-20 on the theory that nushell itself
 # had regressed to a 136ms floor. That was wrong: `nu` on PATH was a mise shim,


### PR DESCRIPTION
Two cleanups — and checking the first one before deleting anything turned up a
live failure.

## 1. The nightly corralctl sync has been broken for five days

Verifying it was safe to delete a stale `~/.local/bin/corralctl` meant reading
what the LaunchAgent actually runs. It has been failing every single night since
at least 2026-08-15:

```
===== corralctl sync started 2026-08-20 00:00:05 =====
corralctl-sync.sh: line 20: corralctl: command not found
----- finished: exit=127 synced=0 errors=0 -----
```

`corralctl-sync.sh` hardcodes:

```bash
PATH="/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin"
```

corralctl is in **neither**. It is installed only through mise, so that PATH
could never have resolved it. launchd starts the agent with a bare environment
and never runs `mise activate`, so the tool directories an interactive shell
gets do not exist here either.

**It failed silently** because the macOS notification fires only on errors the
*tool* reports, and an exit 127 never gets that far.

### The fix

The mise shims directory now leads that PATH. This is the one place shims are
the *right* answer: #1006 demoted them below the tool directories for
interactive shells, because a shim re-execs a 137MB mise binary on every call —
but in a non-interactive context with no activation, a shim is the only way to
reach a mise-managed binary at all.

Verified under the script's exact environment:

```
$ env -i HOME=$HOME PATH="$HOME/.local/share/mise/shims:/opt/homebrew/bin:..." \
    sh -c 'command -v corralctl && corralctl --version'
/Users/seb/.local/share/mise/shims/corralctl
corralctl version 0.0.23
```

### Worth re-reading in light of this

Earlier in this work the sidecar migration looked like slow natural progress:
150 legacy sidecars in `~/Code` against 14 migrated. It was not progress. It was
a sync that had not run in five days.

## 2. Tightens `THRESHOLD_MS_ZSH` from 110 to 100

110 was set while a Rust build was saturating the machine (load 6–13 on 6 cores,
readings spanning 82–131ms), so it was padded for noise rather than derived.

Quiet-machine figures are tighter — **89ms at load 2.14**, 82–90ms across loads
2.0–3.4. 100 sits above that with real headroom and still catches a regression
110 would have waved through.

## Also done, outside the repo

Deleted `~/.local/bin/corralctl` — a `v0.0.20-2-gabcc283-dirty` build from
18 Aug, 13MB. Confirmed first that it was not chezmoi-managed, not referenced
anywhere, and not what currently resolves. After deletion `corralctl` still
resolves through mise and reports 0.0.23.

Note `~/.local/bin` also holds a stale `chezmoi v2.47.1` against mise's v2.72.0.
mise wins today under the #1006 ordering, so it is latent rather than active —
left alone, flagged here.

## Verification

`test_auto_bin_corralctl_sync_sh.sh` and `test_coverage_commands_exercise.sh`
pass. shellcheck, shfmt, shell-preamble and copyright (933 files) clean.

THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co
