### PR TITLE
fix(qa): traceability-coverage.sh no longer masks its own exit code

### DIFF
--- a/scripts/qa/traceability-coverage.sh
+++ b/scripts/qa/traceability-coverage.sh
@@ -109,7 +109,14 @@ main() {
     } | sort -u
   )
 
-  report_traceability
+  # Capture report_traceability's exit — without this the trailing
+  # `printf PASS...` returns 0 and overwrites the awk threshold verdict,
+  # so a below-threshold run silently exits 0 (same bug as docs-coverage.sh).
+  if ! report_traceability; then
+    printf 'FAIL: traceability coverage below MIN_TRACEABILITY_COVERAGE=%s%%\n' \
+      "$MIN_TRACEABILITY_COVERAGE" >&2
+    return 1
+  fi
 
   printf 'PASS: core internal behaviors have implementation, test, and documentation traceability at or above the required threshold\n'
 }


### PR DESCRIPTION
## Summary

Same class of bug as #1032 but in `scripts/qa/traceability-coverage.sh`. `report_traceability` ends with `awk 'BEGIN{exit !(p+0 >= min+0)}'` which correctly returns non-zero when below threshold — but `main()` then unconditionally prints `PASS: ...`, which returns 0 and overwrites the awk exit code.

## Reproducer (against current main)

```console
$ MIN_TRACEABILITY_COVERAGE=101 bash scripts/qa/traceability-coverage.sh > /dev/null; echo "exit=$?"
exit=0                                       # ← should be 1
```

## Fix

Capture `report_traceability`'s return value with `if ! …`; print an explicit `FAIL:` line to stderr and `return 1` on regression.

## Verified

- `MIN_TRACEABILITY_COVERAGE=100` with 100.00% coverage → exit 0 (was 0) ✓
- `MIN_TRACEABILITY_COVERAGE=101` with 100.00% coverage → exit 1 (was 0) ✓
- `bash -n scripts/qa/traceability-coverage.sh` clean

## Scope

Single file, 8-line addition. No behavior change when at or above threshold. Companion PR to #1032 (which fixes the same pattern in `docs-coverage.sh`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co
