### PR TITLE
fix(chezmoi): stop managing macOS home folders to prevent data loss

### DIFF
--- a/defaults/.chezmoiignore.tmpl
+++ b/defaults/.chezmoiignore.tmpl
@@ -109,13 +109,21 @@ lib/**
 {{- end }}
 
 {{- if eq .chezmoi.os "darwin" }}
-# TCC-protected macOS home folders: the symlink_*.tmpl entries try to route
-# these into iCloud, but chezmoi cannot remove the real dirs to replace them,
-# so apply errors. iCloud sync for these isn't set up (targets are circular
-# symlinks / separate folders), so ignore them here.
+# DO NOT let chezmoi manage these macOS home folders. The former symlink_*.tmpl
+# entries told chezmoi to replace them with iCloud symlinks; because chezmoi
+# removes the existing directory *recursively*, an apply deleted the real
+# ~/Documents contents. Those symlink_*.tmpl sources have been removed, and
+# these folders are ignored here so chezmoi can never touch or delete them
+# again. Set up any iCloud symlinks manually, outside chezmoi.
 Desktop
 Documents
+Downloads
+Drop
+Movies
+Music
+Pictures
 Public
+Safe
 .config/i3
 .config/i3/**
 .config/fontconfig

--- a/defaults/symlink_Desktop.tmpl
+++ b/defaults/symlink_Desktop.tmpl
@@ -1,3 +1,0 @@
-{{- if eq .chezmoi.os "darwin" -}}
-{{ .chezmoi.homeDir }}/Library/Mobile Documents/com~apple~CloudDocs/Desktop
-{{- end -}}

--- a/defaults/symlink_Documents.tmpl
+++ b/defaults/symlink_Documents.tmpl
@@ -1,3 +1,0 @@
-{{- if eq .chezmoi.os "darwin" -}}
-{{ .chezmoi.homeDir }}/Library/Mobile Documents/com~apple~CloudDocs/Documents
-{{- end -}}

--- a/defaults/symlink_Downloads.tmpl
+++ b/defaults/symlink_Downloads.tmpl
@@ -1,3 +1,0 @@
-{{- if eq .chezmoi.os "darwin" -}}
-{{ .chezmoi.homeDir }}/Library/Mobile Documents/com~apple~CloudDocs/Downloads
-{{- end -}}

--- a/defaults/symlink_Drop.tmpl
+++ b/defaults/symlink_Drop.tmpl
@@ -1,3 +1,0 @@
-{{- if eq .chezmoi.os "darwin" -}}
-{{ .chezmoi.homeDir }}/Library/Mobile Documents/com~apple~CloudDocs/Drop
-{{- end -}}

--- a/defaults/symlink_Movies.tmpl
+++ b/defaults/symlink_Movies.tmpl
@@ -1,3 +1,0 @@
-{{- if eq .chezmoi.os "darwin" -}}
-{{ .chezmoi.homeDir }}/Library/Mobile Documents/com~apple~CloudDocs/Movies
-{{- end -}}

--- a/defaults/symlink_Music.tmpl
+++ b/defaults/symlink_Music.tmpl
@@ -1,3 +1,0 @@
-{{- if eq .chezmoi.os "darwin" -}}
-{{ .chezmoi.homeDir }}/Library/Mobile Documents/com~apple~CloudDocs/Music
-{{- end -}}

--- a/defaults/symlink_Pictures.tmpl
+++ b/defaults/symlink_Pictures.tmpl
@@ -1,3 +1,0 @@
-{{- if eq .chezmoi.os "darwin" -}}
-{{ .chezmoi.homeDir }}/Library/Mobile Documents/com~apple~CloudDocs/Pictures
-{{- end -}}

--- a/defaults/symlink_Public.tmpl
+++ b/defaults/symlink_Public.tmpl
@@ -1,3 +1,0 @@
-{{- if eq .chezmoi.os "darwin" -}}
-{{ .chezmoi.homeDir }}/Library/Mobile Documents/com~apple~CloudDocs/Public
-{{- end -}}

--- a/defaults/symlink_Safe.tmpl
+++ b/defaults/symlink_Safe.tmpl
@@ -1,3 +1,0 @@
-{{- if eq .chezmoi.os "darwin" -}}
-{{ .chezmoi.homeDir }}/Library/Mobile Documents/com~apple~CloudDocs/Safe
-{{- end -}}


### PR DESCRIPTION
Remove the symlink_*.tmpl home-folder entries and ignore those 9 folders on macOS. chezmoi recursively deletes a directory before replacing it with a symlink, which wiped ~/Documents; this prevents any recurrence. Existing on-disk symlinks are untouched.

THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co