### PR TITLE
ci: exempt bot-authored PRs from the signature gate

### DIFF
--- a/.github/workflows/pr-signature.yml
+++ b/.github/workflows/pr-signature.yml
@@ -11,6 +11,15 @@ permissions:
 jobs:
   check-signature:
     name: Verify PR description signature
+    # The signature is a human attestation of authorship. A bot cannot
+    # make it, so requiring it of bot-authored PRs makes them
+    # permanently unmergeable rather than unsigned — nine Dependabot
+    # updates were stuck on exactly this. Skipping is the honest
+    # outcome: an absent signature on a Dependabot PR is accurate.
+    if: >-
+      github.event.pull_request.user.login != 'dependabot[bot]' &&
+      github.event.pull_request.user.login != 'dependabot-preview[bot]' &&
+      github.event.pull_request.user.login != 'github-actions[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Harden runner (block mode)


### PR DESCRIPTION
The `Verify PR description signature` gate requires the PR body to carry a personal signature. That is a human attestation of authorship — **a bot cannot make it**, so the gate does not mark bot PRs unsigned, it makes them permanently unmergeable. Nine Dependabot updates are currently stuck on exactly this.

Skips for `dependabot[bot]`, `dependabot-preview[bot]` and `github-actions[bot]`. Human-authored PRs are unaffected.

## This PR cannot pass its own gate

I am not a bot, so the gate applies here too — and the signature is yours to give, not mine to write on your behalf. **This needs the signature block appended to this PR's description by you**, after which it will go green.

The same applies to #1017 (the licence sweep), which is blocked on the same check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)