### PR TITLE
test(regression): help registry symmetry — phantom + functional gate

### DIFF
--- a/tests/regression/test_dot_help_registry_symmetry.sh
+++ b/tests/regression/test_dot_help_registry_symmetry.sh
@@ -19,8 +19,13 @@
 #   2. Functional drift: `dot help <cmd>` actually invoked for every
 #      routed command; must not return "Unknown help topic" (soft —
 #      HIDDEN_FROM_HELP exemption matches the smoke test).
+#
+# Bash 3.2 compatible: macOS stock bash is 3.2 and CI runs on
+# macos-14 / macos-latest with the stock shell. Avoid associative
+# arrays, mapfile, and `set -e` + `((VAR++))` (returns 0 the first
+# time and kills the shell under `set -e`).
 
-set -euo pipefail
+set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
@@ -29,7 +34,7 @@ source "$SCRIPT_DIR/../framework/assertions.sh"
 DOT_CLI="$REPO_ROOT/bin/dot"
 
 # Sandbox HOME to keep help invocations off real user state.
-sandbox="$(mktemp -d -t help-symmetry.XXXXXX)"
+sandbox="$(mktemp -d 2>/dev/null || mktemp -d -t 'help-symmetry')"
 trap 'rm -rf "$sandbox"' EXIT
 export HOME="$sandbox" \
   XDG_CONFIG_HOME="$sandbox/.config" \
@@ -40,50 +45,65 @@ export HOME="$sandbox" \
 mkdir -p "$XDG_CONFIG_HOME" "$XDG_DATA_HOME" "$XDG_CACHE_HOME" "$XDG_STATE_HOME"
 
 # ---------------------------------------------------------------------------
-# Extract the 3 registries.
+# Extract the 3 registries as plain arrays (bash 3.2 compatible).
 # ---------------------------------------------------------------------------
 routes=()
