### PR TITLE
fix(doctor): stop reporting purgeable macOS caches, and name broken links

### DIFF
--- a/scripts/diagnostics/doctor.sh
+++ b/scripts/diagnostics/doctor.sh
@@ -470,20 +470,33 @@ fi
 
 # --- Symlinks ---
 broken_links=0
+broken_list=""
 for root in "$HOME/.config" "$HOME/.local/bin" "$HOME/.local/share" "$HOME/.ssh"; do
   [[ -d "$root" ]] || continue
   while IFS= read -r -d '' link; do
     link_name="$(basename "$link")"
     [[ "$link" == *"google-chrome-backup"* ]] && continue
     [[ "$link_name" == SingletonLock || "$link_name" == SingletonCookie || "$link_name" == SingletonSocket ]] && continue
-    [[ -e "$link" ]] || broken_links=$((broken_links + 1))
+    [[ -e "$link" ]] && continue
+    # A link into ~/Library/Caches dangling is macOS working as designed, not a
+    # health problem: the OS purges that directory whenever it wants the space,
+    # and the owning tool recreates its cache on next use. ~/.config/swiftpm/cache
+    # -> ~/Library/Caches/org.swift.swiftpm is the usual one; it was "fixed" by
+    # recreating the target earlier the same day and had broken again by evening,
+    # which is the tell that it is not fixable, only re-reported.
+    case "$(readlink "$link" 2>/dev/null)" in
+      "$HOME/Library/Caches/"*) continue ;;
+    esac
+    broken_links=$((broken_links + 1))
+    broken_list="${broken_list:+$broken_list, }$(pretty_path "$link")"
   done < <(find "$root" -maxdepth 3 -type l -print0 2>/dev/null)
 done
 
 if [[ $broken_links -eq 0 ]]; then
   _ok "symlinks" "none broken"
 else
-  _warn "symlinks" "$broken_links broken"
+  # Name them. "1 broken" with no path meant hunting for it by hand, twice.
+  _warn "symlinks" "$broken_links broken: $broken_list"
 fi
 
 # --- Portability ---


### PR DESCRIPTION
Two problems with the same check.

## 1. It reported a condition that cannot be fixed

A symlink into `~/Library/Caches` dangling is **macOS working as designed**, not
a health problem: the OS purges that directory whenever it wants the space, and
the owning tool recreates its cache on next use.

The usual one is `~/.config/swiftpm/cache -> ~/Library/Caches/org.swift.swiftpm`,
created by Xcode and not chezmoi-managed.

The tell that it is *unfixable* rather than *unfixed*: it was "fixed" earlier the
same day by recreating the target, and had broken again by evening.

A check that reports a condition the user cannot resolve trains people to ignore
it — which costs them the next warning that actually matters. The check already
skips Chrome's `SingletonLock`/`SingletonCookie`/`SingletonSocket` for exactly
this reason; this extends the same treatment to purgeable caches.

## 2. It didn't say which link

The warning read `symlinks — 1 broken`, and nothing else. Finding out which one
it meant was a manual `find` across four roots — done **twice in one session**.

It now names them:

```
⚠  symlinks   1 broken: ~/.config/dot-doctor-symlink-probe
```

## Verification

Mutation-tested by planting a genuinely broken link outside the cache path:

| state | result |
| --- | --- |
| broken link planted in `~/.config` | `⚠ 1 broken: ~/.config/dot-doctor-symlink-probe` |
| link removed | `✓ none broken` |

So the exclusion is narrow — it suppresses purgeable-cache targets only, not
broken links generally.

`test_diagnostics_doctor.sh` 11/11, `test_auto_doctor.sh` 6/6, shell-preamble
clean. Warning count on this machine goes **2 → 1**.

THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co
