### PR TITLE
fix(chezmoi): non-interactive init in CI / drift detection

### DIFF
--- a/defaults/.chezmoi.toml.tmpl
+++ b/defaults/.chezmoi.toml.tmpl
@@ -5,10 +5,20 @@ sourceDir = "{{ .chezmoi.homeDir }}/.dotfiles"
 # Variable fallback - Age encryption variables with fallback chain:
 # promptString function behavior:
 # - If value exists in chezmoi data: use stored value
-# - If value doesn't exist: prompt user with default shown in quotes
-# - User response gets stored for future runs (no re-prompting)
-{{ $age_identity := promptString "age_identity" "~/.config/chezmoi/key.txt" }}
-{{ $age_recipient := promptString "age_recipient" "" }}
+# - If value doesn't exist AND stdin is a TTY: prompt user
+# - Non-interactive (CI, drift detection): silently use the default so
+#   `chezmoi init --apply=false` doesn't die on "could not open a new TTY".
+#   Override in CI via CHEZMOI_AGE_IDENTITY / CHEZMOI_AGE_RECIPIENT env vars.
+{{- $age_identity := "" }}
+{{- $age_recipient := "" }}
+{{- if stdinIsATTY }}
+{{-   $age_identity = promptString "age_identity" "~/.config/chezmoi/key.txt" }}
+{{-   $age_recipient = promptString "age_recipient" "" }}
+{{- else }}
+{{-   $age_identity = env "CHEZMOI_AGE_IDENTITY" }}
+{{-   if eq $age_identity "" }}{{ $age_identity = "~/.config/chezmoi/key.txt" }}{{ end }}
+{{-   $age_recipient = env "CHEZMOI_AGE_RECIPIENT" }}
+{{- end }}
 
 # Conditional encryption block - only enable if age_identity is provided
 # Template control flow: "if ne $age_identity" checks if variable is not empty
@@ -32,18 +42,17 @@ encryption = "age"
     command = "vimdiff"
 
 [data]
-# User profile data with promptString fallback chains
-# promptString fallback mechanism:
-# 1. Check ~/.config/chezmoi/chezmoi.toml [data] section for existing value
-# 2. If found: use stored value (no prompting)
-# 3. If not found: prompt user with default value shown
-# 4. Store user response in chezmoi data for future template executions
-profile = "{{ promptString "profile" "laptop" }}"                    # Device type fallback
-theme = "{{ promptString "theme" "tokyonight-night" }}"              # Color scheme fallback
-git_name = "{{ promptString "git_name" "Your Name" }}"               # Git author name fallback
-git_email = "{{ promptString "git_email" "you@example.com" }}"       # Git author email fallback
-git_signingkey = "{{ promptString "git_signingkey" "~/.ssh/id_ed25519" }}" # Git signing key path fallback
-git_signingformat = "{{ promptString "git_signingformat" "ssh" }}"   # Git signing format fallback
+# User profile data with promptString fallback chains.
+# Interactive path: prompt with the shown default; stored for next run.
+# Non-interactive path (CI, drift detection): fall through to the same
+# default silently so `chezmoi init --apply=false` succeeds without a TTY.
+{{- $tty := stdinIsATTY }}
+profile           = "{{ if $tty }}{{ promptString "profile" "laptop" }}{{ else }}laptop{{ end }}"
+theme             = "{{ if $tty }}{{ promptString "theme" "tokyonight-night" }}{{ else }}tokyonight-night{{ end }}"
+git_name          = "{{ if $tty }}{{ promptString "git_name" "Your Name" }}{{ else }}Your Name{{ end }}"
+git_email         = "{{ if $tty }}{{ promptString "git_email" "you@example.com" }}{{ else }}you@example.com{{ end }}"
+git_signingkey    = "{{ if $tty }}{{ promptString "git_signingkey" "~/.ssh/id_ed25519" }}{{ else }}~/.ssh/id_ed25519{{ end }}"
+git_signingformat = "{{ if $tty }}{{ promptString "git_signingformat" "ssh" }}{{ else }}ssh{{ end }}"
 
 # Expose age variables in data section for use in other templates
 # Variable scope: $age_identity and $age_recipient defined at file top are accessible here


### PR DESCRIPTION
## Summary

Cherry-picked from `feat/v0.2.503` (commit `8167ffe`). Fixes the nightly Drift Detection workflow which has been failing on:

```
chezmoi: template: chezmoi.toml:10:20: executing "chezmoi.toml"
at <promptString "age_identity" ...>: error calling promptString:
could not open a new TTY: open /dev/tty: no such device or address
```

## Root cause

`defaults/.chezmoi.toml.tmpl` called `promptString` unconditionally for `age_identity`, `age_recipient`, and the git/profile/theme fields. `promptString` requires a TTY. CI runners don't have one, so `chezmoi init --source "$GITHUB_WORKSPACE" --apply=false` blew up before drift detection could run.

## Fix

Wrap each `promptString` in `{{ if stdinIsATTY }}` and fall through to the same default value on the non-interactive branch. Interactive runs unchanged (still prompt with the same default). CI / drift runs get:

- `age_identity` = `env "CHEZMOI_AGE_IDENTITY"` or `~/.config/chezmoi/key.txt`
- `age_recipient` = `env "CHEZMOI_AGE_RECIPIENT"` or `""`
- `profile` = `"laptop"`
- `theme` = `"tokyonight-night"`
- `git_name` / `git_email` / `git_signingkey` / `git_signingformat` = documented defaults

Setting `CHEZMOI_AGE_IDENTITY` / `CHEZMOI_AGE_RECIPIENT` env vars in a CI job that needs real age keys is now the escape hatch.

## Verified

- `chezmoi init --source $(pwd) --apply=false` exits 0 non-interactively
- Interactive `chezmoi apply` still prompts (`stdinIsATTY` resolves true)

## Scope

Single file, +25/-16. The one file (`defaults/.chezmoi.toml.tmpl`) has not been touched on `main` in a way that conflicts — cherry-pick applied cleanly.

Signed-off-by: Sebastien Rousseau <sebastian.rousseau@gmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co
