### PR TITLE
fix(theme): match mixed-case theme names in all_theme_names regex

### DIFF
--- a/scripts/theme/switch.sh
+++ b/scripts/theme/switch.sh
@@ -123,7 +123,7 @@ theme_exists() {
 }
 
 all_theme_names() {
-  sed -n 's/^\[themes\.\([a-z0-9-]*\)\]$/\1/p' "$THEMES_FILE" | sort -u
+  sed -n 's/^\[themes\.\([a-zA-Z0-9-]*\)\]$/\1/p' "$THEMES_FILE" | sort -u
 }
 
 # List wallpaper families that have BOTH dark and light variants in themes.toml.


### PR DESCRIPTION
## Summary

Cherry-picked from `feat/v0.2.503` (commit `9f05365`). One-line regex widening in `scripts/theme/switch.sh`.

## Bug

`dot theme list` reports "0 wallpaper themes available" after `dot theme rebuild` on Linux when the wallpaper library contains capitalised filenames (`Altai.png`, `Bauhaus.png`, etc.).

Root cause: the sed regex extracting theme keys from `themes.toml` used `[a-z0-9-]*` (lowercase only), but capitalised wallpapers produce section headers like `[themes.Altai-dark]`. All 226 such themes were silently dropped, leaving only 42 lowercase system-wallpaper themes — none of which formed a complete dark+light pair after filtering.

## Fix

Widen the character class to `[a-zA-Z0-9-]*`. One character (`A-Z`), one bug fixed.

## Verified (on my Linux workstation)

- **Before:** `dot theme list` → 0 themes
- **After:** `dot theme list` → 115 paired themes (of 268 sections total)

## Scope

Single character in a single line in a single file. No behavior change for repos with only lowercase theme names. Cherry-picked cleanly.

Signed-off-by: Sebastien Rousseau <sebastian.rousseau@gmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co
