### PR TITLE
fix(chezmoi): ignore ~/Desktop on macOS to prevent apply failure

### DIFF
--- a/defaults/.chezmoiignore.tmpl
+++ b/defaults/.chezmoiignore.tmpl
@@ -109,6 +109,9 @@ lib/**
 {{- end }}
 
 {{- if eq .chezmoi.os "darwin" }}
+# ~/Desktop is a TCC-protected macOS folder; symlinking it into iCloud
+# (see symlink_Desktop.tmpl) cannot replace the real dir and errors on apply.
+Desktop
 .config/i3
 .config/i3/**
 .config/fontconfig


### PR DESCRIPTION
symlink_Desktop.tmpl points ~/Desktop at iCloud, but iCloud/Desktop is a symlink back to ~/Desktop — a circular link chezmoi cannot apply (nor can it remove the TCC-protected ~/Desktop). Ignoring it stops chezmoi update / topgrade failing. Both folders are empty; no data affected.

Signed-off-by: Sebastien Rousseau <sebastian.rousseau@gmail.com>

Assisted-by: Claude:claude-opus-5

THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co