### PR TITLE
fix(docs): stop build-manual.sh stripping frontmatter and fighting over command-index

### DIFF
--- a/docs/manual/concept-index.md
+++ b/docs/manual/concept-index.md
@@ -9,6 +9,7 @@ Alphabetical list of concepts covered in the manual.
 - Accessibility
 - Adding a New Flag
 - Agent Policy Enforcement
+- Agents
 - AI & Agents
 - Algorithms
 - Apply / Sync
@@ -97,6 +98,7 @@ Alphabetical list of concepts covered in the manual.
 - Read by Tools
 - Recovery
 - Reference
+- Registry
 - Required Binaries
 - Scenario
 - Secret-Related

--- a/tools/docs/build-manual.sh
+++ b/tools/docs/build-manual.sh
@@ -127,6 +127,15 @@ log "found $TOTAL_FILES manual files"
 build_indexes() {
   log "generating concept-index"
   {
+    # `render_with_liquid: false` is required, not decoration. Jekyll otherwise
+    # parses `{{ ... }}` and `{% ... %}` inside the page, and concept headings
+    # come from manual prose that contains both. Every other doc under docs/
+    # carries it; omitting it here made every run of this script strip it back
+    # off, so the checked-in file and the generator disagreed permanently.
+    echo "---"
+    echo "render_with_liquid: false"
+    echo "---"
+    echo ""
     echo "# Concept Index"
     echo ""
     echo "Alphabetical list of concepts covered in the manual."
@@ -138,18 +147,19 @@ build_indexes() {
   } >"$SOURCE_DIR/concept-index.md.gen"
   mv "$SOURCE_DIR/concept-index.md.gen" "$SOURCE_DIR/concept-index.md"
 
-  log "generating command-index"
-  {
-    echo "# Command Index"
-    echo ""
-    echo "Alphabetical list of \`dot\` subcommands referenced in the manual."
-    echo ""
-    # shellcheck disable=SC2016 # literal grep pattern; single quotes intentional
-    grep -rhoE '`dot [a-z][a-z-]+( [a-z-]+)?`' "$SOURCE_DIR"/*.md "$SOURCE_DIR"/*/*.md 2>/dev/null |
-      sort -u |
-      awk '{ print "- " $0 }'
-  } >"$SOURCE_DIR/command-index.md.gen"
-  mv "$SOURCE_DIR/command-index.md.gen" "$SOURCE_DIR/command-index.md"
+  # command-index.md is deliberately NOT generated here.
+  #
+  # tools/docs/generate-command-index.sh owns that file, and the CI job
+  # `Generators / command-index` checks its output. This function used to write
+  # it too, from a different source (backticked `dot ...` strings scraped out of
+  # the manual) in a different format (a bullet list, no frontmatter, no
+  # descriptions). The two disagreed completely, so whichever ran last won:
+  # running build-manual.sh alone replaced the table with a bullet list and
+  # dropped the frontmatter, which fails that CI job for reasons unrelated to
+  # whatever the author was actually doing.
+  #
+  # One generator per generated file. This one reads command-index.md when it
+  # assembles the manual; it does not write it.
 }
 
 build_indexes


### PR DESCRIPTION
## What was wrong

Two generators were writing `docs/manual/command-index.md` in incompatible
formats, and neither emitted the frontmatter the site requires.

## 1. Stripped frontmatter

`render_with_liquid: false` is required, not decoration. Jekyll otherwise parses
`{{ ... }}` and `{% ... %}` inside the page, and concept headings come from
manual prose containing both. **Every other doc under `docs/` carries it**,
including `command-index.md`.

`build_indexes()` wrote `concept-index.md` without it, so every run of
`build-manual.sh` stripped it back off. The checked-in file and the generator
disagreed permanently — drift that reproduces on a clean `origin/main` worktree
with no local changes at all.

## 2. The worse half: two owners, one file

`build_indexes()` also generated `command-index.md`:

| | `build-manual.sh` | `generate-command-index.sh` |
| --- | --- | --- |
| source | backticked `` `dot ...` `` scraped from the manual | `dot help all` |
| format | bullet list | table with descriptions |
| frontmatter | none | yes |
| checked by CI | no | **yes** — `Generators / command-index` |

Whichever ran last won. Running `build-manual.sh` alone replaced the table with
a bullet list and dropped the frontmatter — **failing that CI job for reasons
entirely unrelated to whatever the author was doing.** Verified before the fix
by running it and diffing:

```
--- command-index head, after build-manual.sh alone ---
# Command Index

Alphabetical list of `dot` subcommands referenced in the manual.

- `dot add`
- `dot agent`
```

## The fix

- `concept-index` now emits the frontmatter.
- **`command-index` generation is removed from `build_indexes()` entirely.** One
  generator per generated file. `build-manual.sh` still *reads*
  `command-index.md` when assembling the manual; it no longer writes it.

## Verification

After the change, `build-manual.sh`:

- leaves `command-index.md` **untouched** (confirmed via `git status`)
- produces a `concept-index.md` whose only diff is the two concepts genuinely
  added since it was last regenerated — `Agents` and `Registry` — with the
  frontmatter intact
- is **idempotent**: a second run produces no further change

`tests/unit/docs` passes (`test_build_manual.sh`, `test_check_manual.sh`,
`test_roadmap_canonical.sh`). shell-preamble and copyright (933 files) clean.

## Unrelated, left alone

`build-manual.sh` exits 1 locally because `pandoc` is not installed under mise
("No version is set for shim: pandoc"). That reproduces on a clean
`origin/main` worktree, so it is pre-existing and environmental, not introduced
here.

THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co
