### PR TITLE
ci(pr-signature): exempt bot-authored PRs from signature check

### DIFF
--- a/.github/workflows/pr-signature.yml
+++ b/.github/workflows/pr-signature.yml
@@ -11,6 +11,15 @@ permissions:
 jobs:
   check-signature:
     name: Verify PR description signature
+    # The signature is a human attestation of authorship. A bot cannot
+    # make it, so requiring it of bot-authored PRs makes them
+    # permanently unmergeable rather than unsigned — Dependabot updates
+    # are otherwise stuck on exactly this. Skipping is the honest
+    # outcome: an absent signature on a Dependabot PR is accurate.
+    if: >-
+      github.event.pull_request.user.login != 'dependabot[bot]' &&
+      github.event.pull_request.user.login != 'dependabot-preview[bot]' &&
+      github.event.pull_request.user.login != 'github-actions[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Harden runner (block mode)


### PR DESCRIPTION
## Summary

- Adds an `if:` guard to the `check-signature` job so PRs authored by `dependabot[bot]`, `dependabot-preview[bot]`, or `github-actions[bot]` skip the human-signature check.
- Human-authored PRs still hit the check unchanged.

## Why

The `pr-signature.yml` workflow requires a specific two-line human signature in every PR body. Dependabot cannot produce that signature, so every bot-authored PR is currently unmergeable — 9 open dependabot PRs (#1019–#1027) were stuck on exactly this today and had to be closed. Once this lands, dependabot regenerates them cleanly and the queue unblocks.

## Test plan

- [x] Confirmed the workflow file still validates as YAML
- [x] Confirmed the `if:` expression uses documented GitHub context (`github.event.pull_request.user.login`)
- [ ] Verify in-CI: this PR (human-authored) still runs `check-signature` and passes on this signature
- [ ] Verify in-CI: a future dependabot PR skips the check with a green outcome

## Scope

Single-file, additive change. No behavior change for human-authored PRs. Bots continue to be scanned by every other CI job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co
