### PR TITLE
fix(qa): docs-coverage.sh no longer masks its own exit code

### DIFF
--- a/scripts/qa/docs-coverage.sh
+++ b/scripts/qa/docs-coverage.sh
@@ -104,7 +104,13 @@ main() {
   check_ai_provider_docs
   check_utility_docs
   check_function_group_docs
-  report_coverage
+  # Capture the coverage threshold verdict — without this the final
+  # `printf PASS...` overwrites report_coverage's exit code and CI
+  # never sees a coverage regression.
+  if ! report_coverage; then
+    printf 'FAIL: docs coverage below MIN_DOCS_COVERAGE=%s%%\n' "$MIN_DOCS_COVERAGE" >&2
+    return 1
+  fi
 
   printf 'PASS: public dot commands, utility entrypoints, AI providers, and function groups are documented at or above the required threshold\n'
 }


### PR DESCRIPTION
## Summary

`scripts/qa/docs-coverage.sh`'s coverage-threshold gate is silently a no-op today. `report_coverage` ends with `awk 'BEGIN{exit !(p+0 >= min+0)}'` which correctly returns non-zero when below threshold — but `main()` then unconditionally prints `PASS: ...`, which returns 0 and overwrites the awk exit code.

## Reproducer (against current main)

```console
$ MIN_DOCS_COVERAGE=101 bash scripts/qa/docs-coverage.sh > /dev/null; echo "exit=$?"
exit=0                                       # ← should be 1
```

## Fix

Capture `report_coverage`'s return value with `if ! …`; print an explicit `FAIL:` line to stderr and `return 1` on regression.

## Verified

- `MIN_DOCS_COVERAGE=100` → exit 0 (was 0) ✓
- `MIN_DOCS_COVERAGE=101` → exit 1 (was 0) ✓
- `bash -n scripts/qa/docs-coverage.sh` clean

## Scope

Single file, 7-line addition. No behavior change when coverage is at or above threshold. Only affects the below-threshold path — which was the whole point of the gate.

## Test plan

- [x] Manual reproducer with contrived threshold
- [x] Bash syntax check
- [ ] CI: `MIN_DOCS_COVERAGE=100 bash scripts/qa/docs-coverage.sh` still passes on this PR (should — main is at 206/206)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co
