### PR TITLE
feat(mise): manage pandoc so every machine can build the manual

### DIFF
--- a/defaults/dot_config/mise/conf.d/00-dotfiles.toml
+++ b/defaults/dot_config/mise/conf.d/00-dotfiles.toml
@@ -62,6 +62,13 @@ codex = "latest"
 "github:sebastienrousseau/corral" = "latest"
 eza = "latest"
 gping = "latest"
+# pandoc builds the HTML/PDF/EPUB manual. Without it tools/docs/build-manual.sh
+# exits 1 at the "building HTML single page" step with "No version is set for
+# shim: pandoc", so `dot doctor`'s manual check reports a missing local build on
+# any machine that has not installed it by hand. Managed here rather than in
+# config.toml (which is chezmoi-ignored) so every machine can build the docs,
+# not just the one where someone ran `mise use -g`.
+pandoc = "latest"
 ripgrep = "latest"
 ruff = "latest"
 yazi = "26.5.6"


### PR DESCRIPTION
## What

`tools/docs/build-manual.sh` exits 1 at the "building HTML single page" step
without pandoc:

```
mise ERROR No version is set for shim: pandoc
```

So `dot doctor`'s manual check reports a missing local build on any machine
where nobody has installed it by hand. That was the state on this workstation
until today.

## Why not just `mise use -g`

That writes `~/.config/mise/config.toml`, which is **deliberately
chezmoi-ignored** so mise's own version writes cannot drift the source. The tool
would exist on exactly one machine.

This is the same shape as corralctl before #997, and takes the same fix: move it
into the chezmoi-managed `conf.d` base layer so `mise install` provisions it
everywhere.

The machine-local pin is removed in the same move, so the managed entry is the
only one and there is nothing to drift against.

## Verification

| check | result |
| --- | --- |
| `conf.d/00-dotfiles.toml` | carries `pandoc = "latest"` |
| `config.toml` | no longer does |
| `mise ls` | attributes pandoc to `00-dotfiles.toml` |
| `build-manual.sh` | **exit 0**, all 14 output formats |
| TOML parse | valid, 54 tools |

THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co