-while IFS= read -r line; do routes+=("$line"); done < <(
+while IFS= read -r line; do
+  routes[${#routes[@]}]="$line"
+done < <(
   awk '/^_dot_command_routes\(\)/,/^\}/' "$DOT_CLI" |
     awk -F'|' '/^[a-z][a-z0-9-]*\|[a-z]+$/ { print $1 }' |
     sort -u
 )
 
 specs=()
-while IFS= read -r line; do specs+=("$line"); done < <(
+while IFS= read -r line; do
+  specs[${#specs[@]}]="$line"
+done < <(
   awk '/^_dot_help_specs\(\)/,/^\}/' "$DOT_CLI" |
     awk -F'|' 'NF >= 2 && $2 ~ /^[a-z][a-z0-9-]*$/ { print $2 }' |
     sort -u
 )
 
 details=()
-while IFS= read -r line; do details+=("$line"); done < <(
+while IFS= read -r line; do
+  details[${#details[@]}]="$line"
+done < <(
   awk '/^_dot_help_details\(\)/,/^\}/' "$DOT_CLI" |
     awk -F'|' '$1 ~ /^[a-z][a-z0-9-]*$/ { print $1 }' |
     sort -u
 )
 
-declare -A ROUTES=()
-for c in "${routes[@]}"; do ROUTES["$c"]=1; done
+# Membership check via linear scan — same performance profile at
+# these list sizes as declare -A. Portable to bash 3.2.
+_in_list() {
+  local needle="$1"
+  shift
+  local item
+  for item in "$@"; do
+    [ "$item" = "$needle" ] && return 0
+  done
+  return 1
+}
 
 # ---------------------------------------------------------------------------
 # 0. Sanity: parsers found entries.
 # ---------------------------------------------------------------------------
 test_start "route_table_nonempty"
-if [[ ${#routes[@]} -ge 30 ]]; then
-  ((TESTS_PASSED++)) || true
+if [ ${#routes[@]} -ge 30 ]; then
+  TESTS_PASSED=$((TESTS_PASSED + 1))
   printf '  \033[0;32m✓\033[0m %s: %d routes\n' "$CURRENT_TEST" "${#routes[@]}"
 else
-  ((TESTS_FAILED++)) || true
+  TESTS_FAILED=$((TESTS_FAILED + 1))
   printf '  \033[0;31m✗\033[0m %s: only %d routes — parser broken?\n' "$CURRENT_TEST" "${#routes[@]}"
 fi
 
 test_start "help_tables_nonempty"
-if [[ ${#specs[@]} -ge 30 && ${#details[@]} -ge 30 ]]; then
-  ((TESTS_PASSED++)) || true
+if [ ${#specs[@]} -ge 30 ] && [ ${#details[@]} -ge 30 ]; then
+  TESTS_PASSED=$((TESTS_PASSED + 1))
   printf '  \033[0;32m✓\033[0m %s: %d specs + %d details\n' "$CURRENT_TEST" "${#specs[@]}" "${#details[@]}"
 else
-  ((TESTS_FAILED++)) || true
+  TESTS_FAILED=$((TESTS_FAILED + 1))
   printf '  \033[0;31m✗\033[0m %s: specs=%d details=%d\n' "$CURRENT_TEST" "${#specs[@]}" "${#details[@]}"
 fi
 
@@ -93,26 +113,30 @@ fi
 test_start "no_phantom_help_specs"
 phantom_specs=()
 for c in "${specs[@]}"; do
-  [[ -z "${ROUTES[$c]:-}" ]] && phantom_specs+=("$c")
+  if ! _in_list "$c" "${routes[@]}"; then
+    phantom_specs[${#phantom_specs[@]}]="$c"
+  fi
 done
-if [[ ${#phantom_specs[@]} -eq 0 ]]; then
-  ((TESTS_PASSED++)) || true
+if [ ${#phantom_specs[@]} -eq 0 ]; then
+  TESTS_PASSED=$((TESTS_PASSED + 1))
   printf '  \033[0;32m✓\033[0m %s\n' "$CURRENT_TEST"
 else
-  ((TESTS_FAILED++)) || true
+  TESTS_FAILED=$((TESTS_FAILED + 1))
   printf '  \033[0;31m✗\033[0m %s: %s\n' "$CURRENT_TEST" "${phantom_specs[*]}"
 fi
 
 test_start "no_phantom_help_details"
 phantom_details=()
 for c in "${details[@]}"; do
-  [[ -z "${ROUTES[$c]:-}" ]] && phantom_details+=("$c")
+  if ! _in_list "$c" "${routes[@]}"; then
+    phantom_details[${#phantom_details[@]}]="$c"
+  fi
 done
-if [[ ${#phantom_details[@]} -eq 0 ]]; then
-  ((TESTS_PASSED++)) || true
+if [ ${#phantom_details[@]} -eq 0 ]; then
+  TESTS_PASSED=$((TESTS_PASSED + 1))
   printf '  \033[0;32m✓\033[0m %s\n' "$CURRENT_TEST"
 else
-  ((TESTS_FAILED++)) || true
+  TESTS_FAILED=$((TESTS_FAILED + 1))
   printf '  \033[0;31m✗\033[0m %s: %s\n' "$CURRENT_TEST" "${phantom_details[*]}"
 fi
 
@@ -121,49 +145,42 @@ fi
 #    for any routed command. Uses the same HIDDEN_FROM_HELP exemption
 #    as tests/regression/test_dot_subcommand_smoke.sh for consistency.
 # ---------------------------------------------------------------------------
-HIDDEN_FROM_HELP=(
-  apply update scorecard attestation security-score
-  health health-check smoke-test heal drift intelligence
-  conflicts locks log-rotate alias-check setup setup-mode
-  load-bench-pty
-  agents init registry manual patterns
-)
-
-_is_hidden() {
-  local n="$1"
-  local h
-  for h in "${HIDDEN_FROM_HELP[@]}"; do
-    [[ "$h" == "$n" ]] && return 0
-  done
-  return 1
-}
+HIDDEN_FROM_HELP="apply update scorecard attestation security-score health health-check smoke-test heal drift intelligence conflicts locks log-rotate alias-check setup setup-mode load-bench-pty agents init registry manual patterns"
 
 test_start "dot_help_cmd_works_for_every_visible_command"
 broken=()
 skipped=0
 for cmd in "${routes[@]}"; do
   # Meta routes never take `dot help`
-  case "$cmd" in
-    help|--help|-h|version|--version|-v) continue ;;
+  case " help --help -h version --version -v " in
+    *" $cmd "*) continue ;;
   esac
-  if _is_hidden "$cmd"; then
-    skipped=$((skipped + 1))
-    continue
+  # Hidden-from-help exemption
+  case " $HIDDEN_FROM_HELP " in
+    *" $cmd "*) skipped=$((skipped + 1)); continue ;;
+  esac
+  # timeout is GNU-only; use gtimeout on macOS if available, otherwise
+  # trust bash to bound the help invocation (it's in-process).
+  if command -v timeout >/dev/null 2>&1; then
+    out="$(timeout 5 bash "$DOT_CLI" help "$cmd" 2>&1 || true)"
+  elif command -v gtimeout >/dev/null 2>&1; then
+    out="$(gtimeout 5 bash "$DOT_CLI" help "$cmd" 2>&1 || true)"
+  else
+    out="$(bash "$DOT_CLI" help "$cmd" 2>&1 || true)"
   fi
-  out="$(timeout 5 bash "$DOT_CLI" help "$cmd" 2>&1 || true)"
-  # ANSI-strip the output before matching (help formatter emits color).
-  clean="${out//$'\x1b'[??]*[mK]/}"
-  if [[ "$clean" == *"Unknown help topic"* ]]; then
-    broken+=("$cmd")
-  fi
+  # ANSI-strip via sed for portability.
+  clean="$(printf '%s' "$out" | sed 's/\x1b\[[0-9;]*[mK]//g')"
+  case "$clean" in
+    *"Unknown help topic"*) broken[${#broken[@]}]="$cmd" ;;
+  esac
 done
-if [[ ${#broken[@]} -eq 0 ]]; then
-  ((TESTS_PASSED++)) || true
-  visible_count=$(( ${#routes[@]} - skipped - 6 ))
+if [ ${#broken[@]} -eq 0 ]; then
+  TESTS_PASSED=$((TESTS_PASSED + 1))
+  visible_count=$((${#routes[@]} - skipped - 6))
   printf '  \033[0;32m✓\033[0m %s: %d visible commands answered, %d hidden skipped\n' \
     "$CURRENT_TEST" "$visible_count" "$skipped"
 else
-  ((TESTS_FAILED++)) || true
+  TESTS_FAILED=$((TESTS_FAILED + 1))
   printf '  \033[0;31m✗\033[0m %s: Unknown help topic for: %s\n' "$CURRENT_TEST" "${broken[*]}"
 fi
 

--- a/tests/regression/test_dot_help_registry_symmetry.sh
+++ b/tests/regression/test_dot_help_registry_symmetry.sh
@@ -81,7 +81,7 @@ _in_list() {
   shift
   local item
   for item in "$@"; do
-    [ "$item" = "$needle" ] && return 0
+    [[ "$item" = "$needle" ]] && return 0
   done
   return 1
 }
@@ -90,7 +90,7 @@ _in_list() {
 # 0. Sanity: parsers found entries.
 # ---------------------------------------------------------------------------
 test_start "route_table_nonempty"
-if [ ${#routes[@]} -ge 30 ]; then
+if [[ ${#routes[@]} -ge 30 ]]; then
   TESTS_PASSED=$((TESTS_PASSED + 1))
   printf '  \033[0;32m✓\033[0m %s: %d routes\n' "$CURRENT_TEST" "${#routes[@]}"
 else
@@ -99,7 +99,7 @@ else
 fi
 
 test_start "help_tables_nonempty"
-if [ ${#specs[@]} -ge 30 ] && [ ${#details[@]} -ge 30 ]; then
+if [[ ${#specs[@]} -ge 30 && ${#details[@]} -ge 30 ]]; then
   TESTS_PASSED=$((TESTS_PASSED + 1))
   printf '  \033[0;32m✓\033[0m %s: %d specs + %d details\n' "$CURRENT_TEST" "${#specs[@]}" "${#details[@]}"
 else
@@ -117,7 +117,7 @@ for c in "${specs[@]}"; do
     phantom_specs[${#phantom_specs[@]}]="$c"
   fi
 done
-if [ ${#phantom_specs[@]} -eq 0 ]; then
+if [[ ${#phantom_specs[@]} -eq 0 ]]; then
   TESTS_PASSED=$((TESTS_PASSED + 1))
   printf '  \033[0;32m✓\033[0m %s\n' "$CURRENT_TEST"
 else
@@ -132,7 +132,7 @@ for c in "${details[@]}"; do
     phantom_details[${#phantom_details[@]}]="$c"
   fi
 done
-if [ ${#phantom_details[@]} -eq 0 ]; then
+if [[ ${#phantom_details[@]} -eq 0 ]]; then
   TESTS_PASSED=$((TESTS_PASSED + 1))
   printf '  \033[0;32m✓\033[0m %s\n' "$CURRENT_TEST"
 else
@@ -174,7 +174,7 @@ for cmd in "${routes[@]}"; do
     *"Unknown help topic"*) broken[${#broken[@]}]="$cmd" ;;
   esac
 done
-if [ ${#broken[@]} -eq 0 ]; then
+if [[ ${#broken[@]} -eq 0 ]]; then
   TESTS_PASSED=$((TESTS_PASSED + 1))
   visible_count=$((${#routes[@]} - skipped - 6))
   printf '  \033[0;32m✓\033[0m %s: %d visible commands answered, %d hidden skipped\n' \

--- a/tests/regression/test_dot_help_registry_symmetry.sh
+++ b/tests/regression/test_dot_help_registry_symmetry.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2015-2026 Sebastien Rousseau
+# shellcheck disable=SC1090,SC1091,SC2034
+# Symmetry ratchet between bin/dot's three static registries:
+#   * _dot_command_routes()  — every command the dispatcher can route
+#   * _dot_help_specs()      — every command shown in the compact overview
+#   * _dot_help_details()    — every command with a detailed body
+#
+# `_dot_help_summary()` reads details first, then falls back to specs.
+# So a command with only a specs entry still works — this test does
+# NOT require details entries for every spec.
+#
+# What this test catches (that test_dot_subcommand_smoke.sh doesn't):
+#
+#   1. Phantom help topics: entries in _dot_help_specs or
+#      _dot_help_details that don't map to any real route (leftover
+#      after a route was renamed/removed).
+#   2. Functional drift: `dot help <cmd>` actually invoked for every
+#      routed command; must not return "Unknown help topic" (soft —
+#      HIDDEN_FROM_HELP exemption matches the smoke test).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+source "$SCRIPT_DIR/../framework/assertions.sh"
+
+DOT_CLI="$REPO_ROOT/bin/dot"
+
+# Sandbox HOME to keep help invocations off real user state.
+sandbox="$(mktemp -d -t help-symmetry.XXXXXX)"
+trap 'rm -rf "$sandbox"' EXIT
+export HOME="$sandbox" \
+  XDG_CONFIG_HOME="$sandbox/.config" \
+  XDG_DATA_HOME="$sandbox/.local/share" \
+  XDG_CACHE_HOME="$sandbox/.cache" \
+  XDG_STATE_HOME="$sandbox/.local/state" \
+  CHEZMOI_SOURCE_DIR="$REPO_ROOT"
+mkdir -p "$XDG_CONFIG_HOME" "$XDG_DATA_HOME" "$XDG_CACHE_HOME" "$XDG_STATE_HOME"
+
+# ---------------------------------------------------------------------------
+# Extract the 3 registries.
+# ---------------------------------------------------------------------------
+routes=()
+while IFS= read -r line; do routes+=("$line"); done < <(
+  awk '/^_dot_command_routes\(\)/,/^\}/' "$DOT_CLI" |
+    awk -F'|' '/^[a-z][a-z0-9-]*\|[a-z]+$/ { print $1 }' |
+    sort -u
+)
+
+specs=()
+while IFS= read -r line; do specs+=("$line"); done < <(
+  awk '/^_dot_help_specs\(\)/,/^\}/' "$DOT_CLI" |
+    awk -F'|' 'NF >= 2 && $2 ~ /^[a-z][a-z0-9-]*$/ { print $2 }' |
+    sort -u
+)
+
+details=()
+while IFS= read -r line; do details+=("$line"); done < <(
+  awk '/^_dot_help_details\(\)/,/^\}/' "$DOT_CLI" |
+    awk -F'|' '$1 ~ /^[a-z][a-z0-9-]*$/ { print $1 }' |
+    sort -u
+)
+
+declare -A ROUTES=()
+for c in "${routes[@]}"; do ROUTES["$c"]=1; done
+
+# ---------------------------------------------------------------------------
+# 0. Sanity: parsers found entries.
+# ---------------------------------------------------------------------------
+test_start "route_table_nonempty"
+if [[ ${#routes[@]} -ge 30 ]]; then
+  ((TESTS_PASSED++)) || true
+  printf '  \033[0;32m✓\033[0m %s: %d routes\n' "$CURRENT_TEST" "${#routes[@]}"
+else
+  ((TESTS_FAILED++)) || true
+  printf '  \033[0;31m✗\033[0m %s: only %d routes — parser broken?\n' "$CURRENT_TEST" "${#routes[@]}"
+fi
+
+test_start "help_tables_nonempty"
+if [[ ${#specs[@]} -ge 30 && ${#details[@]} -ge 30 ]]; then
+  ((TESTS_PASSED++)) || true
+  printf '  \033[0;32m✓\033[0m %s: %d specs + %d details\n' "$CURRENT_TEST" "${#specs[@]}" "${#details[@]}"
+else
+  ((TESTS_FAILED++)) || true
+  printf '  \033[0;31m✗\033[0m %s: specs=%d details=%d\n' "$CURRENT_TEST" "${#specs[@]}" "${#details[@]}"
+fi
+
+# ---------------------------------------------------------------------------
+# 1. Phantom entries — help text for a topic no route can dispatch.
+# ---------------------------------------------------------------------------
+test_start "no_phantom_help_specs"
+phantom_specs=()
+for c in "${specs[@]}"; do
+  [[ -z "${ROUTES[$c]:-}" ]] && phantom_specs+=("$c")
+done
+if [[ ${#phantom_specs[@]} -eq 0 ]]; then
+  ((TESTS_PASSED++)) || true
+  printf '  \033[0;32m✓\033[0m %s\n' "$CURRENT_TEST"
+else
+  ((TESTS_FAILED++)) || true
+  printf '  \033[0;31m✗\033[0m %s: %s\n' "$CURRENT_TEST" "${phantom_specs[*]}"
+fi
+
+test_start "no_phantom_help_details"
+phantom_details=()
+for c in "${details[@]}"; do
+  [[ -z "${ROUTES[$c]:-}" ]] && phantom_details+=("$c")
+done
+if [[ ${#phantom_details[@]} -eq 0 ]]; then
+  ((TESTS_PASSED++)) || true
+  printf '  \033[0;32m✓\033[0m %s\n' "$CURRENT_TEST"
+else
+  ((TESTS_FAILED++)) || true
+  printf '  \033[0;31m✗\033[0m %s: %s\n' "$CURRENT_TEST" "${phantom_details[*]}"
+fi
+
+# ---------------------------------------------------------------------------
+# 2. Functional gate — `dot help <cmd>` must not return "Unknown"
+#    for any routed command. Uses the same HIDDEN_FROM_HELP exemption
+#    as tests/regression/test_dot_subcommand_smoke.sh for consistency.
+# ---------------------------------------------------------------------------
+HIDDEN_FROM_HELP=(
+  apply update scorecard attestation security-score
+  health health-check smoke-test heal drift intelligence
+  conflicts locks log-rotate alias-check setup setup-mode
+  load-bench-pty
+  agents init registry manual patterns
+)
+
+_is_hidden() {
+  local n="$1"
+  local h
+  for h in "${HIDDEN_FROM_HELP[@]}"; do
+    [[ "$h" == "$n" ]] && return 0
+  done
+  return 1
+}
+
+test_start "dot_help_cmd_works_for_every_visible_command"
+broken=()
+skipped=0
+for cmd in "${routes[@]}"; do
+  # Meta routes never take `dot help`
+  case "$cmd" in
+    help|--help|-h|version|--version|-v) continue ;;
+  esac
+  if _is_hidden "$cmd"; then
+    skipped=$((skipped + 1))
+    continue
+  fi
+  out="$(timeout 5 bash "$DOT_CLI" help "$cmd" 2>&1 || true)"
+  # ANSI-strip the output before matching (help formatter emits color).
+  clean="${out//$'\x1b'[??]*[mK]/}"
+  if [[ "$clean" == *"Unknown help topic"* ]]; then
+    broken+=("$cmd")
+  fi
+done
+if [[ ${#broken[@]} -eq 0 ]]; then
+  ((TESTS_PASSED++)) || true
+  visible_count=$(( ${#routes[@]} - skipped - 6 ))
+  printf '  \033[0;32m✓\033[0m %s: %d visible commands answered, %d hidden skipped\n' \
+    "$CURRENT_TEST" "$visible_count" "$skipped"
+else
+  ((TESTS_FAILED++)) || true
+  printf '  \033[0;31m✗\033[0m %s: Unknown help topic for: %s\n' "$CURRENT_TEST" "${broken[*]}"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+printf '\n  Tests: %d  \033[0;32mPassed: %d\033[0m  \033[0;31mFailed: %d\033[0m\n' \
+  "$TESTS_RUN" "$TESTS_PASSED" "$TESTS_FAILED"
+printf 'RESULTS:%d:%d:%d\n' "$TESTS_RUN" "$TESTS_PASSED" "$TESTS_FAILED"
+exit "$TESTS_FAILED"


### PR DESCRIPTION
## Summary

Adds `tests/regression/test_dot_help_registry_symmetry.sh` — a small (176 line, ~1.3s) ratchet that complements the existing `test_dot_subcommand_smoke.sh` with two gaps it doesn't cover.

## Gaps closed

### 1. Phantom help topics

An entry in `_dot_help_specs` or `_dot_help_details` that has no matching route in `_dot_command_routes`. These are leftover documentation after a route rename/removal — `dot help <cmd>` returns text for a command that no longer dispatches.

Currently: 0 phantoms in either table (`main` is clean today). The ratchet locks it in.

### 2. Functional help gate

Actually invokes `bash bin/dot help <cmd>` for every routed command and fails if any returns "Unknown help topic". The existing smoke test checks table entries statically; this one exercises the runtime path (which includes `_dot_help_summary`'s specs→details fallback).

Uses the same `HIDDEN_FROM_HELP` exemption as `test_dot_subcommand_smoke.sh` so the two stay in lockstep on which commands are intentionally hidden.

Result today: 75 visible commands answer correctly, 22 hidden skipped.

## Test plan

- [x] `bash tests/regression/test_dot_help_registry_symmetry.sh` → 5/5 pass, 0 fail, exit 0
- [x] `bash -n` clean
- [x] Sandbox HOME so help invocations don't touch real user state
- [x] Runs in ~1.3s

## Scope

Single new file. Purely additive. Zero changes to `bin/dot` or the help tables. If a real phantom or functional break exists, it will surface; today `main` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co
