### PR TITLE
feat(v0.2.520): safe macOS iCloud symlinks, performance budgets, and the v0.2.520 bump

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -501,14 +501,16 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-    env:
-      # Budgets are calibrated at 2x the median measured on a developer
-      # machine (see docs/operations/PERFORMANCE_BUDGETS.md). GitHub-hosted
-      # runners are slower again, so scale the budgets rather than inflate
-      # the recorded baselines — local runs stay strict at the default 100%.
-      # Tighten this once real runner medians are known; the gate prints
-      # every median, so the first green run tells you what to set.
-      PERF_BUDGET_PERCENT: "200"
+    # No PERF_BUDGET_PERCENT override: the gate runs at its strict 100%.
+    #
+    # The first CI run assumed hosted runners were ~2x slower and scaled
+    # budgets accordingly. The measured medians said otherwise — the macOS
+    # runner is comparable to or FASTER than the reference machine on every
+    # gate (docs-coverage 679ms vs 969, traceability 1775 vs 2389,
+    # help-registry 3318 vs 4449, dot doctor 1746 vs 4423). The worst
+    # runner/local ratio observed was 1.25x (dot search), so budgets set at
+    # 2x the local median keep >= 1.6x headroom here. Scaling them further
+    # would only have blunted the gate.
     steps:
       - name: Harden runner (audit mode)
         uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -492,6 +492,41 @@ jobs:
   # ============================================================================
   # STAGE 4: QUALITY (Depends on lint + test passing)
   # ============================================================================
+  quality-performance:
+    name: Quality / Performance budgets (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    needs: [lint-shell, test-unit]
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    env:
+      # Budgets are calibrated at 2x the median measured on a developer
+      # machine (see docs/operations/PERFORMANCE_BUDGETS.md). GitHub-hosted
+      # runners are slower again, so scale the budgets rather than inflate
+      # the recorded baselines — local runs stay strict at the default 100%.
+      # Tighten this once real runner medians are known; the gate prints
+      # every median, so the first green run tells you what to set.
+      PERF_BUDGET_PERCENT: "200"
+    steps:
+      - name: Harden runner (audit mode)
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Chezmoi
+        uses: ./.github/actions/setup-chezmoi
+
+      # No `|| true`. This gate exists to fail the build when a budget is
+      # breached or a measured command exits non-zero; swallowing its status
+      # would make it exactly the silently-passing gate it is meant to be.
+      - name: Performance budgets
+        run: bash tests/performance/test_perf_budgets.sh
+
+
   quality-idempotency:
     name: Quality / Idempotency
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -513,7 +513,7 @@ jobs:
     # would only have blunted the gate.
     steps:
       - name: Harden runner (audit mode)
-        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
         with:
           egress-policy: audit
 
@@ -526,7 +526,7 @@ jobs:
       # breached or a measured command exits non-zero; swallowing its status
       # would make it exactly the silently-passing gate it is meant to be.
       - name: Performance budgets
-        run: bash tests/performance/test_perf_budgets.sh
+        run: bash benches/test_perf_budgets.sh
 
 
   quality-idempotency:

--- a/.well-known/agent-card.json
+++ b/.well-known/agent-card.json
@@ -1,7 +1,7 @@
 {
   "specVersion": "0.3",
   "name": "dotfiles-agent",
-  "version": "0.2.519",
+  "version": "0.2.520",
   "description": "Trusted workstation agent surface for local shell automation, configuration governance, and fleet management.",
   "url": "https://github.com/sebastienrousseau/dotfiles",
   "skills": [

--- a/.well-known/mcp/server-card.json
+++ b/.well-known/mcp/server-card.json
@@ -1,7 +1,7 @@
 {
   "cardVersion": "2026.03",
   "name": "dotfiles-mcp",
-  "version": "0.2.519",
+  "version": "0.2.520",
   "description": "Read-only MCP server over the dotfiles workstation governance surface: MCP policy audit, agent operating profiles, workstation attestation and fleet status.",
   "protocolVersions": ["2025-06-18", "2025-03-26", "2024-11-05"],
   "transport": {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@
 
 ## Project Overview
 
-Chezmoi-managed dotfiles for macOS, Linux, WSL, and PowerShell 7.5+. Version `0.2.519`.
+Chezmoi-managed dotfiles for macOS, Linux, WSL, and PowerShell 7.5+. Version `0.2.520`.
 
 ## Key Commands
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,18 @@ This file documents all notable changes to this project.
   rationale in `docs/operations/PERFORMANCE_BUDGETS.md`.
 - A gate-integrity regression test asserting that the safety checks cannot be
   disabled without a test failing.
+- `dot mcp serve` — a real stdio Model Context Protocol server, where the
+  published card had previously described one that did not exist. Full
+  lifecycle with version negotiation across three protocol revisions,
+  `tools/list`, `tools/call`, resources and logging, with proper JSON-RPC
+  error objects. All four tools are read-only and run from closed argument
+  vectors without a shell; the mutating operations are deliberately
+  unreachable. Go, standard library only.
+- A feature matrix covering every routable command, flag, environment
+  variable and config key, each row naming the regression test, benchmark,
+  example and manual section that covers it. The gate fails when a command
+  gains no row, or when a row names a test or example that does not exist,
+  so coverage cannot be claimed in the table without being written.
 - `dot attest --verify` (`--json|-j`, `--max-age|-a`): checks a workstation
   evidence record against the attestation policy by running `lib/wasm-tools`
   as WebAssembly under `wasmtime`. The module gets stdin, stdout and a clock
@@ -35,6 +47,34 @@ This file documents all notable changes to this project.
   execution assertion, the WebAssembly integration tests, the shell caller's
   test, and the `.wasm` uploaded as an artefact.
 
+### Changed
+
+- Bash line coverage went from 59% to **98.14%**. Roughly half of that came
+  from fixing the measurement rather than adding tests: untraceable lines sat
+  in the denominator, 540 of 706 test files discarded their traces through
+  `2>&1`, silent timeout kills were counted as passes, and the sweep's `PS4`
+  truncated at 100 characters so the figure depended on how long your checkout
+  path was. Correcting those alone moved it 59.36% to 72.29% with no new test
+  written. Both Go modules are at 100%, where fuzzing found four defects.
+- The terminal palette now takes more than one colour from the wallpaper.
+  `term.bg` had two distinct values across all 228 themes; it now has 36, and
+  the status bar carries a secondary and tertiary alongside the accent. The
+  background is *tinted* rather than replaced — lightness is unchanged, so the
+  low-eye-strain surface the engine was built around is preserved, and
+  `DOTFILES_TERM_TINT=0` restores the flat neutrals.
+- Rust is no longer managed by mise. Its plugin exports `RUSTUP_TOOLCHAIN`,
+  which silently overrides `rust-toolchain.toml` in every project — a
+  repository pinned to 1.98.0 was being built with 1.97.1, and a local "all
+  green" said nothing about CI. rustup governs instead, so each project's own
+  pin is honoured.
+- `~/.cargo/config.toml` no longer sets a global `target-dir`. Cargo takes an
+  exclusive lock on it, so every repository sharing one path serialised: a
+  build in one project blocked `cargo test` in another, and cargo prints
+  nothing while it waits, so it read as a hang. sccache recovers the shared
+  dependency cache without the lock.
+- mise's tool directories are promoted above Homebrew and the shims on `PATH`,
+  fused into the existing dedup pass rather than added as a second walk.
+
 ### Fixed
 
 - Replaced the destructive mechanism behind the macOS iCloud symlink hook. The
@@ -51,6 +91,29 @@ This file documents all notable changes to this project.
   third-party tooling or as "not actually WebAssembly": `docs/ECOSYSTEM.md`,
   `docs/architecture/REPO_LAYOUT.md`, `docs/STRUCTURE.md`,
   `docs/ARCHITECTURE.md`, `docs/reference/TOOLS.md` and `REUSE.toml`.
+- `workbench.colorTheme` had been commented out on every machine this was
+  ever applied to. A template newline was chomped, welding the setting onto
+  the comment above it. Two thirds of the theme labels also named themes no
+  extension registers — "Tokyonight Mocha" and "Everforest Latte", where
+  Mocha and Latte are Catppuccin flavours rather than a general dark/light
+  suffix. The editor is now pinned to Catppuccin, and the icon theme ids are
+  the ones the extension actually declares.
+- Twelve documented defects, each with a regression test proven to fail
+  against the unfixed code first: `dot theme set` aborting before its picker,
+  `dot fleet namespace set` reporting success while writing nothing,
+  `dot agent delegate` requiring a GNU `timeout` absent from stock macOS, a
+  registry cache keyed by path so changing the URL served a stale index for
+  six hours, and `dot doctor --audit` routing to a script not in the tree.
+  Two of the reported findings turned out to be wrong, and correcting them
+  was more useful than fixing them.
+- `chezmoi apply` no longer silently discards edits made directly in `$HOME`.
+  Local drift is captured into the source instead of overwritten.
+- macOS home folders (`~/Desktop`, `~/Documents`, `~/Public` and the rest) are
+  excluded from chezmoi management entirely, as a second layer beneath the
+  iCloud hook's own refusals.
+- `docs-coverage.sh` and `traceability-coverage.sh` stopped masking their own
+  exit codes, so a failing gate now fails.
+- `dot benchmark` is routed. Every layer but the router already had it.
 
 ## v0.2.519 — 2026-08-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,18 @@
 
 This file documents all notable changes to this project.
 
-## Unreleased
+## v0.2.520 — 2026-09-10
 
 ### Added
 
+- `docs/guides/MACOS_ICLOUD_SYMLINKS.md`, documenting what the hook does, the
+  cases it refuses, and how to resolve each one by hand.
+- A safety regression suite and a unit suite for the hook, covering the refusal
+  paths that the destructive version never had.
+- Performance budgets for the shell startup path, with the budget table and its
+  rationale in `docs/operations/PERFORMANCE_BUDGETS.md`.
+- A gate-integrity regression test asserting that the safety checks cannot be
+  disabled without a test failing.
 - `dot attest --verify` (`--json|-j`, `--max-age|-a`): checks a workstation
   evidence record against the attestation policy by running `lib/wasm-tools`
   as WebAssembly under `wasmtime`. The module gets stdin, stdout and a clock
@@ -29,6 +37,11 @@ This file documents all notable changes to this project.
 
 ### Fixed
 
+- Replaced the destructive mechanism behind the macOS iCloud symlink hook. The
+  previous implementation could remove real content from `~/Documents` and
+  `~/Desktop`; the replacement only ever removes an empty directory, refuses to
+  act on a non-empty one, and leaves an existing correct symlink untouched.
+- Reported what it declined to do, and why, instead of failing silently.
 - The health-probe record no longer claims `"engine": "wasm"` when it was
   produced by a host binary. `ENGINE` is now `cfg`-selected, so the field
   states where the bytes were actually computed: `wasm` from the module,
@@ -38,26 +51,6 @@ This file documents all notable changes to this project.
   third-party tooling or as "not actually WebAssembly": `docs/ECOSYSTEM.md`,
   `docs/architecture/REPO_LAYOUT.md`, `docs/STRUCTURE.md`,
   `docs/ARCHITECTURE.md`, `docs/reference/TOOLS.md` and `REUSE.toml`.
-## v0.2.520 — 2026-08-13
-
-### Fixed
-
-- Replaced the destructive mechanism behind the macOS iCloud symlink hook. The
-  previous implementation could remove real content from `~/Documents` and
-  `~/Desktop`; the replacement only ever removes an empty directory, refuses to
-  act on a non-empty one, and leaves an existing correct symlink untouched.
-- Reported what it declined to do, and why, instead of failing silently.
-
-### Added
-
-- `docs/guides/MACOS_ICLOUD_SYMLINKS.md`, documenting what the hook does, the
-  cases it refuses, and how to resolve each one by hand.
-- A safety regression suite and a unit suite for the hook, covering the refusal
-  paths that the destructive version never had.
-- Performance budgets for the shell startup path, with the budget table and its
-  rationale in `docs/operations/PERFORMANCE_BUDGETS.md`.
-- A gate-integrity regression test asserting that the safety checks cannot be
-  disabled without a test failing.
 
 ## v0.2.519 — 2026-08-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,26 @@ This file documents all notable changes to this project.
   third-party tooling or as "not actually WebAssembly": `docs/ECOSYSTEM.md`,
   `docs/architecture/REPO_LAYOUT.md`, `docs/STRUCTURE.md`,
   `docs/ARCHITECTURE.md`, `docs/reference/TOOLS.md` and `REUSE.toml`.
+## v0.2.520 — 2026-08-13
+
+### Fixed
+
+- Replaced the destructive mechanism behind the macOS iCloud symlink hook. The
+  previous implementation could remove real content from `~/Documents` and
+  `~/Desktop`; the replacement only ever removes an empty directory, refuses to
+  act on a non-empty one, and leaves an existing correct symlink untouched.
+- Reported what it declined to do, and why, instead of failing silently.
+
+### Added
+
+- `docs/guides/MACOS_ICLOUD_SYMLINKS.md`, documenting what the hook does, the
+  cases it refuses, and how to resolve each one by hand.
+- A safety regression suite and a unit suite for the hook, covering the refusal
+  paths that the destructive version never had.
+- Performance budgets for the shell startup path, with the budget table and its
+  rationale in `docs/operations/PERFORMANCE_BUDGETS.md`.
+- A gate-integrity regression test asserting that the safety checks cannot be
+  disabled without a test failing.
 
 ## v0.2.519 — 2026-08-13
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -24,7 +24,7 @@ license:
   - Apache-2.0
   - MIT
 version: 0.2.520
-date-released: "2026-08-13"
+date-released: "2026-09-10"
 keywords:
   - dotfiles
   - chezmoi

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -23,7 +23,7 @@ url: "https://doc.dotfiles.io/"
 license:
   - Apache-2.0
   - MIT
-version: 0.2.519
+version: 0.2.520
 date-released: "2026-08-13"
 keywords:
   - dotfiles

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@
 
 ## Project Overview
 
-Chezmoi-managed dotfiles for macOS, Linux, WSL, and PowerShell 7.5+. Version `0.2.519`.
+Chezmoi-managed dotfiles for macOS, Linux, WSL, and PowerShell 7.5+. Version `0.2.520`.
 
 ## Key Commands
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 <p align="center">
   <a href="https://github.com/sebastienrousseau/dotfiles/actions"><img src="https://img.shields.io/github/actions/workflow/status/sebastienrousseau/dotfiles/ci.yml?style=for-the-badge&logo=githubactions&logoColor=white" alt="Build" /></a>
-  <a href="https://github.com/sebastienrousseau/dotfiles/releases/latest"><img src="https://img.shields.io/badge/Version-v0.2.519-blue?style=for-the-badge&logo=semanticrelease&logoColor=white" alt="Version" /></a>
+  <a href="https://github.com/sebastienrousseau/dotfiles/releases/latest"><img src="https://img.shields.io/badge/Version-v0.2.520-blue?style=for-the-badge&logo=semanticrelease&logoColor=white" alt="Version" /></a>
   <a href="https://www.npmjs.com/package/@sebastienrousseau/dotfiles"><img src="https://img.shields.io/npm/v/@sebastienrousseau/dotfiles?style=for-the-badge&logo=npm&logoColor=white&label=npm" alt="npm" /></a>
   <a href="https://doc.dotfiles.io/"><img src="https://img.shields.io/badge/Manual-doc.dotfiles.io-66c2a5?style=for-the-badge&labelColor=555555&logo=materialformkdocs&logoColor=white" alt="Manual" /></a>
   <a href="https://github.com/sebastienrousseau/dotfiles/releases"><img src="https://img.shields.io/github/downloads/sebastienrousseau/dotfiles/total?style=for-the-badge&logo=github&logoColor=white" alt="Downloads" /></a>
@@ -95,7 +95,7 @@ per-release hash and how it is generated are documented in
 
 ```bash
 curl -fsSL -o /tmp/dotfiles-install.sh \
-  https://raw.githubusercontent.com/sebastienrousseau/dotfiles/v0.2.519/install.sh
+  https://raw.githubusercontent.com/sebastienrousseau/dotfiles/v0.2.520/install.sh
 echo "3b5d1332fb07a1261da117e53f69acc0097c3d9bd676fc9f53a000257b72978e  /tmp/dotfiles-install.sh" \
   | shasum -a 256 -c
 bash /tmp/dotfiles-install.sh

--- a/README.md
+++ b/README.md
@@ -113,10 +113,10 @@ directory. The archive
 carries SLSA build provenance (keyless, via Fulcio + Rekor):
 
 ```bash
-gh release download v0.2.519 --repo sebastienrousseau/dotfiles --pattern 'dot-*.tar.gz'
-gh attestation verify dot-0.2.519.tar.gz --repo sebastienrousseau/dotfiles
-tar -xzf dot-0.2.519.tar.gz
-make -C dot-0.2.519 install PREFIX=/usr/local
+gh release download v0.2.520 --repo sebastienrousseau/dotfiles --pattern 'dot-*.tar.gz'
+gh attestation verify dot-0.2.520.tar.gz --repo sebastienrousseau/dotfiles
+tar -xzf dot-0.2.520.tar.gz
+make -C dot-0.2.520 install PREFIX=/usr/local
 ```
 
 [`release-install-smoke.yml`](.github/workflows/release-install-smoke.yml)
@@ -310,7 +310,7 @@ every push.
 bash -c "$(curl -fsSL https://raw.githubusercontent.com/sebastienrousseau/dotfiles/main/install.sh)"
 
 # Only the dot CLI, from the attested release archive
-gh release download v0.2.519 --repo sebastienrousseau/dotfiles --pattern 'dot-*.tar.gz'
+gh release download v0.2.520 --repo sebastienrousseau/dotfiles --pattern 'dot-*.tar.gz'
 
 # The Go satellites are (re)built on apply by
 #   defaults/run_onchange_24-build-dot-ui.sh.tmpl
@@ -861,7 +861,7 @@ design is
 
 ```toml
 # defaults/.chezmoidata.toml — repo-wide defaults, schema-checked in CI
-dotfiles_version = "0.2.519"
+dotfiles_version = "0.2.520"
 
 [features]
 alias_wrapper = false   # confirm destructive aliases

--- a/benches/test_perf_budgets.sh
+++ b/benches/test_perf_budgets.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright (c) 2015-2026 Sebastien Rousseau
+# shellcheck disable=SC1090,SC1091,SC2034
+#
+# Performance budgets — one place, tiered targets, measured baselines.
+#
+# ── The tiers ──────────────────────────────────────────────────────
+#
+#   INSTANT (≤  500ms) — anything a human sees in a shell prompt
+#     * dot version / dot --version
+#     * dot help / dot help <cmd>
+#     * dot search <keyword>
+#     * The iCloud script itself (one full pass)
+#     * Version-consistency gate
+#     * docs-coverage gate
+#     * iCloud regression safety test (9 assertions)
+#
+#   FAST    (≤ 2000ms) — heavier gates + sandboxed CLI reads
+#     * dot status
+#     * dot diff
+#     * traceability-coverage gate
+#     * iCloud unit test (29 assertions with fs sandbox setup)
+#     * test_dot_subcommand_smoke
+#     * test_dot_help_registry_symmetry
+#
+#   MEDIUM  (≤ 5000ms) — full diagnostics runs
+#     * dot doctor
+#     * tests/performance/bench.sh (quick mode)
+#
+#   ACCEPTED-SLOW (documented, best-effort)
+#     * test_dot_help_flag_universal — invokes dot help --help on ~100
+#       commands via a subshell each; ~11s is legitimate for the
+#       coverage it provides. Not gated here; tracked in wall-clock
+#       ratchet (tests/performance/test_help_gates_wall_clock.sh).
+#
+#   OUT-OF-SCOPE — multi-minute operations we do not gate per-run
+#     * chezmoi apply (fresh macOS: minutes)
+#     * install.sh (downloads packages)
+#     * dot upgrade (mise + chezmoi + pkgmgr)
+#     * Full test suite
+#
+# All thresholds carry ≥2× headroom over the reference-machine
+# median so CI-runner variance doesn't cause flakes. When a real
+# regression happens, the median jumps outside the headroom band.
+#
+# Baseline captured on 2026-08-30, rousseau-cachyos-geekom-a9,
+# Ryzen AI 9 HX 370. CI runners are usually 1.5-2× slower.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+source "$SCRIPT_DIR/../framework/assertions.sh"
+
+DOT_CLI="$REPO_ROOT/bin/dot"
+ICLOUD_TMPL="$REPO_ROOT/defaults/run_once_before_macos-icloud-symlinks.sh.tmpl"
+
+# ---------------------------------------------------------------------------
+# _measure — run a command N times, return median wall-clock ms.
+# Uses date +%s%N for high-resolution timing (bash builtin timings
+# aren't consistent across shells / macOS bash).
+# ---------------------------------------------------------------------------
+_measure() {
+  local runs="$1"; shift
+  local times=() total=0
+  local i start_ns end_ns
+  for ((i=0; i<runs; i++)); do
+    start_ns=$(date +%s%N)
+    "$@" >/dev/null 2>&1 || true
+    end_ns=$(date +%s%N)
+    times+=("$(( (end_ns - start_ns) / 1000000 ))")
+  done
+  # median
+  local sorted
+  IFS=$'\n' sorted=($(printf '%s\n' "${times[@]}" | sort -n))
+  unset IFS
+  local mid=$((runs / 2))
+  printf '%s' "${sorted[$mid]}"
+}
+
+_gate() {
+  local label="$1" budget_ms="$2" runs="$3"; shift 3
+  local median
+  median="$(_measure "$runs" "$@")"
+  if [[ "$median" -le "$budget_ms" ]]; then
+    ((TESTS_PASSED++)) || true
+    printf '  \033[0;32m✓\033[0m %s: median=%sms budget=%sms\n' \
+      "$CURRENT_TEST" "$median" "$budget_ms"
+  else
+    ((TESTS_FAILED++)) || true
+    printf '  \033[0;31m✗\033[0m %s: median=%sms EXCEEDS budget=%sms\n' \
+      "$CURRENT_TEST" "$median" "$budget_ms"
+  fi
+}
+
+# Sandbox HOME so cold reads don't hit real ~/.zsh_history etc.
+_sandbox() {
+  local sb
+  sb="$(mktemp -d)"
+  export HOME="$sb"
+  export XDG_CONFIG_HOME="$sb/.config"
+  export XDG_DATA_HOME="$sb/.local/share"
+  export XDG_CACHE_HOME="$sb/.cache"
+  export XDG_STATE_HOME="$sb/.local/state"
+  mkdir -p "$XDG_CONFIG_HOME" "$XDG_DATA_HOME" "$XDG_CACHE_HOME" "$XDG_STATE_HOME/dotfiles"
+  export CHEZMOI_SOURCE_DIR="$REPO_ROOT"
+  # iCloud mock for icloud-script perf test
+  mkdir -p "$sb/Library/Mobile Documents/com~apple~CloudDocs"
+  export DOTFILES_NO_BANNER=1
+  printf '%s\n' "$sb"
+}
+
+# =============================================================================
+# TIER 1: INSTANT (≤500ms)
+# =============================================================================
+_sandbox >/dev/null
+
+test_start "instant_dot_version"
+_gate "$CURRENT_TEST" 500 5 bash "$DOT_CLI" version
+
+test_start "instant_dot_help"
+_gate "$CURRENT_TEST" 500 5 bash "$DOT_CLI" help
+
+test_start "instant_dot_help_doctor"
+_gate "$CURRENT_TEST" 500 5 bash "$DOT_CLI" help doctor
+
+test_start "instant_dot_help_theme"
+_gate "$CURRENT_TEST" 500 5 bash "$DOT_CLI" help theme
+
+test_start "instant_dot_help_apply"
+_gate "$CURRENT_TEST" 500 5 bash "$DOT_CLI" help apply
+
+test_start "instant_dot_search"
+_gate "$CURRENT_TEST" 500 5 bash "$DOT_CLI" search theme
+
+test_start "instant_icloud_script_single_run"
+# Render darwin-guarded template to a plain script
+_rendered="$(mktemp)"
+sed -e '/^{{- if eq \.chezmoi\.os "darwin" -}}$/d' \
+    -e '/^{{- end -}}$/d' \
+    "$ICLOUD_TMPL" > "$_rendered"
+_gate "$CURRENT_TEST" 500 5 bash "$_rendered"
+rm -f "$_rendered"
+
+test_start "instant_check_version_consistency"
+_gate "$CURRENT_TEST" 500 5 bash "$REPO_ROOT/scripts/qa/check-version-consistency.sh"
+
+test_start "instant_docs_coverage"
+_gate "$CURRENT_TEST" 500 5 bash "$REPO_ROOT/scripts/qa/docs-coverage.sh"
+
+test_start "instant_icloud_regression_test"
+_gate "$CURRENT_TEST" 500 5 bash "$REPO_ROOT/tests/regression/test_macos_icloud_symlinks_safety.sh"
+
+# =============================================================================
+# TIER 2: FAST (≤2000ms)
+# =============================================================================
+
+test_start "fast_traceability_coverage"
+_gate "$CURRENT_TEST" 2000 3 bash "$REPO_ROOT/scripts/qa/traceability-coverage.sh"
+
+test_start "fast_icloud_unit_test"
+_gate "$CURRENT_TEST" 2000 3 bash "$REPO_ROOT/tests/unit/misc/test_macos_icloud_symlinks.sh"
+
+test_start "fast_dot_subcommand_smoke"
+_gate "$CURRENT_TEST" 2000 3 bash "$REPO_ROOT/tests/regression/test_dot_subcommand_smoke.sh"
+
+test_start "fast_dot_help_registry_symmetry"
+_gate "$CURRENT_TEST" 2000 3 bash "$REPO_ROOT/tests/regression/test_dot_help_registry_symmetry.sh"
+
+test_start "fast_dot_status"
+_gate "$CURRENT_TEST" 2000 3 bash "$DOT_CLI" status
+
+test_start "fast_dot_diff"
+_gate "$CURRENT_TEST" 2000 3 bash "$DOT_CLI" diff
+
+# =============================================================================
+# TIER 3: MEDIUM (≤5000ms)
+# =============================================================================
+
+test_start "medium_dot_doctor"
+_gate "$CURRENT_TEST" 5000 3 bash "$DOT_CLI" doctor
+
+# tests/performance/bench.sh has been observed at ~2s; give it 5s headroom
+test_start "medium_bench_quick_mode"
+if [[ -f "$REPO_ROOT/tests/performance/bench.sh" ]]; then
+  _gate "$CURRENT_TEST" 5000 3 bash "$REPO_ROOT/tests/performance/bench.sh" --quick
+else
+  ((TESTS_PASSED++)) || true
+  printf '  \033[0;33m~\033[0m %s (bench.sh not executable — skipped)\n' "$CURRENT_TEST"
+fi
+
+# =============================================================================
+# Summary
+# =============================================================================
+printf '\n  Tests: %d  \033[0;32mPassed: %d\033[0m  \033[0;31mFailed: %d\033[0m\n' \
+  "$TESTS_RUN" "$TESTS_PASSED" "$TESTS_FAILED"
+printf 'RESULTS:%d:%d:%d\n' "$TESTS_RUN" "$TESTS_PASSED" "$TESTS_FAILED"
+exit "$TESTS_FAILED"

--- a/benches/test_perf_budgets.sh
+++ b/benches/test_perf_budgets.sh
@@ -14,7 +14,7 @@
 #     * The iCloud script itself (one full pass)
 #     * Version-consistency gate
 #     * docs-coverage gate
-#     * iCloud regression safety test (9 assertions)
+#     * iCloud regression safety test (10 assertions, budget 600ms)
 #
 #   FAST    (≤ 2000ms) — heavier gates + sandboxed CLI reads
 #     * dot status
@@ -150,7 +150,14 @@ test_start "instant_docs_coverage"
 _gate "$CURRENT_TEST" 500 5 bash "$REPO_ROOT/scripts/qa/docs-coverage.sh"
 
 test_start "instant_icloud_regression_test"
-_gate "$CURRENT_TEST" 500 5 bash "$REPO_ROOT/tests/regression/test_macos_icloud_symlinks_safety.sh"
+# 600ms, not the tier's nominal 500ms: this budget is calibrated per
+# assertion count (see tier notes above). At 9 assertions it measured
+# ~435ms against a 500ms gate; the 10th assertion (link-form recognition,
+# which shares a sandbox with invariant 3 to stay cheap) moves the median
+# to ~495ms — inside 500ms on a good run, over it on a noisy one. 600ms
+# restores the ~20% headroom the 9-assertion calibration had, so the gate
+# still catches real regressions instead of flaking on scheduler noise.
+_gate "$CURRENT_TEST" 600 5 bash "$REPO_ROOT/tests/regression/test_macos_icloud_symlinks_safety.sh"
 
 # =============================================================================
 # TIER 2: FAST (≤2000ms)

--- a/benches/test_perf_budgets.sh
+++ b/benches/test_perf_budgets.sh
@@ -131,6 +131,15 @@ _gate_max_rc() {
     ((TESTS_FAILED++)) || true
     printf '  \033[0;31m✗\033[0m %s: exited %s (max allowed %s) — timing is meaningless\n' \
       "$label" "$failed" "$max_rc"
+    # Re-run once with output captured. An exit code with no context is
+    # undebuggable in CI, where you cannot reproduce the environment by hand.
+    local diag
+    diag="$("$@" 2>&1 | tail -25)"
+    if [[ -n "$diag" ]]; then
+      printf '%s\n' "$diag" | sed 's/^/        | /'
+    else
+      printf '        | (command produced no output)\n'
+    fi
   elif [[ "$median" -le "$budget_ms" ]]; then
     ((TESTS_PASSED++)) || true
     printf '  \033[0;32m✓\033[0m %s: median=%sms budget=%sms\n' \

--- a/benches/test_perf_budgets.sh
+++ b/benches/test_perf_budgets.sh
@@ -53,8 +53,10 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
 source "$SCRIPT_DIR/../framework/assertions.sh"
 
-DOT_CLI="$REPO_ROOT/bin/dot"
-ICLOUD_TMPL="$REPO_ROOT/defaults/run_once_before_macos-icloud-symlinks.sh.tmpl"
+# Overridable so the breakage-detection path can be exercised against a
+# deliberately corrupted CLI without touching the real one.
+DOT_CLI="${DOT_CLI:-$REPO_ROOT/bin/dot}"
+ICLOUD_TMPL="$REPO_ROOT/defaults/run_before_macos-icloud-symlinks.sh.tmpl"
 
 # ---------------------------------------------------------------------------
 # _measure — run a command N times, return median wall-clock ms.
@@ -63,12 +65,18 @@ ICLOUD_TMPL="$REPO_ROOT/defaults/run_once_before_macos-icloud-symlinks.sh.tmpl"
 # ---------------------------------------------------------------------------
 _measure() {
   local runs="$1"; shift
-  local times=() total=0
+  local times=() worst_rc=0 rc=0
   local i start_ns end_ns
   for ((i=0; i<runs; i++)); do
     start_ns=$(date +%s%N)
-    "$@" >/dev/null 2>&1 || true
+    # F2: capture the exit status instead of discarding it. A command that
+    # crashes instantly is FAST, and the old `|| true` let it sail through
+    # its budget — a broken `dot` reported excellent performance.
+    "$@" >/dev/null 2>&1 || rc=$?
     end_ns=$(date +%s%N)
+    # Bookkeeping AFTER the clock stops, so it is not counted in the median.
+    [[ "$rc" -gt "$worst_rc" ]] && worst_rc="$rc"
+    rc=0
     times+=("$(( (end_ns - start_ns) / 1000000 ))")
   done
   # median
@@ -76,21 +84,83 @@ _measure() {
   IFS=$'\n' sorted=($(printf '%s\n' "${times[@]}" | sort -n))
   unset IFS
   local mid=$((runs / 2))
-  printf '%s' "${sorted[$mid]}"
+  printf '%s %s' "$worst_rc" "${sorted[$mid]}"
 }
 
-_gate() {
-  local label="$1" budget_ms="$2" runs="$3"; shift 3
-  local median
-  median="$(_measure "$runs" "$@")"
-  if [[ "$median" -le "$budget_ms" ]]; then
+# Budgets can be scaled for meta-testing: PERF_BUDGET_PERCENT=0 makes every
+# budget impossible, which is how tests/regression/test_gate_integrity.sh
+# proves this gate actually fails rather than merely existing.
+_scaled_budget() {
+  printf '%s' "$(($1 * ${PERF_BUDGET_PERCENT:-100} / 100))"
+}
+
+# PERF_GATE_FILTER runs only gates whose label contains the given substring.
+# Skipped gates never call test_start, so TESTS_RUN == PASSED + FAILED holds
+# (the invariant tests/regression/test_test_framework_invariants.sh enforces).
+_gate_selected() {
+  case "$1" in
+    *"${PERF_GATE_FILTER:-}"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# _gate <label> <budget_ms> <runs> <command...>
+#   Requires exit 0. Use for anything that should simply succeed.
+_gate() { _gate_max_rc 0 "$@"; }
+
+# _gate_diag — same, but tolerates exit 1.
+#   Diagnostics report findings through their exit status: `dot doctor`
+#   exits 1 when it finds issues (it does so on a healthy machine too), and
+#   bench.sh exits 1 when a shell breaches its own startup threshold. Both
+#   still RAN, so their timing is meaningful. Anything >= 2 — not-found,
+#   permission, signal, syntax error — is still a hard failure, so this is
+#   far narrower than the blanket `|| true` it replaces.
+_gate_diag() { _gate_max_rc 1 "$@"; }
+
+_gate_max_rc() {
+  local max_rc="$1" label="$2" budget_ms="$3" runs="$4"
+  shift 4
+  _gate_selected "$label" || return 0
+  test_start "$label"
+  budget_ms="$(_scaled_budget "$budget_ms")"
+  local out failed median
+  out="$(_measure "$runs" "$@")"
+  failed="${out%% *}"
+  median="${out##* }"
+  if [[ "$failed" -gt "$max_rc" ]]; then
+    ((TESTS_FAILED++)) || true
+    printf '  \033[0;31m✗\033[0m %s: exited %s (max allowed %s) — timing is meaningless\n' \
+      "$label" "$failed" "$max_rc"
+  elif [[ "$median" -le "$budget_ms" ]]; then
     ((TESTS_PASSED++)) || true
     printf '  \033[0;32m✓\033[0m %s: median=%sms budget=%sms\n' \
-      "$CURRENT_TEST" "$median" "$budget_ms"
+      "$label" "$median" "$budget_ms"
   else
     ((TESTS_FAILED++)) || true
     printf '  \033[0;31m✗\033[0m %s: median=%sms EXCEEDS budget=%sms\n' \
-      "$CURRENT_TEST" "$median" "$budget_ms"
+      "$label" "$median" "$budget_ms"
+  fi
+}
+
+# =============================================================================
+# TIER 0: SELF-TEST — the gate must be able to fail.
+# =============================================================================
+# Runs on every pass. If breakage detection is ever removed from _measure,
+# this fails here rather than silently green-lighting a broken CLI.
+_selftest_rejects_broken() {
+  _gate_selected "selftest_gate_rejects_broken_command" || return 0
+  test_start "selftest_gate_rejects_broken_command"
+  local out failed
+  out="$(_measure 2 /nonexistent/definitely-not-a-real-binary --version)"
+  failed="${out%% *}"
+  # 127 = not found. Any non-zero proves the status reached the caller.
+  if [[ "$failed" -ne 0 ]]; then
+    ((TESTS_PASSED++)) || true
+    printf '  \033[0;32m✓\033[0m %s\n' "$CURRENT_TEST"
+  else
+    ((TESTS_FAILED++)) || true
+    printf '  \033[0;31m✗\033[0m %s: a broken command was measured as healthy\n' \
+      "$CURRENT_TEST"
   fi
 }
 
@@ -105,6 +175,11 @@ _sandbox() {
   export XDG_STATE_HOME="$sb/.local/state"
   mkdir -p "$XDG_CONFIG_HOME" "$XDG_DATA_HOME" "$XDG_CACHE_HOME" "$XDG_STATE_HOME/dotfiles"
   export CHEZMOI_SOURCE_DIR="$REPO_ROOT"
+  # chezmoi resolves its source dir under XDG_DATA_HOME. Without this the
+  # sandbox has none, so `dot status` / `diff` / `doctor` all abort with
+  # "no such file or directory" — and before breakage detection existed,
+  # those gates were silently timing the failure path, not the command.
+  ln -s "$REPO_ROOT" "$XDG_DATA_HOME/chezmoi"
   # iCloud mock for icloud-script perf test
   mkdir -p "$sb/Library/Mobile Documents/com~apple~CloudDocs"
   export DOTFILES_NO_BANNER=1
@@ -116,86 +191,99 @@ _sandbox() {
 # =============================================================================
 _sandbox >/dev/null
 
-test_start "instant_dot_version"
-_gate "$CURRENT_TEST" 500 5 bash "$DOT_CLI" version
+_selftest_rejects_broken
 
-test_start "instant_dot_help"
-_gate "$CURRENT_TEST" 500 5 bash "$DOT_CLI" help
+_gate "instant_dot_version" 500 5 bash "$DOT_CLI" version
 
-test_start "instant_dot_help_doctor"
-_gate "$CURRENT_TEST" 500 5 bash "$DOT_CLI" help doctor
+_gate "instant_dot_help" 500 5 bash "$DOT_CLI" help
 
-test_start "instant_dot_help_theme"
-_gate "$CURRENT_TEST" 500 5 bash "$DOT_CLI" help theme
+_gate "instant_dot_help_doctor" 500 5 bash "$DOT_CLI" help doctor
 
-test_start "instant_dot_help_apply"
-_gate "$CURRENT_TEST" 500 5 bash "$DOT_CLI" help apply
+_gate "instant_dot_help_theme" 500 5 bash "$DOT_CLI" help theme
 
-test_start "instant_dot_search"
-_gate "$CURRENT_TEST" 500 5 bash "$DOT_CLI" search theme
+_gate "instant_dot_help_apply" 500 5 bash "$DOT_CLI" help apply
 
-test_start "instant_icloud_script_single_run"
+_gate "instant_dot_search" 500 5 bash "$DOT_CLI" search theme
+
 # Render darwin-guarded template to a plain script
 _rendered="$(mktemp)"
 sed -e '/^{{- if eq \.chezmoi\.os "darwin" -}}$/d' \
     -e '/^{{- end -}}$/d' \
     "$ICLOUD_TMPL" > "$_rendered"
-_gate "$CURRENT_TEST" 500 5 bash "$_rendered"
+_gate "instant_icloud_script_single_run" 500 5 bash "$_rendered"
 rm -f "$_rendered"
 
-test_start "instant_check_version_consistency"
-_gate "$CURRENT_TEST" 500 5 bash "$REPO_ROOT/scripts/qa/check-version-consistency.sh"
 
-test_start "instant_docs_coverage"
-_gate "$CURRENT_TEST" 500 5 bash "$REPO_ROOT/scripts/qa/docs-coverage.sh"
 
-test_start "instant_icloud_regression_test"
-# 600ms, not the tier's nominal 500ms: this budget is calibrated per
-# assertion count (see tier notes above). At 9 assertions it measured
-# ~435ms against a 500ms gate; the 10th assertion (link-form recognition,
-# which shares a sandbox with invariant 3 to stay cheap) moves the median
-# to ~495ms — inside 500ms on a good run, over it on a noisy one. 600ms
-# restores the ~20% headroom the 9-assertion calibration had, so the gate
-# still catches real regressions instead of flaking on scheduler noise.
-_gate "$CURRENT_TEST" 600 5 bash "$REPO_ROOT/tests/regression/test_macos_icloud_symlinks_safety.sh"
 
 # =============================================================================
 # TIER 2: FAST (≤2000ms)
 # =============================================================================
 
-test_start "fast_traceability_coverage"
-_gate "$CURRENT_TEST" 2000 3 bash "$REPO_ROOT/scripts/qa/traceability-coverage.sh"
 
-test_start "fast_icloud_unit_test"
-_gate "$CURRENT_TEST" 2000 3 bash "$REPO_ROOT/tests/unit/misc/test_macos_icloud_symlinks.sh"
 
-test_start "fast_dot_subcommand_smoke"
-_gate "$CURRENT_TEST" 2000 3 bash "$REPO_ROOT/tests/regression/test_dot_subcommand_smoke.sh"
 
-test_start "fast_dot_help_registry_symmetry"
-_gate "$CURRENT_TEST" 2000 3 bash "$REPO_ROOT/tests/regression/test_dot_help_registry_symmetry.sh"
 
-test_start "fast_dot_status"
-_gate "$CURRENT_TEST" 2000 3 bash "$DOT_CLI" status
+_gate "fast_dot_status" 2000 3 bash "$DOT_CLI" status
 
-test_start "fast_dot_diff"
-_gate "$CURRENT_TEST" 2000 3 bash "$DOT_CLI" diff
+_gate "fast_dot_diff" 2000 3 bash "$DOT_CLI" diff
 
 # =============================================================================
 # TIER 3: MEDIUM (≤5000ms)
 # =============================================================================
 
-test_start "medium_dot_doctor"
-_gate "$CURRENT_TEST" 5000 3 bash "$DOT_CLI" doctor
+_gate_diag "medium_dot_doctor" 5000 3 bash "$DOT_CLI" doctor
 
 # tests/performance/bench.sh has been observed at ~2s; give it 5s headroom
-test_start "medium_bench_quick_mode"
 if [[ -f "$REPO_ROOT/tests/performance/bench.sh" ]]; then
-  _gate "$CURRENT_TEST" 5000 3 bash "$REPO_ROOT/tests/performance/bench.sh" --quick
+  _gate_diag "medium_bench_quick_mode" 5000 3 bash "$REPO_ROOT/tests/performance/bench.sh" --quick
 else
-  ((TESTS_PASSED++)) || true
-  printf '  \033[0;33m~\033[0m %s (bench.sh not executable — skipped)\n' "$CURRENT_TEST"
+  # Absent bench.sh is not a pass — skip silently rather than bump a counter
+  # without a matching test_start, which would break the framework invariant
+  # TESTS_RUN == TESTS_PASSED + TESTS_FAILED.
+  printf '  \033[0;33m~\033[0m medium_bench_quick_mode (bench.sh absent — not measured)\n'
 fi
+
+
+# =============================================================================
+# TIER 4: GATES — CI quality gates and test suites
+# =============================================================================
+# These are NOT interactive operations, so the instant/fast ceilings (which
+# describe latency a human perceives at a prompt) never applied to them. They
+# get individual budgets from the doc's own rule — 2x the measured median —
+# taken on the SLOWEST supported platform rather than the fastest.
+#
+# That last part matters: the previous budgets came solely from a Ryzen Linux
+# desktop, where these run 3-6x faster than on macOS (fork/exec is markedly
+# more expensive here, and every gate is fork-heavy shell). CI covers Linux
+# AND macOS, so a Linux-only calibration cannot hold — which is why five of
+# these sat red. Medians below measured on rousseau-mbp-m1, 2026-08-30.
+#
+#   docs-coverage.sh          ~930ms  -> 2000
+#   check-version-consistency ~ <50ms -> 500   (unchanged; genuinely fast)
+#   iCloud regression test    ~475ms  -> 1000
+#   iCloud unit test          ~1620ms -> 3500
+#   traceability-coverage.sh  ~2390ms -> 5000
+#   dot_subcommand_smoke      ~3620ms -> 7500
+#   dot_help_registry_symmetry ~4420ms -> 9000
+#
+# The iCloud regression budget replaces an earlier ad-hoc 500->600ms nudge
+# made to accommodate a newly added assertion. 1000ms comes from the same
+# 2x rule as every other entry here, so it is calibrated rather than fudged.
+
+_gate "gate_check_version_consistency" 500 5 bash "$REPO_ROOT/scripts/qa/check-version-consistency.sh"
+
+_gate "gate_docs_coverage" 2000 3 bash "$REPO_ROOT/scripts/qa/docs-coverage.sh"
+
+_gate "gate_icloud_regression_test" 1000 5 bash "$REPO_ROOT/tests/regression/test_macos_icloud_symlinks_safety.sh"
+
+_gate "gate_icloud_unit_test" 3500 3 bash "$REPO_ROOT/tests/unit/misc/test_macos_icloud_symlinks.sh"
+
+_gate "gate_traceability_coverage" 5000 3 bash "$REPO_ROOT/scripts/qa/traceability-coverage.sh"
+
+_gate "gate_dot_subcommand_smoke" 7500 3 bash "$REPO_ROOT/tests/regression/test_dot_subcommand_smoke.sh"
+
+_gate "gate_dot_help_registry_symmetry" 9000 3 bash "$REPO_ROOT/tests/regression/test_dot_help_registry_symmetry.sh"
 
 # =============================================================================
 # Summary

--- a/benches/test_perf_budgets.sh
+++ b/benches/test_perf_budgets.sh
@@ -2,6 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright (c) 2015-2026 Sebastien Rousseau
 # shellcheck disable=SC1090,SC1091,SC2034
+# preamble:skip
+#
+# This is a test-framework script, not a program: it uses the same assertion
+# helpers as tests/, reports every budget it breaches rather than dying on the
+# first, and measures commands whose non-zero exit is the thing being asserted.
+# `set -e` would abort at the first violation and turn a full report into a
+# single line. It lived under tests/ — which the preamble check skips for
+# exactly this reason — until benches/ became the home for timing work.
 #
 # Performance budgets — one place, tiered targets, measured baselines.
 #
@@ -26,13 +34,13 @@
 #
 #   MEDIUM  (≤ 5000ms) — full diagnostics runs
 #     * dot doctor
-#     * tests/performance/bench.sh (quick mode)
+#     * benches/bench.sh (quick mode)
 #
 #   ACCEPTED-SLOW (documented, best-effort)
 #     * test_dot_help_flag_universal — invokes dot help --help on ~100
 #       commands via a subshell each; ~11s is legitimate for the
 #       coverage it provides. Not gated here; tracked in wall-clock
-#       ratchet (tests/performance/test_help_gates_wall_clock.sh).
+#       ratchet (benches/test_help_gates_wall_clock.sh).
 #
 #   OUT-OF-SCOPE — multi-minute operations we do not gate per-run
 #     * chezmoi apply (fresh macOS: minutes)
@@ -50,8 +58,11 @@
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
-source "$SCRIPT_DIR/../framework/assertions.sh"
+REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+# The assertions framework lives under tests/, not beside this file: benches/
+# is a sibling of tests/, so it is addressed from the repository root rather
+# than relative to SCRIPT_DIR.
+source "$REPO_ROOT/tests/framework/assertions.sh"
 
 # Overridable so the breakage-detection path can be exercised against a
 # deliberately corrupted CLI without touching the real one.
@@ -79,10 +90,12 @@ _measure() {
     rc=0
     times+=("$(( (end_ns - start_ns) / 1000000 ))")
   done
-  # median
-  local sorted
-  IFS=$'\n' sorted=($(printf '%s\n' "${times[@]}" | sort -n))
-  unset IFS
+  # median. Read the sorted list line by line rather than word-splitting a
+  # command substitution: mapfile is bash 4, and macOS ships bash 3.2.
+  local sorted=() _t
+  while IFS= read -r _t; do
+    sorted+=("$_t")
+  done < <(printf '%s\n' "${times[@]}" | sort -n)
   local mid=$((runs / 2))
   printf '%s %s' "$worst_rc" "${sorted[$mid]}"
 }
@@ -243,9 +256,9 @@ _gate "fast_dot_diff" 2000 3 bash "$DOT_CLI" diff
 
 _gate_diag "medium_dot_doctor" 5000 3 bash "$DOT_CLI" doctor
 
-# tests/performance/bench.sh has been observed at ~2s; give it 5s headroom
-if [[ -f "$REPO_ROOT/tests/performance/bench.sh" ]]; then
-  _gate_diag "medium_bench_quick_mode" 5000 3 bash "$REPO_ROOT/tests/performance/bench.sh" --quick
+# benches/bench.sh has been observed at ~2s; give it 5s headroom
+if [[ -f "$REPO_ROOT/benches/bench.sh" ]]; then
+  _gate_diag "medium_bench_quick_mode" 5000 3 bash "$REPO_ROOT/benches/bench.sh" --quick
 else
   # Absent bench.sh is not a pass — skip silently rather than bump a counter
   # without a matching test_start, which would break the framework invariant

--- a/benches/test_perf_budgets.sh
+++ b/benches/test_perf_budgets.sh
@@ -346,6 +346,12 @@ _gate "gate_docs_coverage" 2000 3 bash "$REPO_ROOT/scripts/qa/docs-coverage.sh"
 
 _gate "gate_icloud_regression_test" 1000 5 bash "$REPO_ROOT/tests/regression/test_macos_icloud_symlinks_safety.sh"
 
+# Hashes the whole sandbox tree before and after each scenario, so it costs
+# more than the canary-file suite above and is measured separately. Local
+# median 1575ms; 5000ms keeps >3x headroom, which the disk-bound work here
+# needs on a hosted runner.
+_gate "gate_icloud_manifest_test" 5000 3 bash "$REPO_ROOT/tests/regression/test_macos_icloud_symlinks_manifest.sh"
+
 _gate "gate_icloud_unit_test" 3500 3 bash "$REPO_ROOT/tests/unit/misc/test_macos_icloud_symlinks.sh"
 
 _gate "gate_traceability_coverage" 5000 3 bash "$REPO_ROOT/scripts/qa/traceability-coverage.sh"

--- a/benches/test_perf_budgets.sh
+++ b/benches/test_perf_budgets.sh
@@ -70,26 +70,52 @@ DOT_CLI="${DOT_CLI:-$REPO_ROOT/bin/dot}"
 ICLOUD_TMPL="$REPO_ROOT/defaults/run_before_macos-icloud-symlinks.sh.tmpl"
 
 # ---------------------------------------------------------------------------
-# _measure — run a command N times, return median wall-clock ms.
-# Uses date +%s%N for high-resolution timing (bash builtin timings
-# aren't consistent across shells / macOS bash).
+# _measure — run a command N times, return "<worst exit status> <median ms>".
+#
+# Timing comes from the `time` keyword with TIMEFORMAT, not from
+# `date +%s%N`. %N is a GNU extension: BSD date, which is what macOS 14 and
+# earlier ship, copies the literal "N" through. Every arithmetic below then
+# died on "value too great for base", _measure returned nothing, and an empty
+# median compares as 0 against any budget — so on those machines this gate
+# reported every budget met, including for a CLI that could not parse. It was
+# the silently-passing gate this file exists to argue against, and it went
+# unnoticed because the runner that exposed it, macos-14, is the only one in
+# the matrix old enough to have a date without %N.
+#
+# The `time` keyword is a shell builtin, present and millisecond-accurate in
+# bash 3.2, and needs no external clock at all. LC_ALL is pinned because
+# TIMEFORMAT renders the decimal separator per locale.
 # ---------------------------------------------------------------------------
 _measure() {
   local runs="$1"; shift
   local times=() worst_rc=0 rc=0
-  local i start_ns end_ns
+  local i elapsed secs ms rc_file
+  local TIMEFORMAT='%3R'
+  rc_file="$(mktemp)"
   for ((i=0; i<runs; i++)); do
-    start_ns=$(date +%s%N)
     # F2: capture the exit status instead of discarding it. A command that
     # crashes instantly is FAST, and the old `|| true` let it sail through
-    # its budget — a broken `dot` reported excellent performance.
-    "$@" >/dev/null 2>&1 || rc=$?
-    end_ns=$(date +%s%N)
-    # Bookkeeping AFTER the clock stops, so it is not counted in the median.
+    # its budget — a broken `dot` reported excellent performance. The status
+    # is written to a file because `time` needs the command inside its own
+    # group, whose exit status the substitution below does not carry out.
+    elapsed="$(
+      LC_ALL=C
+      { time { "$@" >/dev/null 2>&1; printf '%s' "$?" >"$rc_file"; }; } 2>&1
+    )"
+    rc="$(cat "$rc_file")"
     [[ "$rc" -gt "$worst_rc" ]] && worst_rc="$rc"
-    rc=0
-    times+=("$(( (end_ns - start_ns) / 1000000 ))")
+    # "1.234" -> 1234. Split on the decimal point rather than using floating
+    # point, which the shell has none of.
+    secs="${elapsed%%.*}"
+    ms="${elapsed##*.}"
+    if [[ ! "$secs" =~ ^[0-9]+$ ]] || [[ ! "$ms" =~ ^[0-9]{3}$ ]]; then
+      rm -f "$rc_file"
+      printf 'CLOCK_UNUSABLE %s' "$elapsed"
+      return 0
+    fi
+    times+=("$((10#$secs * 1000 + 10#$ms))")
   done
+  rm -f "$rc_file"
   # median. Read the sorted list line by line rather than word-splitting a
   # command substitution: mapfile is bash 4, and macOS ships bash 3.2.
   local sorted=() _t
@@ -140,6 +166,16 @@ _gate_max_rc() {
   out="$(_measure "$runs" "$@")"
   failed="${out%% *}"
   median="${out##* }"
+  # A gate that could not measure must fail, not pass. Both fields go through
+  # `-gt` / `-le`, and bash reads a non-numeric operand there as 0 — so
+  # without this an unusable clock would have silently satisfied every budget,
+  # which is exactly how the BSD-date breakage stayed invisible.
+  if [[ ! "$failed" =~ ^[0-9]+$ ]] || [[ ! "$median" =~ ^[0-9]+$ ]]; then
+    ((TESTS_FAILED++)) || true
+    printf '  \033[0;31m✗\033[0m %s: could not measure (got %s) — refusing to report a pass\n' \
+      "$label" "$out"
+    return 0
+  fi
   if [[ "$failed" -gt "$max_rc" ]]; then
     ((TESTS_FAILED++)) || true
     printf '  \033[0;31m✗\033[0m %s: exited %s (max allowed %s) — timing is meaningless\n' \

--- a/benches/test_perf_budgets.sh
+++ b/benches/test_perf_budgets.sh
@@ -246,13 +246,24 @@ rm -f "$_rendered"
 
 
 
-_gate "fast_dot_status" 2000 3 bash "$DOT_CLI" status
-
-_gate "fast_dot_diff" 2000 3 bash "$DOT_CLI" diff
-
 # =============================================================================
 # TIER 3: MEDIUM (≤5000ms)
 # =============================================================================
+
+# `dot status` and `dot diff` were first placed in FAST at 2000ms against
+# reference medians of 1510ms and 1420ms — 1.3x and 1.4x headroom, below the
+# >= 2x this file requires of every budget. The gate never actually ran until
+# now (it died sourcing its framework), so nothing measured them on a hosted
+# runner. The first real run did: 2290ms / 2157ms on macOS and 2329ms / 2136ms
+# on Ubuntu. Two unrelated platforms agreeing within 8% is a property of the
+# commands, not of one slow runner — both shell out to chezmoi, which walks the
+# whole source tree, and that is disk-bound. MEDIUM is where their measured
+# cost puts them: 2.1x headroom over the worst observed, so a genuine doubling
+# still fails. Lowering the bar to fit a measurement would be worth objecting
+# to; this is the first measurement the bar was ever set against.
+_gate "medium_dot_status" 5000 3 bash "$DOT_CLI" status
+
+_gate "medium_dot_diff" 5000 3 bash "$DOT_CLI" diff
 
 _gate_diag "medium_dot_doctor" 5000 3 bash "$DOT_CLI" doctor
 

--- a/bin/dot
+++ b/bin/dot
@@ -4,7 +4,7 @@
 # Copyright (c) 2015-2026 Sebastien Rousseau
 set -euo pipefail
 
-# Dotfiles CLI Entry Point - v0.2.520
+# Dotfiles CLI Entry Point - v0.2.519
 
 # Ensure XDG Base Directory variables are set
 export XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"
@@ -22,7 +22,7 @@ if [ -e "${HOME}/.nix-profile/etc/profile.d/nix.sh" ]; then
   . "${HOME}/.nix-profile/etc/profile.d/nix.sh"
 fi
 
-VERSION="0.2.520"
+VERSION="0.2.519"
 
 COMMAND="${1:-}"
 if [ -n "${1:-}" ]; then

--- a/bin/dot
+++ b/bin/dot
@@ -4,7 +4,7 @@
 # Copyright (c) 2015-2026 Sebastien Rousseau
 set -euo pipefail
 
-# Dotfiles CLI Entry Point - v0.2.519
+# Dotfiles CLI Entry Point - v0.2.520
 
 # Ensure XDG Base Directory variables are set
 export XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"
@@ -22,7 +22,7 @@ if [ -e "${HOME}/.nix-profile/etc/profile.d/nix.sh" ]; then
   . "${HOME}/.nix-profile/etc/profile.d/nix.sh"
 fi
 
-VERSION="0.2.519"
+VERSION="0.2.520"
 
 COMMAND="${1:-}"
 if [ -n "${1:-}" ]; then

--- a/bin/dot
+++ b/bin/dot
@@ -4,7 +4,7 @@
 # Copyright (c) 2015-2026 Sebastien Rousseau
 set -euo pipefail
 
-# Dotfiles CLI Entry Point - v0.2.519
+# Dotfiles CLI Entry Point - v0.2.520
 
 # Ensure XDG Base Directory variables are set
 export XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"
@@ -22,7 +22,7 @@ if [ -e "${HOME}/.nix-profile/etc/profile.d/nix.sh" ]; then
   . "${HOME}/.nix-profile/etc/profile.d/nix.sh"
 fi
 
-VERSION="0.2.519"
+VERSION="0.2.520"
 
 COMMAND="${1:-}"
 if [ -n "${1:-}" ]; then
@@ -52,8 +52,8 @@ _resolve_source_dir() {
   done
   if script_path="$(cd "$(dirname "$script_path")" && pwd 2>/dev/null)"; then
     script_dir="$script_path"
-    # Post-v0.2.519: the canonical dispatcher lives at <repo>/bin/dot, so
-    # $script_dir/.. is the repo root. Pre-v0.2.519 (and chezmoi-deployed
+    # Post-v0.2.520: the canonical dispatcher lives at <repo>/bin/dot, so
+    # $script_dir/.. is the repo root. Pre-v0.2.520 (and chezmoi-deployed
     # wrapper invocations that still exec the canonical) the dispatcher
     # was at <repo>/dot_local/bin/executable_dot, so $script_dir/../..
     # was the repo. Probe both to cover the transition.

--- a/defaults/.chezmoidata.toml
+++ b/defaults/.chezmoidata.toml
@@ -1,5 +1,5 @@
 # Active profile - change this to switch configurations
-dotfiles_version = "0.2.519"
+dotfiles_version = "0.2.520"
 profile = "laptop"
 
 # Machine preset — set per-host in ~/.config/chezmoi/chezmoi.toml:

--- a/defaults/.chezmoidata.toml
+++ b/defaults/.chezmoidata.toml
@@ -1,5 +1,5 @@
 # Active profile - change this to switch configurations
-dotfiles_version = "0.2.520"
+dotfiles_version = "0.2.519"
 profile = "laptop"
 
 # Machine preset — set per-host in ~/.config/chezmoi/chezmoi.toml:

--- a/defaults/.chezmoitemplates/README.md
+++ b/defaults/.chezmoitemplates/README.md
@@ -5,7 +5,7 @@
   align="right"
 />
 
-# Chezmoi Templates (v0.2.519)
+# Chezmoi Templates (v0.2.520)
 
 Modular shell configuration managed by Chezmoi
 

--- a/defaults/.chezmoitemplates/aliases/README.md
+++ b/defaults/.chezmoitemplates/aliases/README.md
@@ -5,7 +5,7 @@
   align="right"
 />
 
-# Dotfiles Aliases (v0.2.519)
+# Dotfiles Aliases (v0.2.520)
 
 Modular alias definitions managed by Chezmoi
 

--- a/defaults/.chezmoitemplates/functions/README.md
+++ b/defaults/.chezmoitemplates/functions/README.md
@@ -5,7 +5,7 @@
   align="right"
 />
 
-# Dotfiles Functions (v0.2.519)
+# Dotfiles Functions (v0.2.520)
 
 > Modular shell utilities managed by Chezmoi
 

--- a/defaults/dot_config/shell/README.md
+++ b/defaults/dot_config/shell/README.md
@@ -27,7 +27,7 @@ Welcome to your universally compatible, high-performance dotfiles configuration,
 To install these dotfiles on a new machine, run:
 
 ```bash
-bash -c "$(curl -fsSL https://raw.githubusercontent.com/sebastienrousseau/dotfiles/v0.2.519/install.sh)"
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/sebastienrousseau/dotfiles/v0.2.520/install.sh)"
 ```
 
 This command will:

--- a/defaults/dot_local/share/dot-mcp/example_test.go
+++ b/defaults/dot_local/share/dot-mcp/example_test.go
@@ -20,7 +20,7 @@ func ExampleServer_Serve() {
 		fmt.Println("serve:", err)
 	}
 	// Output:
-	// {"jsonrpc":"2.0","id":1,"result":{"capabilities":{"logging":{},"resources":{"listChanged":false,"subscribe":false},"tools":{"listChanged":false}},"instructions":"Read-only governance surface for a chezmoi-managed dotfiles workstation. Tools run the `dot` CLI's own audit commands and never change configuration. Resources expose the MCP policy, the MCP registry, the agent profiles and the discovery cards.","protocolVersion":"2025-06-18","serverInfo":{"name":"dotfiles-mcp","title":"dotfiles workstation governance","version":"0.2.519"}}}
+	// {"jsonrpc":"2.0","id":1,"result":{"capabilities":{"logging":{},"resources":{"listChanged":false,"subscribe":false},"tools":{"listChanged":false}},"instructions":"Read-only governance surface for a chezmoi-managed dotfiles workstation. Tools run the `dot` CLI's own audit commands and never change configuration. Resources expose the MCP policy, the MCP registry, the agent profiles and the discovery cards.","protocolVersion":"2025-06-18","serverInfo":{"name":"dotfiles-mcp","title":"dotfiles workstation governance","version":"0.2.520"}}}
 }
 
 // ExampleServer_Serve_toolsCall shows a tool call being answered with both a

--- a/defaults/dot_local/share/dot-mcp/main.go
+++ b/defaults/dot_local/share/dot-mcp/main.go
@@ -32,7 +32,7 @@ import (
 // defaults/.chezmoidata.toml and is kept in step with
 // .well-known/mcp/server-card.json by scripts/version-sync.sh; the pairing is
 // asserted by TestVersionMatchesServerCard.
-const version = "0.2.519"
+const version = "0.2.520"
 
 // Process-boundary seams. Each wraps exactly one call that cannot be exercised
 // in-process by `go test`: os.Exit terminates the test binary. Tests substitute

--- a/defaults/run_before_macos-icloud-symlinks.sh.tmpl
+++ b/defaults/run_before_macos-icloud-symlinks.sh.tmpl
@@ -3,7 +3,7 @@
 # Copyright (c) 2015-2026 Sebastien Rousseau
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# run_once_before_macos-icloud-symlinks.sh.tmpl
+# run_before_macos-icloud-symlinks.sh.tmpl
 #
 # =============================================================================
 # WHAT THIS SCRIPT DOES (and, critically, WHAT IT REFUSES TO DO)
@@ -20,9 +20,20 @@
 #
 # This script replaces that mechanism with a paranoid, additive approach:
 #
-#   1. It runs ONCE, before chezmoi apply, on macOS only. `run_once_before_`
-#      means chezmoi only runs it if the file's contents change from the
-#      previously-applied version — and only before any other apply steps.
+#   1. It runs before every `chezmoi apply`, on macOS only, and CONVERGES:
+#      each run re-evaluates the refusal matrix and links whatever has
+#      become safe to link since the last one.
+#
+#      This deliberately is NOT `run_once_before_`. A run-once script gets
+#      exactly one attempt, and on a fresh Mac that attempt lands while
+#      iCloud Drive is still syncing the folder tree down — so every
+#      candidate hits "iCloud source does not exist yet", skips, and the
+#      one chance is spent. The links would then never be created, which
+#      is precisely the opposite of what this script is for.
+#
+#      Re-running is safe by construction: every branch of the refusal
+#      matrix below is idempotent, and an already-correct link is a
+#      logged no-op. Steady-state cost is a few milliseconds.
 #
 #   2. It NEVER removes non-empty directories. Ever. The only removal it
 #      performs is `rmdir` on an empty dir — a call that fails safely if
@@ -84,11 +95,18 @@ LOG_DIR="$XDG_STATE_HOME/dotfiles"
 LOG_FILE="$LOG_DIR/icloud-symlinks.log"
 mkdir -p "$LOG_DIR"
 
+# One timestamp per run, not one per line. Every line in a run shares the
+# same second anyway, so per-line `date` calls bought nothing but ~13
+# subprocess spawns — a third of this script's runtime. Measured 92ms ->
+# 61ms median (interleaved A/B, 25 samples). bash 3.2 is the target here
+# (stock macOS), so printf '%(%s)T' is not available.
+_RUN_TS="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
 _log() {
   # Always both stdout (visible in chezmoi apply output) and the log file.
   local msg="$1"
   printf '[icloud-symlinks] %s\n' "$msg"
-  printf '%s [icloud-symlinks] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$msg" \
+  printf '%s [icloud-symlinks] %s\n' "$_RUN_TS" "$msg" \
     >> "$LOG_FILE"
 }
 

--- a/defaults/run_once_before_macos-icloud-symlinks.sh.tmpl
+++ b/defaults/run_once_before_macos-icloud-symlinks.sh.tmpl
@@ -1,0 +1,220 @@
+{{- if eq .chezmoi.os "darwin" -}}
+#!/usr/bin/env bash
+# Copyright (c) 2015-2026 Sebastien Rousseau
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+# run_once_before_macos-icloud-symlinks.sh.tmpl
+#
+# =============================================================================
+# WHAT THIS SCRIPT DOES (and, critically, WHAT IT REFUSES TO DO)
+# =============================================================================
+#
+# Re-establishes the iCloud Drive symlinks that the deleted
+# defaults/symlink_*.tmpl files used to manage — SAFELY.
+#
+# The previous mechanism used chezmoi's symlink_ templates, which have a
+# fatal flaw: chezmoi's "replace target with symlink" logic is essentially
+# `rm -rf $target; ln -s $source $target`. If the target directory has
+# ANY content when chezmoi first applies, that content is destroyed. This
+# is the bug that deleted a user's real ~/Documents (see #1018).
+#
+# This script replaces that mechanism with a paranoid, additive approach:
+#
+#   1. It runs ONCE, before chezmoi apply, on macOS only. `run_once_before_`
+#      means chezmoi only runs it if the file's contents change from the
+#      previously-applied version — and only before any other apply steps.
+#
+#   2. It NEVER removes non-empty directories. Ever. The only removal it
+#      performs is `rmdir` on an empty dir — a call that fails safely if
+#      the dir contains anything, including hidden files.
+#
+#   3. It NEVER moves user data into iCloud. Users move their own data.
+#      The script's contract: "if you tell me the target is safe to link,
+#      I'll link it. Otherwise I'll skip and log why."
+#
+#   4. It requires iCloud Drive to be set up (checks that the CloudDocs
+#      container exists on disk). If iCloud isn't set up on the machine,
+#      the script silently skips — no error, no partial state.
+#
+#   5. It writes a persistent log to $XDG_STATE_HOME/dotfiles/icloud-
+#      symlinks.log with a decision per candidate. Every run appends;
+#      nothing is ever silently overwritten.
+#
+#   6. It has an override: touch $HOME/.dotfiles.icloud-skip to short-
+#      circuit the whole script permanently. Useful for CI, VMs, or
+#      Macs where iCloud symlinks are actively unwanted.
+#
+#   7. It reports what it did to stdout so `chezmoi apply` shows a
+#      summary of "linked / already linked / skipped-because-non-empty /
+#      skipped-because-iCloud-source-missing / skipped-because-override".
+#
+# --- REFUSAL MATRIX ---
+#
+# For each candidate directory (~/Desktop, ~/Documents, ~/Downloads,
+# ~/Movies, ~/Music, ~/Pictures, ~/Public), the script decides:
+#
+#   State of $HOME/$name           | Action taken
+#   -------------------------------|----------------------------------------
+#   Symlink to iCloud source       | NO-OP (already correct)
+#   Symlink to somewhere else      | SKIP + log (never overwrite user's link)
+#   Regular dir, non-empty         | SKIP + log (data protection - never touch)
+#   Regular dir, empty             | rmdir + create symlink
+#   Regular file                   | SKIP + log (unexpected — never touch)
+#   Does not exist                 | Create symlink directly
+#
+#   State of iCloud source dir     | Action taken
+#   -------------------------------|----------------------------------------
+#   Does not exist                 | SKIP + log (iCloud may still be syncing)
+#   Is a directory                 | Proceed with link
+#   Is a symlink                   | SKIP + log (unexpected iCloud state)
+#
+# --- ENV OVERRIDES ---
+#
+#   DOTFILES_ICLOUD_SYMLINKS=0     Skip entirely (documented alt to touch-file)
+#   DOTFILES_ICLOUD_DRY_RUN=1      Log decisions, take no action
+#
+# =============================================================================
+
+set -euo pipefail
+
+# --- 0. Log destination -------------------------------------------------------
+XDG_STATE_HOME="${XDG_STATE_HOME:-$HOME/.local/state}"
+LOG_DIR="$XDG_STATE_HOME/dotfiles"
+LOG_FILE="$LOG_DIR/icloud-symlinks.log"
+mkdir -p "$LOG_DIR"
+
+_log() {
+  # Always both stdout (visible in chezmoi apply output) and the log file.
+  local msg="$1"
+  printf '[icloud-symlinks] %s\n' "$msg"
+  printf '%s [icloud-symlinks] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$msg" \
+    >> "$LOG_FILE"
+}
+
+# --- 1. Kill-switches ---------------------------------------------------------
+if [[ -f "$HOME/.dotfiles.icloud-skip" ]]; then
+  _log "SKIP-ALL: found kill-switch file ~/.dotfiles.icloud-skip"
+  exit 0
+fi
+
+if [[ "${DOTFILES_ICLOUD_SYMLINKS:-1}" == "0" ]]; then
+  _log "SKIP-ALL: DOTFILES_ICLOUD_SYMLINKS=0"
+  exit 0
+fi
+
+DRY_RUN=0
+if [[ "${DOTFILES_ICLOUD_DRY_RUN:-0}" == "1" ]]; then
+  DRY_RUN=1
+  _log "DRY-RUN: no changes will be applied"
+fi
+
+# --- 2. iCloud availability ---------------------------------------------------
+ICLOUD_ROOT="$HOME/Library/Mobile Documents/com~apple~CloudDocs"
+if [[ ! -d "$ICLOUD_ROOT" ]]; then
+  _log "SKIP-ALL: iCloud Drive not initialised on this Mac ($ICLOUD_ROOT missing)"
+  exit 0
+fi
+
+# --- 3. Candidate directories -------------------------------------------------
+# Kept as a single-column list for clarity. Any name added here MUST also
+# be listed in defaults/.chezmoiignore.tmpl's Darwin block — that's the
+# belt-and-braces guarantee that chezmoi never manages these paths.
+CANDIDATES=(
+  Desktop
+  Documents
+  Downloads
+  Movies
+  Music
+  Pictures
+  Public
+)
+
+# --- 4. Per-candidate decision --------------------------------------------
+# Each candidate is handled independently. Failure of one MUST NOT abort
+# the others — so we wrap the per-candidate logic in a subshell + `|| true`.
+# This is a deliberate tradeoff: partial success is better than no
+# progress. Every decision is logged.
+
+_link_if_safe() {
+  local name="$1"
+  local target="$HOME/$name"
+  local source="$ICLOUD_ROOT/$name"
+
+  # --- iCloud source checks (READ-ONLY) ---
+  if [[ ! -e "$source" ]]; then
+    _log "SKIP '$name': iCloud source does not exist yet ('$source')"
+    return 0
+  fi
+  if [[ -L "$source" ]]; then
+    _log "SKIP '$name': iCloud source is itself a symlink (unexpected)"
+    return 0
+  fi
+  if [[ ! -d "$source" ]]; then
+    _log "SKIP '$name': iCloud source exists but is not a directory"
+    return 0
+  fi
+
+  # --- Target checks (destructive-adjacent — MAXIMUM CAUTION) ---
+  if [[ -L "$target" ]]; then
+    # Already a symlink. Compare where it points to.
+    local current
+    current="$(readlink "$target" 2>/dev/null || echo '')"
+    if [[ "$current" == "$source" ]]; then
+      _log "OK   '$name': already symlinked to iCloud"
+      return 0
+    fi
+    # Symlink pointing elsewhere — user's own setup, do not touch.
+    _log "SKIP '$name': is a symlink to '$current' (not iCloud) — leaving alone"
+    return 0
+  fi
+
+  if [[ -f "$target" ]]; then
+    # Unexpected: a regular file where we'd expect a dir/symlink. Refuse.
+    _log "SKIP '$name': target is a regular file, refusing to touch"
+    return 0
+  fi
+
+  if [[ -d "$target" ]]; then
+    # It's a directory. Is it EMPTY? Use `ls -A` (shows hidden) + wc.
+    # NOT `find -empty` because we want to be paranoid about a file
+    # named `.DS_Store` — that still counts as "user has data here."
+    local count
+    count="$(ls -A "$target" 2>/dev/null | wc -l | tr -d ' ')"
+    if [[ "$count" != "0" ]]; then
+      _log "SKIP '$name': target dir has $count entries, refusing (user data protection)"
+      _log "     to link this dir manually: move your files into '$source' then run:"
+      _log "       rm -rf '$target' && ln -s '$source' '$target'"
+      return 0
+    fi
+    # Empty dir. Safe to rmdir + symlink.
+    if [[ "$DRY_RUN" == "1" ]]; then
+      _log "DRY  '$name': would rmdir empty target + create symlink to iCloud"
+      return 0
+    fi
+    # rmdir fails safely on non-empty (double-check in case of TOCTOU
+    # race — a file could appear between our check and the rmdir).
+    if ! rmdir "$target" 2>/dev/null; then
+      _log "SKIP '$name': rmdir of empty dir failed (race? permissions?) — no action"
+      return 0
+    fi
+    ln -s "$source" "$target"
+    _log "LINK '$name': created symlink -> iCloud"
+    return 0
+  fi
+
+  # Target does not exist at all — simplest case, just create the link.
+  if [[ "$DRY_RUN" == "1" ]]; then
+    _log "DRY  '$name': would create symlink to iCloud (target missing)"
+    return 0
+  fi
+  ln -s "$source" "$target"
+  _log "LINK '$name': created symlink -> iCloud (target didn't exist)"
+  return 0
+}
+
+_log "== BEGIN run — user=$(whoami) host=$(hostname) =="
+for name in "${CANDIDATES[@]}"; do
+  ( _link_if_safe "$name" ) || _log "ERR  '$name': subshell failed (see above)"
+done
+_log "== END run =="
+{{- end -}}

--- a/defaults/run_once_before_macos-icloud-symlinks.sh.tmpl
+++ b/defaults/run_once_before_macos-icloud-symlinks.sh.tmpl
@@ -66,7 +66,8 @@
 #   -------------------------------|----------------------------------------
 #   Does not exist                 | SKIP + log (iCloud may still be syncing)
 #   Is a directory                 | Proceed with link
-#   Is a symlink                   | SKIP + log (unexpected iCloud state)
+#   Is a symlink                   | SKIP + log (macOS native Desktop &
+#                                 |   Documents sync: already synced)
 #
 # --- ENV OVERRIDES ---
 #
@@ -146,7 +147,16 @@ _link_if_safe() {
     return 0
   fi
   if [[ -L "$source" ]]; then
-    _log "SKIP '$name': iCloud source is itself a symlink (unexpected)"
+    # Not an error, and usually not exotic: when macOS's native "Desktop &
+    # Documents Folders" sync is enabled, macOS itself places
+    # CloudDocs/Desktop -> ~/Desktop and CloudDocs/Documents -> ~/Documents.
+    # Those folders are then ALREADY fully iCloud-synced by macOS, and
+    # hand-symlinking them would fight the native feature. Skipping is
+    # correct; say so plainly rather than calling it "unexpected", which
+    # would invite the user to "fix" a working setup and lose data.
+    _log "SKIP '$name': iCloud source is itself a symlink — normal when macOS"
+    _log "     'Desktop & Documents Folders' sync owns this folder, in which case"
+    _log "     it is already synced by macOS and needs no symlink. Leaving alone."
     return 0
   fi
   if [[ ! -d "$source" ]]; then
@@ -156,10 +166,18 @@ _link_if_safe() {
 
   # --- Target checks (destructive-adjacent — MAXIMUM CAUTION) ---
   if [[ -L "$target" ]]; then
-    # Already a symlink. Compare where it points to.
-    local current
+    # Already a symlink. Compare where it RESOLVES to, not the literal
+    # link text. A trailing slash, a relative target, or a chain of links
+    # all name the correct directory but fail a string compare — which
+    # would misreport an already-correct link as "not iCloud" and defeat
+    # the idempotency contract. Resolution failing (dangling link) leaves
+    # `resolved` empty, so we fall through to the skip branch: an
+    # unresolvable link is still never overwritten.
+    local current resolved source_phys
     current="$(readlink "$target" 2>/dev/null || echo '')"
-    if [[ "$current" == "$source" ]]; then
+    resolved="$(cd -P "$target" 2>/dev/null && pwd -P || echo '')"
+    source_phys="$(cd -P "$source" 2>/dev/null && pwd -P || echo '')"
+    if [[ -n "$resolved" ]] && [[ "$resolved" == "$source_phys" ]]; then
       _log "OK   '$name': already symlinked to iCloud"
       return 0
     fi

--- a/docs/COPYRIGHT
+++ b/docs/COPYRIGHT
@@ -1,5 +1,5 @@
 /*
-* 🅳🅾🆃🅵🅸🅻🅴🆂 (v0.2.519) - <https://github.com/sebastienrousseau/dotfiles>
+* 🅳🅾🆃🅵🅸🅻🅴🆂 (v0.2.520) - <https://github.com/sebastienrousseau/dotfiles>
 * Made With ❤️ in London, United Kingdom
 * Designed by
 * Copyright (c) 2015-2026. All rights reserved.

--- a/docs/guides/MACOS_ICLOUD_SYMLINKS.md
+++ b/docs/guides/MACOS_ICLOUD_SYMLINKS.md
@@ -1,0 +1,73 @@
+---
+render_with_liquid: false
+---
+
+# macOS iCloud Drive Symlinks
+
+On macOS, this dotfiles setup can (safely) symlink personal directories into iCloud Drive so `~/Desktop`, `~/Documents`, `~/Downloads`, `~/Movies`, `~/Music`, `~/Pictures`, and `~/Public` all live in iCloud and back up automatically.
+
+The mechanism is `defaults/run_once_before_macos-icloud-symlinks.sh.tmpl`, which chezmoi runs once (before `apply`) whenever its contents change.
+
+## Safety guarantees
+
+This script is the **replacement** for a previous `symlink_*.tmpl` set that had a data-loss bug (see #1018): chezmoi's built-in symlink handling does `rm -rf $target; ln -s $source $target`, which destroys real content if the target directory has data.
+
+The current script's contract is:
+
+| Situation | What the script does |
+|---|---|
+| `~/$name` is already the correct symlink to iCloud | no-op |
+| `~/$name` is a symlink pointing somewhere else | **skip, log** — never overwrite your own link |
+| `~/$name` is a directory with any content (including `.DS_Store`) | **skip, log** — never delete your data |
+| `~/$name` is an empty directory | `rmdir` (fails safely if non-empty due to a race) + create symlink |
+| `~/$name` is a regular file | **skip, log** — never touch |
+| `~/$name` does not exist | create symlink directly |
+| iCloud source `com~apple~CloudDocs/$name` does not exist | **skip, log** — iCloud may still be syncing |
+| iCloud Drive is not set up on the Mac | **skip everything, log** — no partial state |
+
+The script has **two kill-switches**:
+
+- `touch ~/.dotfiles.icloud-skip` — permanent per-machine opt-out
+- `DOTFILES_ICLOUD_SYMLINKS=0` — env var, one run only
+
+And a **dry-run mode**:
+
+- `DOTFILES_ICLOUD_DRY_RUN=1` — log every decision, take no action
+
+## Rescue: how to link a directory that has content
+
+If your `~/Documents` already has content and you want it in iCloud:
+
+```bash
+# 1. Move your data into iCloud MANUALLY
+mv ~/Documents/* ~/Documents/.* "~/Library/Mobile Documents/com~apple~CloudDocs/Documents/" 2>/dev/null
+
+# 2. Verify iCloud has everything
+ls -la "~/Library/Mobile Documents/com~apple~CloudDocs/Documents/"
+
+# 3. Now the dir is empty — chezmoi's next apply will do the rmdir + symlink
+rmdir ~/Documents          # sanity check: this succeeds only if truly empty
+chezmoi apply
+```
+
+## Log
+
+Every run appends to `$XDG_STATE_HOME/dotfiles/icloud-symlinks.log` (default: `~/.local/state/dotfiles/icloud-symlinks.log`). Grep for `SKIP` to see why a candidate wasn't linked, or `LINK` to see what was created.
+
+## Belt-and-braces protection
+
+The same directory names are listed in `defaults/.chezmoiignore.tmpl`'s Darwin block, so even if the script never ran, chezmoi's regular `apply` would still refuse to touch these paths on macOS. Two independent layers of protection.
+
+## Tests
+
+`tests/unit/misc/test_macos_icloud_symlinks.sh` runs 16 assertions covering every branch of the refusal matrix. If any of them regress, CI blocks the merge.
+
+## Manual override: disable entirely
+
+If you never want the automation:
+
+```bash
+touch ~/.dotfiles.icloud-skip
+```
+
+The script sees this file in the first 5 lines of execution and exits 0 immediately, without touching the filesystem.

--- a/docs/guides/MACOS_ICLOUD_SYMLINKS.md
+++ b/docs/guides/MACOS_ICLOUD_SYMLINKS.md
@@ -6,7 +6,7 @@ render_with_liquid: false
 
 On macOS, this dotfiles setup can (safely) symlink personal directories into iCloud Drive so `~/Desktop`, `~/Documents`, `~/Downloads`, `~/Movies`, `~/Music`, `~/Pictures`, and `~/Public` all live in iCloud and back up automatically.
 
-The mechanism is `defaults/run_once_before_macos-icloud-symlinks.sh.tmpl`, which chezmoi runs once (before `apply`) whenever its contents change.
+The mechanism is `defaults/run_before_macos-icloud-symlinks.sh.tmpl`, which chezmoi runs once (before `apply`) whenever its contents change.
 
 ## `~/Desktop` and `~/Documents` are a special case
 

--- a/docs/guides/MACOS_ICLOUD_SYMLINKS.md
+++ b/docs/guides/MACOS_ICLOUD_SYMLINKS.md
@@ -8,6 +8,28 @@ On macOS, this dotfiles setup can (safely) symlink personal directories into iCl
 
 The mechanism is `defaults/run_once_before_macos-icloud-symlinks.sh.tmpl`, which chezmoi runs once (before `apply`) whenever its contents change.
 
+## `~/Desktop` and `~/Documents` are a special case
+
+macOS has its own **"Desktop & Documents Folders"** iCloud feature (System Settings -> Apple Account -> iCloud -> iCloud Drive -> Options). When it is on, macOS itself syncs those two folders, and it marks them in the iCloud container by putting symlinks there pointing *back* at your home directory:
+
+```text
+com~apple~CloudDocs/Desktop    -> ~/Desktop
+com~apple~CloudDocs/Documents  -> ~/Documents
+```
+
+Check whether it is on:
+
+```bash
+defaults read com.apple.finder FXICloudDriveDesktop    # 1 = Desktop sync on
+defaults read com.apple.finder FXICloudDriveDocuments  # 1 = Documents sync on
+```
+
+**If those return `1`, `~/Desktop` and `~/Documents` are already fully synced to iCloud and across your devices — by macOS, not by this script.** They will show as `SKIP ... iCloud source is itself a symlink` in the log. That is the correct outcome, not a failure.
+
+Do **not** apply the manual migration recipe below to `~/Desktop` or `~/Documents` while native sync is on: you would be moving data into a symlink that points back at its own source, fighting a feature macOS is already managing. Turn native sync off first if you genuinely want the symlink approach — but for these two folders the native feature is the better mechanism, since Finder, Migration Assistant, and iOS all understand it.
+
+The symlink approach in this guide is for the folders macOS does *not* cover natively: `~/Downloads`, `~/Movies`, `~/Music`, `~/Pictures`, `~/Public`.
+
 ## Safety guarantees
 
 This script is the **replacement** for a previous `symlink_*.tmpl` set that had a data-loss bug (see #1018): chezmoi's built-in symlink handling does `rm -rf $target; ln -s $source $target`, which destroys real content if the target directory has data.
@@ -24,6 +46,7 @@ The current script's contract is:
 | `~/$name` does not exist | create symlink directly |
 | iCloud source `com~apple~CloudDocs/$name` does not exist | **skip, log** — iCloud may still be syncing |
 | iCloud Drive is not set up on the Mac | **skip everything, log** — no partial state |
+| iCloud source `com~apple~CloudDocs/$name` is itself a symlink | **skip, log** — macOS's native Desktop & Documents sync owns it (see below) |
 
 The script has **two kill-switches**:
 
@@ -36,7 +59,7 @@ And a **dry-run mode**:
 
 ## Rescue: how to link a directory that has content
 
-If your `~/Documents` already has content and you want it in iCloud:
+If one of the non-native folders (`~/Downloads`, `~/Movies`, `~/Music`, `~/Pictures`, `~/Public`) already has content and you want it in iCloud — the example uses `Documents`, which applies only if you have turned native Desktop & Documents sync **off**:
 
 ```bash
 # 1. Move your data into iCloud MANUALLY
@@ -60,7 +83,7 @@ The same directory names are listed in `defaults/.chezmoiignore.tmpl`'s Darwin b
 
 ## Tests
 
-`tests/unit/misc/test_macos_icloud_symlinks.sh` runs 16 assertions covering every branch of the refusal matrix. If any of them regress, CI blocks the merge.
+`tests/unit/misc/test_macos_icloud_symlinks.sh` runs 29 assertions covering every branch of the refusal matrix, and `tests/regression/test_macos_icloud_symlinks_safety.sh` runs 10 more covering the data-loss invariants. If any of them regress, CI blocks the merge.
 
 ## Manual override: disable entirely
 

--- a/docs/guides/MACOS_ICLOUD_SYMLINKS.md
+++ b/docs/guides/MACOS_ICLOUD_SYMLINKS.md
@@ -6,7 +6,7 @@ render_with_liquid: false
 
 On macOS, this dotfiles setup can (safely) symlink personal directories into iCloud Drive so `~/Desktop`, `~/Documents`, `~/Downloads`, `~/Movies`, `~/Music`, `~/Pictures`, and `~/Public` all live in iCloud and back up automatically.
 
-The mechanism is `defaults/run_before_macos-icloud-symlinks.sh.tmpl`, which chezmoi runs once (before `apply`) whenever its contents change.
+The mechanism is `defaults/run_before_macos-icloud-symlinks.sh.tmpl`, which chezmoi runs before **every** `apply` — not once, and not only when the script changes. That is deliberate: a run-once script gets a single attempt, and on a fresh Mac that attempt lands while iCloud Drive is still syncing the folder tree down, so every candidate would skip and the one chance would be spent. Running each time lets it link whatever has become safe to link since the last apply. Repeat runs are no-ops that cost a few milliseconds.
 
 ## `~/Desktop` and `~/Documents` are a special case
 
@@ -73,6 +73,25 @@ rmdir ~/Documents          # sanity check: this succeeds only if truly empty
 chezmoi apply
 ```
 
+## After the links exist: what changes
+
+Linking a folder into iCloud does exactly what it says, and that has consequences worth understanding *before* you migrate rather than after.
+
+**Storage.** Everything saved to a linked folder counts against your iCloud quota, not just local disk. `~/Downloads` is the one that catches people out.
+
+**Deletion.** Deleting a file from a linked folder deletes it from iCloud, and therefore from every device signed into that account. There is no local-only copy any more. This is inherent to symlinking and is not something the hook can guard.
+
+**Eviction.** macOS may evict a synced file's contents to reclaim disk space, leaving a placeholder behind. Reading it downloads it again — so a script that walks one of these folders can block on the network where it used to return instantly.
+
+**Two things in this repository write into these folders.** Neither runs during `chezmoi apply`; both are commands you invoke deliberately:
+
+| What | Where | Why it matters after linking |
+|---|---|---|
+| `scripts/theme/merge-wallpaper.sh` | `~/Pictures/Wallpapers` (override with `DOTFILES_WALLPAPER_DIR`) | Merges a light/dark pair into one `.heic` and then **deletes both source files**. After linking, that pair is consumed from iCloud. Point `DOTFILES_WALLPAPER_DIR` at a local directory to keep the library off iCloud. |
+| `defaults/dot_config/mpv/mpv.conf` | `~/Pictures/Screenshots` | `screenshot-directory` is set here, so mpv screenshots land in iCloud. |
+
+Nothing else in this repository writes into the seven folders, and chezmoi itself never touches them: they are listed in the Darwin block of `.chezmoiignore.tmpl`, and `chezmoi managed` reports none of them among the paths it controls.
+
 ## Log
 
 Every run appends to `$XDG_STATE_HOME/dotfiles/icloud-symlinks.log` (default: `~/.local/state/dotfiles/icloud-symlinks.log`). Grep for `SKIP` to see why a candidate wasn't linked, or `LINK` to see what was created.
@@ -83,7 +102,13 @@ The same directory names are listed in `defaults/.chezmoiignore.tmpl`'s Darwin b
 
 ## Tests
 
-`tests/unit/misc/test_macos_icloud_symlinks.sh` runs 29 assertions covering every branch of the refusal matrix, and `tests/regression/test_macos_icloud_symlinks_safety.sh` runs 10 more covering the data-loss invariants. If any of them regress, CI blocks the merge.
+Three suites, 52 assertions, all of them run under `/bin/bash` 3.2 as well as bash 5:
+
+- `tests/unit/misc/test_macos_icloud_symlinks.sh` — 29 assertions covering every branch of the refusal matrix.
+- `tests/regression/test_macos_icloud_symlinks_safety.sh` — 12 assertions on the data-loss invariants, checking that named canary files survive.
+- `tests/regression/test_macos_icloud_symlinks_manifest.sh` — 11 assertions that hash the *whole* sandbox tree before and after, so a file lost in a path nobody named still shows up. Verified to drop from 11/11 to 4/11 against a deliberately reintroduced #1018.
+
+`tests/regression/test_gate_integrity.sh` adds 10 more asserting those gates fail when they should. If any of them regress, CI blocks the merge.
 
 ## Manual override: disable entirely
 

--- a/docs/manual/00-introduction.md
+++ b/docs/manual/00-introduction.md
@@ -4,7 +4,7 @@ render_with_liquid: false
 
 # Introduction
 
-This manual describes `.dotfiles` v0.2.519 — a trusted agent workstation baseline for macOS, Linux, and WSL.
+This manual describes `.dotfiles` v0.2.520 — a trusted agent workstation baseline for macOS, Linux, and WSL.
 
 The repository is more than a personal dotfiles collection. It ships as workstation infrastructure: signed, attested, multi-platform, AI-aware, and self-healing. Chezmoi handles templating and platform differences. The `dot` CLI sits on top and coordinates lifecycle operations.
 

--- a/docs/operations/PERFORMANCE_BUDGETS.md
+++ b/docs/operations/PERFORMANCE_BUDGETS.md
@@ -1,0 +1,105 @@
+---
+render_with_liquid: false
+---
+
+# Performance Budgets
+
+Every operation this repo owns falls into one of four performance tiers. Each tier has a **hard budget** enforced by `tests/performance/test_perf_budgets.sh`. If a change pushes an operation past its budget's headroom, CI fails.
+
+## The tiers
+
+| Tier | Budget | What belongs here |
+|---|---|---|
+| **INSTANT** | ≤ **500ms** | Anything a human sees at a shell prompt |
+| **FAST** | ≤ **2000ms** | Heavier gates + sandboxed CLI reads |
+| **MEDIUM** | ≤ **5000ms** | Full diagnostic runs |
+| **ACCEPTED-SLOW** | documented | Multi-second ops that are legitimately slow (see below) |
+| **OUT-OF-SCOPE** | not gated | Multi-minute ops we don't gate per-run |
+
+## Reference baselines (2026-08-30, `rousseau-cachyos-geekom-a9`, Ryzen AI 9 HX 370)
+
+All medians in milliseconds. Budget = 2× median (or the tier ceiling, whichever is larger).
+
+### INSTANT tier
+
+| Operation | Baseline | Budget | Headroom |
+|---|---:|---:|---:|
+| `dot version` | 10 | 500 | 50× |
+| `dot help` | 13 | 500 | 38× |
+| `dot help <cmd>` | 15 | 500 | 33× |
+| `dot search <keyword>` | 15 | 500 | 33× |
+| iCloud script single-run | 15 | 500 | 33× |
+| `check-version-consistency.sh` | 14 | 500 | 36× |
+| `docs-coverage.sh` | 148 | 500 | 3.4× |
+| iCloud regression test | 94 | 500 | 5.3× |
+
+### FAST tier
+
+| Operation | Baseline | Budget | Headroom |
+|---|---:|---:|---:|
+| `dot status` (sandbox) | 28 | 2000 | 71× |
+| `dot diff` (sandbox) | 32 | 2000 | 62× |
+| `traceability-coverage.sh` | 623 | 2000 | 3.2× |
+| iCloud unit test (29 assertions) | 498 | 2000 | 4× |
+| `test_dot_subcommand_smoke.sh` | 1308 | 2000 | 1.5× |
+| `test_dot_help_registry_symmetry.sh` | 1381 | 2000 | 1.4× |
+
+### MEDIUM tier
+
+| Operation | Baseline | Budget | Headroom |
+|---|---:|---:|---:|
+| `dot doctor` | 3892 | 5000 | 1.3× |
+| `bench.sh --quick` | 826 | 5000 | 6× |
+
+### ACCEPTED-SLOW (documented, not gated per-run)
+
+| Operation | Baseline | Reason |
+|---|---:|---|
+| `test_dot_help_flag_universal.sh` | ~11s | Invokes `dot help --help` on ~100 commands via subshell each. The coverage it provides justifies the cost; regression is caught by `tests/performance/test_help_gates_wall_clock.sh` at the suite level. |
+
+### OUT-OF-SCOPE (not gated per-run)
+
+| Operation | Why we don't gate |
+|---|---|
+| `chezmoi apply` | Fresh macOS: minutes. Depends on iCloud sync + package installs. Gated at suite level only. |
+| `install.sh` full | Downloads + installs packages. Network-bound. |
+| `dot upgrade` | Runs `mise upgrade`, `chezmoi apply`, package manager upgrades. |
+| Full test suite | 15+ minutes on CI. Gated by workflow timeout, not per-run assertion. |
+
+## Ratchet vs aspiration
+
+The budgets above are **regression gates**, not aspirations. If a real optimisation lowers a baseline, edit the doc + the perf test to lower the budget too. If a change pushes something over the budget, the test fails and CI blocks the merge.
+
+The aspirational shell-startup target (`<30ms`) is tracked separately in `tests/performance/bench.sh` — that's a bench, not a budget.
+
+## Adding a new operation
+
+When you add a new script that runs at a shell prompt:
+
+1. Time it 5 runs on a warm system: `for _ in {1..5}; do time bash your-script; done`
+2. Take the median.
+3. Place it in the tier where `budget ≥ 2 × median`. If a median is 400ms it goes in FAST (500ms is uncomfortably tight); if it's 300ms, INSTANT is fine.
+4. Add it to `tests/performance/test_perf_budgets.sh` in the correct tier section.
+5. Add its baseline to this doc.
+
+## Where the enforcement lives
+
+- **Per-op budget test**: `tests/performance/test_perf_budgets.sh`
+- **Suite-level wall-clock ratchet**: `tests/performance/test_help_gates_wall_clock.sh`
+- **CI wiring**: `.github/workflows/dot-cli-coverage.yml` (add here to run on every PR)
+
+## When a budget fires
+
+The error looks like:
+
+```
+✗ instant_dot_help: median=612ms EXCEEDS budget=500ms
+```
+
+Steps:
+
+1. Bisect the change that pushed it over.
+2. Fix the regression, or
+3. If the increase is legitimate (real new work), move the operation to the next tier + update this doc + `test_perf_budgets.sh` in the same PR.
+
+**Never silently bump the budget.** The tier a thing lives in is a promise to users.

--- a/docs/operations/PERFORMANCE_BUDGETS.md
+++ b/docs/operations/PERFORMANCE_BUDGETS.md
@@ -122,11 +122,13 @@ When you add a new script that runs at a shell prompt:
 - **Per-op budget test**: `tests/performance/test_perf_budgets.sh`
 - **Suite-level wall-clock ratchet**: `tests/performance/test_help_gates_wall_clock.sh`
 - **CI wiring**: `.github/workflows/ci.yml`, job `quality-performance` — runs on
-  ubuntu-latest and macos-latest for every PR, with no `|| true`. Hosted runners
-  are slower than a developer machine, so the job sets `PERF_BUDGET_PERCENT=200`
-  to scale budgets rather than inflate the recorded baselines; local runs stay
-  strict at the default 100%. Tighten that number once real runner medians are
-  known — the gate prints every median, so the first green run tells you.
+  ubuntu-latest and macos-latest for every PR, with no `|| true` and no budget
+  scaling. Measured on the hosted macOS runner (2026-08-30), it is comparable to
+  or faster than the reference machine on every gate — docs-coverage 679ms vs
+  969, traceability 1775 vs 2389, help-registry 3318 vs 4449, `dot doctor` 1746
+  vs 4423 — with a worst runner/local ratio of 1.25× (`dot search`). Budgets set
+  at 2× the local median therefore keep ≥1.6× headroom in CI, so the gate runs
+  strict.
 
 ## Environment knobs
 

--- a/docs/operations/PERFORMANCE_BUDGETS.md
+++ b/docs/operations/PERFORMANCE_BUDGETS.md
@@ -29,20 +29,25 @@ All medians in milliseconds. Budget = 2× median (or the tier ceiling, whichever
 | `dot help <cmd>` | 15 | 500 | 33× |
 | `dot search <keyword>` | 15 | 500 | 33× |
 | iCloud script single-run | 15 | 500 | 33× |
-| `check-version-consistency.sh` | 14 | 500 | 36× |
-| `docs-coverage.sh` | 148 | 500 | 3.4× |
-| iCloud regression test | 94 | 500 | 5.3× |
+
 
 ### FAST tier
 
 | Operation | Baseline | Budget | Headroom |
 |---|---:|---:|---:|
-| `dot status` (sandbox) | 28 | 2000 | 71× |
-| `dot diff` (sandbox) | 32 | 2000 | 62× |
-| `traceability-coverage.sh` | 623 | 2000 | 3.2× |
-| iCloud unit test (29 assertions) | 498 | 2000 | 4× |
-| `test_dot_subcommand_smoke.sh` | 1308 | 2000 | 1.5× |
-| `test_dot_help_registry_symmetry.sh` | 1381 | 2000 | 1.4× |
+| `dot status` (sandbox) | 1510 | 2000 | 1.3× |
+| `dot diff` (sandbox) | 1420 | 2000 | 1.4× |
+
+> The previous `dot status` / `dot diff` baselines of 28 ms and 32 ms were not
+> real. The perf sandbox never created chezmoi's source directory, so both
+> commands aborted immediately with *"no such file or directory"* — and
+> `_measure` discarded exit codes, so the gate timed the failure path and
+> called it excellent. The sandbox now links the repo into `XDG_DATA_HOME`,
+> and the figures above are the commands actually running.
+
+The QA gates and test suites that used to sit in this tier moved to GATES
+below: they are not interactive operations, so a ceiling defined by
+human-perceived latency never described them.
 
 ### MEDIUM tier
 
@@ -50,6 +55,36 @@ All medians in milliseconds. Budget = 2× median (or the tier ceiling, whichever
 |---|---:|---:|---:|
 | `dot doctor` | 3892 | 5000 | 1.3× |
 | `bench.sh --quick` | 826 | 5000 | 6× |
+
+Both MEDIUM entries are diagnostics that report findings through their exit
+status — `dot doctor` exits 1 whenever it finds issues, and `bench.sh` exits 1
+when a shell breaches its own startup threshold. They are gated with
+`_gate_diag`, which permits exit 1 but still fails on 2+ (not-found,
+permission, signal, syntax error). That is far narrower than the blanket
+`|| true` it replaced.
+
+### GATES tier (CI quality gates and test suites)
+
+Budgets are 2× the median measured on the **slowest supported platform**,
+not the fastest. Medians below: `rousseau-mbp-m1`, macOS 26 (Darwin 25.6),
+2026-08-30.
+
+| Operation | macOS median | Linux median | Budget | Headroom |
+|---|---:|---:|---:|---:|
+| `check-version-consistency.sh` | 68 | 14 | 500 | 7.4× |
+| `docs-coverage.sh` | 969 | 148 | 2000 | 2.1× |
+| iCloud regression test (12 assertions) | 494 | 94 | 1000 | 2.0× |
+| iCloud unit test (29 assertions) | 1743 | 498 | 3500 | 2.0× |
+| `traceability-coverage.sh` | 2389 | 623 | 5000 | 2.1× |
+| `test_dot_subcommand_smoke.sh` | 3785 | 1308 | 7500 | 2.0× |
+| `test_dot_help_registry_symmetry.sh` | 4449 | 1381 | 9000 | 2.0× |
+
+These gates run **3–6× slower on macOS than on Linux** — fork/exec is markedly
+more expensive there and every one of them is fork-heavy shell. CI covers both
+platforms, so the original Linux-only calibration could not hold, and five of
+these sat red as a result. Re-capture the Linux column when convenient; it is
+carried over from the 2026-08-30 Ryzen baseline and is not the binding
+constraint.
 
 ### ACCEPTED-SLOW (documented, not gated per-run)
 
@@ -86,7 +121,20 @@ When you add a new script that runs at a shell prompt:
 
 - **Per-op budget test**: `tests/performance/test_perf_budgets.sh`
 - **Suite-level wall-clock ratchet**: `tests/performance/test_help_gates_wall_clock.sh`
-- **CI wiring**: `.github/workflows/dot-cli-coverage.yml` (add here to run on every PR)
+- **CI wiring**: `.github/workflows/ci.yml`, job `quality-performance` — runs on
+  ubuntu-latest and macos-latest for every PR, with no `|| true`. Hosted runners
+  are slower than a developer machine, so the job sets `PERF_BUDGET_PERCENT=200`
+  to scale budgets rather than inflate the recorded baselines; local runs stay
+  strict at the default 100%. Tighten that number once real runner medians are
+  known — the gate prints every median, so the first green run tells you.
+
+## Environment knobs
+
+| Variable | Default | Effect |
+|---|---|---|
+| `PERF_BUDGET_PERCENT` | `100` | Scales every budget. `0` makes them all impossible — that is how `test_gate_integrity.sh` proves the gate actually fires. |
+| `PERF_GATE_FILTER` | *(unset)* | Runs only gates whose label contains this substring. Skipped gates never call `test_start`, so `TESTS_RUN == PASSED + FAILED` still holds. |
+| `DOT_CLI` | `bin/dot` | Points the `dot` gates at another binary, so breakage detection can be exercised against a deliberately corrupted CLI. |
 
 ## When a budget fires
 

--- a/docs/operations/PERFORMANCE_BUDGETS.md
+++ b/docs/operations/PERFORMANCE_BUDGETS.md
@@ -86,9 +86,18 @@ not the fastest. Medians below: `rousseau-mbp-m1`, macOS 26 (Darwin 25.6),
 | `docs-coverage.sh` | 969 | 148 | 2000 | 2.1× |
 | iCloud regression test (12 assertions) | 494 | 94 | 1000 | 2.0× |
 | iCloud unit test (29 assertions) | 1743 | 498 | 3500 | 2.0× |
+| iCloud manifest test (11 assertions) | 1575 | — † | 5000 | 3.2× |
 | `traceability-coverage.sh` | 2389 | 623 | 5000 | 2.1× |
 | `test_dot_subcommand_smoke.sh` | 3785 | 1308 | 7500 | 2.0× |
 | `test_dot_help_registry_symmetry.sh` | 4449 | 1381 | 9000 | 2.0× |
+
+† The manifest test hashes an entire sandbox tree before and after every
+scenario, so it is disk-bound in a way the other gates are not. Its budget is
+set at 3.2× the macOS median rather than the 2.0× used above, deliberately:
+`dot status` and `dot diff` were first budgeted at 1.3× and 1.4×, and both
+breached on the first CI run that measured them. The Linux median is left
+unfilled until CI reports one — guessing it would defeat the point of a table
+of measurements.
 
 These gates run **3–6× slower on macOS than on Linux** — fork/exec is markedly
 more expensive there and every one of them is fork-heavy shell. CI covers both

--- a/docs/operations/PERFORMANCE_BUDGETS.md
+++ b/docs/operations/PERFORMANCE_BUDGETS.md
@@ -134,12 +134,33 @@ When you add a new script that runs at a shell prompt:
 - **Suite-level wall-clock ratchet**: `benches/test_help_gates_wall_clock.sh`
 - **CI wiring**: `.github/workflows/ci.yml`, job `quality-performance` — runs on
   ubuntu-latest and macos-latest for every PR, with no `|| true` and no budget
-  scaling. Measured on the hosted macOS runner (2026-08-30), it is comparable to
-  or faster than the reference machine on every gate — docs-coverage 679ms vs
-  969, traceability 1775 vs 2389, help-registry 3318 vs 4449, `dot doctor` 1746
-  vs 4423 — with a worst runner/local ratio of 1.25× (`dot search`). Budgets set
-  at 2× the local median therefore keep ≥1.6× headroom in CI, so the gate runs
-  strict.
+  scaling. On the gates the hosted macOS runner is comparable to or faster than
+  the reference machine — docs-coverage 679 ms vs 969, traceability 1775 vs
+  2389, help-registry 3318 vs 4449, `dot doctor` 1746 vs 4423. The exception is
+  anything that drives chezmoi over the whole source tree: `dot status` and
+  `dot diff` measured ~2× the local median on **both** hosted platforms, which
+  is why they sit in MEDIUM rather than FAST. Budget a new operation against the
+  slowest platform it will run on, not against this machine.
+
+### How the time is measured
+
+`_measure` uses the `time` keyword with `TIMEFORMAT='%3R'`, not `date +%s%N`.
+
+`%N` is a GNU extension. BSD `date` — macOS 14 and earlier — copies the literal
+`N` through, so every arithmetic conversion failed, `_measure` returned nothing,
+and an empty median compares as `0` against any budget. The gate reported every
+budget met on those machines, for any command, including one that could not
+parse. `time` is a shell builtin, is millisecond-accurate in bash 3.2, and needs
+no external clock at all.
+
+Two consequences worth keeping:
+
+- `_gate_max_rc` rejects a non-numeric median outright rather than comparing it.
+  Both fields go through `-gt` / `-le`, where bash reads a non-numeric operand
+  as `0` — so a gate that cannot measure would otherwise report success.
+- `tests/regression/test_gate_integrity.sh` puts a `date` without `%N` first on
+  `PATH` and requires the same verdicts. A future timing rewrite that
+  reintroduces the dependency fails there rather than going quiet.
 
 ## Environment knobs
 

--- a/docs/operations/PERFORMANCE_BUDGETS.md
+++ b/docs/operations/PERFORMANCE_BUDGETS.md
@@ -4,7 +4,7 @@ render_with_liquid: false
 
 # Performance Budgets
 
-Every operation this repo owns falls into one of four performance tiers. Each tier has a **hard budget** enforced by `tests/performance/test_perf_budgets.sh`. If a change pushes an operation past its budget's headroom, CI fails.
+Every operation this repo owns falls into one of four performance tiers. Each tier has a **hard budget** enforced by `benches/test_perf_budgets.sh`. If a change pushes an operation past its budget's headroom, CI fails.
 
 ## The tiers
 
@@ -90,7 +90,7 @@ constraint.
 
 | Operation | Baseline | Reason |
 |---|---:|---|
-| `test_dot_help_flag_universal.sh` | ~11s | Invokes `dot help --help` on ~100 commands via subshell each. The coverage it provides justifies the cost; regression is caught by `tests/performance/test_help_gates_wall_clock.sh` at the suite level. |
+| `test_dot_help_flag_universal.sh` | ~11s | Invokes `dot help --help` on ~100 commands via subshell each. The coverage it provides justifies the cost; regression is caught by `benches/test_help_gates_wall_clock.sh` at the suite level. |
 
 ### OUT-OF-SCOPE (not gated per-run)
 
@@ -105,7 +105,7 @@ constraint.
 
 The budgets above are **regression gates**, not aspirations. If a real optimisation lowers a baseline, edit the doc + the perf test to lower the budget too. If a change pushes something over the budget, the test fails and CI blocks the merge.
 
-The aspirational shell-startup target (`<30ms`) is tracked separately in `tests/performance/bench.sh` — that's a bench, not a budget.
+The aspirational shell-startup target (`<30ms`) is tracked separately in `benches/bench.sh` — that's a bench, not a budget.
 
 ## Adding a new operation
 
@@ -114,13 +114,13 @@ When you add a new script that runs at a shell prompt:
 1. Time it 5 runs on a warm system: `for _ in {1..5}; do time bash your-script; done`
 2. Take the median.
 3. Place it in the tier where `budget ≥ 2 × median`. If a median is 400ms it goes in FAST (500ms is uncomfortably tight); if it's 300ms, INSTANT is fine.
-4. Add it to `tests/performance/test_perf_budgets.sh` in the correct tier section.
+4. Add it to `benches/test_perf_budgets.sh` in the correct tier section.
 5. Add its baseline to this doc.
 
 ## Where the enforcement lives
 
-- **Per-op budget test**: `tests/performance/test_perf_budgets.sh`
-- **Suite-level wall-clock ratchet**: `tests/performance/test_help_gates_wall_clock.sh`
+- **Per-op budget test**: `benches/test_perf_budgets.sh`
+- **Suite-level wall-clock ratchet**: `benches/test_help_gates_wall_clock.sh`
 - **CI wiring**: `.github/workflows/ci.yml`, job `quality-performance` — runs on
   ubuntu-latest and macos-latest for every PR, with no `|| true` and no budget
   scaling. Measured on the hosted macOS runner (2026-08-30), it is comparable to

--- a/docs/operations/PERFORMANCE_BUDGETS.md
+++ b/docs/operations/PERFORMANCE_BUDGETS.md
@@ -33,17 +33,18 @@ All medians in milliseconds. Budget = 2× median (or the tier ceiling, whichever
 
 ### FAST tier
 
-| Operation | Baseline | Budget | Headroom |
-|---|---:|---:|---:|
-| `dot status` (sandbox) | 1510 | 2000 | 1.3× |
-| `dot diff` (sandbox) | 1420 | 2000 | 1.4× |
+Currently empty.
 
-> The previous `dot status` / `dot diff` baselines of 28 ms and 32 ms were not
-> real. The perf sandbox never created chezmoi's source directory, so both
-> commands aborted immediately with *"no such file or directory"* — and
-> `_measure` discarded exit codes, so the gate timed the failure path and
-> called it excellent. The sandbox now links the repo into `XDG_DATA_HOME`,
-> and the figures above are the commands actually running.
+`dot status` and `dot diff` were placed here at 2000ms against reference
+medians of 1510 ms and 1420 ms — 1.3× and 1.4× headroom, short of the ≥ 2×
+this document requires of every budget. They have since moved to MEDIUM; see
+that section for the measurements that prompted it.
+
+> The baselines of 28 ms and 32 ms recorded before those were not real. The
+> perf sandbox never created chezmoi's source directory, so both commands
+> aborted immediately with *"no such file or directory"* — and `_measure`
+> discarded exit codes, so the gate timed the failure path and called it
+> excellent. The sandbox now links the repo into `XDG_DATA_HOME`.
 
 The QA gates and test suites that used to sit in this tier moved to GATES
 below: they are not interactive operations, so a ceiling defined by
@@ -53,11 +54,21 @@ human-perceived latency never described them.
 
 | Operation | Baseline | Budget | Headroom |
 |---|---:|---:|---:|
+| `dot status` (sandbox) | 2329 | 5000 | 2.1× |
+| `dot diff` (sandbox) | 2157 | 5000 | 2.3× |
 | `dot doctor` | 3892 | 5000 | 1.3× |
 | `bench.sh --quick` | 826 | 5000 | 6× |
 
-Both MEDIUM entries are diagnostics that report findings through their exit
-status — `dot doctor` exits 1 whenever it finds issues, and `bench.sh` exits 1
+The `dot status` and `dot diff` baselines are the **worst** of the two hosted
+runners, not the reference machine: macOS measured 2290 ms / 2157 ms and Ubuntu
+2329 ms / 2136 ms, against 1139 ms / 1174 ms locally. Two unrelated platforms
+agreeing within 8% is a property of the commands rather than of one slow
+runner — both shell out to chezmoi, which walks the whole source tree, and that
+is disk-bound. A budget taken from the faster machine would have been a gate
+that only ever fired on other people's hardware.
+
+`dot doctor` and `bench.sh --quick` are diagnostics that report findings through
+their exit status — `dot doctor` exits 1 whenever it finds issues, and `bench.sh` exits 1
 when a shell breaches its own startup threshold. They are gated with
 `_gate_diag`, which permits exit 1 but still fails on 2+ (not-found,
 permission, signal, syntax error). That is far narrower than the blanket

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -95,8 +95,8 @@ Full provenance policy: [`supply-chain/README.md`](https://github.com/sebastienr
 From a release tarball (recommended — it is the attested artefact):
 
 ```sh
-tar -xzf dot-0.2.519.tar.gz
-cd dot-0.2.519
+tar -xzf dot-0.2.520.tar.gz
+cd dot-0.2.520
 make install PREFIX=/usr DESTDIR="$pkgdir"
 ```
 
@@ -166,7 +166,7 @@ and [`security/VERIFY_RELEASE.md`](security/VERIFY_RELEASE.md).
 Minimum a packager should do:
 
 ```sh
-TAG=v0.2.519
+TAG=v0.2.520
 REPO=sebastienrousseau/dotfiles
 
 # SLSA build provenance on the tarball itself
@@ -188,7 +188,7 @@ Tags are signed with an SSH ed25519 key published in
 which is itself a `git allowed_signers` file:
 
 ```sh
-git -c gpg.ssh.allowedSignersFile=KEYS.asc tag -v v0.2.519
+git -c gpg.ssh.allowedSignersFile=KEYS.asc tag -v v0.2.520
 ```
 
 An SBOM ships with every release in both CycloneDX and SPDX JSON.

--- a/install.sh
+++ b/install.sh
@@ -71,7 +71,7 @@ show_help() {
 Usage: install.sh [version] [options]
 
 Arguments:
-  version       The version (tag or branch) to install (default: v0.2.519)
+  version       The version (tag or branch) to install (default: v0.2.520)
 
 Options:
   --help        Show this help message
@@ -87,7 +87,7 @@ EOF
 }
 
 main() {
-  local version="v0.2.519"
+  local version="v0.2.520"
   local version_set=0
   local minimal=0
   local provision="${DOTFILES_PROVISION:-0}"
@@ -117,7 +117,7 @@ main() {
         # like `foobar` doesn't trigger a 30s+ network download attempt.
         # Caught by the install.sh fuzz harness (#881).
         if [[ ! "$arg" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+([-+][a-zA-Z0-9.-]+)?$ ]]; then
-          error "Unrecognized positional argument '$arg' — expected a semver version (e.g. v0.2.519)."
+          error "Unrecognized positional argument '$arg' — expected a semver version (e.g. v0.2.520)."
         fi
         version="$arg"
         version_set=1
@@ -369,7 +369,7 @@ main() {
   # 6. Initialize & Apply
   step "Applying Configuration..."
 
-  # ── Auto-migration for v0.2.519 reorg ─────────────────────────────────
+  # ── Auto-migration for v0.2.520 reorg ─────────────────────────────────
   # If the user is upgrading from a pre-0.2.503 install, run the
   # migration script BEFORE `chezmoi apply` so the reorg's source-
   # path moves don't cause chezmoi to delete deployed files.
@@ -378,7 +378,7 @@ main() {
   for migrate_src in "$SOURCE_DIR" "$LEGACY_SOURCE_DIR"; do
     migrate_script="$migrate_src/install/migrate/migrate-v0_2-to-v0_2_503.sh"
     if [[ -x "$migrate_script" ]]; then
-      echo "   Running v0.2.519 migration (idempotent; safe on fresh installs)..."
+      echo "   Running v0.2.520 migration (idempotent; safe on fresh installs)..."
       "$migrate_script" || echo "   migration exited non-zero — continuing apply"
       break
     fi

--- a/install.sh
+++ b/install.sh
@@ -71,7 +71,7 @@ show_help() {
 Usage: install.sh [version] [options]
 
 Arguments:
-  version       The version (tag or branch) to install (default: v0.2.519)
+  version       The version (tag or branch) to install (default: v0.2.520)
 
 Options:
   --help        Show this help message
@@ -87,7 +87,7 @@ EOF
 }
 
 main() {
-  local version="v0.2.519"
+  local version="v0.2.520"
   local version_set=0
   local minimal=0
   local provision="${DOTFILES_PROVISION:-0}"
@@ -117,7 +117,7 @@ main() {
         # like `foobar` doesn't trigger a 30s+ network download attempt.
         # Caught by the install.sh fuzz harness (#881).
         if [[ ! "$arg" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+([-+][a-zA-Z0-9.-]+)?$ ]]; then
-          error "Unrecognized positional argument '$arg' — expected a semver version (e.g. v0.2.519)."
+          error "Unrecognized positional argument '$arg' — expected a semver version (e.g. v0.2.520)."
         fi
         version="$arg"
         version_set=1

--- a/install.sh
+++ b/install.sh
@@ -71,7 +71,7 @@ show_help() {
 Usage: install.sh [version] [options]
 
 Arguments:
-  version       The version (tag or branch) to install (default: v0.2.520)
+  version       The version (tag or branch) to install (default: v0.2.519)
 
 Options:
   --help        Show this help message
@@ -87,7 +87,7 @@ EOF
 }
 
 main() {
-  local version="v0.2.520"
+  local version="v0.2.519"
   local version_set=0
   local minimal=0
   local provision="${DOTFILES_PROVISION:-0}"
@@ -117,7 +117,7 @@ main() {
         # like `foobar` doesn't trigger a 30s+ network download attempt.
         # Caught by the install.sh fuzz harness (#881).
         if [[ ! "$arg" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+([-+][a-zA-Z0-9.-]+)?$ ]]; then
-          error "Unrecognized positional argument '$arg' — expected a semver version (e.g. v0.2.520)."
+          error "Unrecognized positional argument '$arg' — expected a semver version (e.g. v0.2.519)."
         fi
         version="$arg"
         version_set=1

--- a/lib/dot/bento.sh
+++ b/lib/dot/bento.sh
@@ -33,7 +33,7 @@ _dotfiles_bento_render() {
 
   # Render a fixed-width card (42 cols) so output aligns in any terminal width
   printf "\n"
-  printf "  ${c_cyan}${c_bold}💎  D O T F I L E S${c_reset}  ${c_slate}[v0.2.519]${c_reset}\n"
+  printf "  ${c_cyan}${c_bold}💎  D O T F I L E S${c_reset}  ${c_slate}[v0.2.520]${c_reset}\n"
   printf "  ${c_slate}──────────────────────────────────────────${c_reset}\n"
 
   # Key system properties at a glance — answers "is my env healthy?" in 1 second

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # .dotfiles
 
-> Workstation-infrastructure dotfiles for macOS, Linux, and WSL. Multi-shell by default (zsh, fish, bash, nushell, PowerShell), with wallpaper-driven terminal themes (K-Means CIELAB + WCAG AAA), first-class agent / MCP governance, signed releases, and a self-healing CLI. Chezmoi-managed. Current version: v0.2.519.
+> Workstation-infrastructure dotfiles for macOS, Linux, and WSL. Multi-shell by default (zsh, fish, bash, nushell, PowerShell), with wallpaper-driven terminal themes (K-Means CIELAB + WCAG AAA), first-class agent / MCP governance, signed releases, and a self-healing CLI. Chezmoi-managed. Current version: v0.2.520.
 
 This file is curated for LLM agents indexing the repository. The links below are the *load-bearing* documents — start here, not with `find`.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sebastienrousseau/dotfiles",
-  "version": "0.2.519",
+  "version": "0.2.520",
   "description": "The Trusted Shell Platform — Universal dotfiles managed by Chezmoi. Features Bash & Zsh for macOS, Linux & WSL. Rust modern tooling & enterprise-grade security.",
   "main": "install.sh",
   "bin": {

--- a/scripts/git-hooks/pre-commit-audit.sh
+++ b/scripts/git-hooks/pre-commit-audit.sh
@@ -141,6 +141,6 @@ if [[ $FAILED -eq 1 ]]; then
   printf '%b\\n' "   (Use --no-verify to bypass if absolutely necessary)"
   exit 1
 else
-  printf '%b\n' "${GREEN}${BOLD}✅ Audit passed.${NC} v0.2.519 standards maintained."
+  printf '%b\n' "${GREEN}${BOLD}✅ Audit passed.${NC} v0.2.520 standards maintained."
   exit 0
 fi

--- a/scripts/version-sync.sh
+++ b/scripts/version-sync.sh
@@ -293,7 +293,7 @@ update_version_references() {
     files_processed=$((files_processed + 1))
 
     # Skip milestone and other historical files
-    if [[ "$(basename "$file")" == MILESTONE_* ]]; then
+    if _is_historical_record "$file"; then
       log_info "Skipping historical file: $file"
       continue
     fi
@@ -372,6 +372,22 @@ update_version_references() {
   echo "$changes_made"
 }
 
+# A version reference is only drift if it is meant to track the release. In a
+# historical record it is evidence: GOLD-STANDARD-AUDIT.md records which tag
+# `git tag -v` was run against and what it printed, and MILESTONE_* files
+# describe releases that already happened. Rewriting either to the version
+# being prepared would claim a verification nobody performed against a tag
+# that does not exist yet, which is a worse outcome than a stale-looking
+# string. Both the updater and the verifier consult this, so they cannot
+# disagree about which files are in scope.
+_is_historical_record() {
+  case "$(basename "$1")" in
+    MILESTONE_*) return 0 ;;
+    GOLD-STANDARD-AUDIT.md) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 verify_version_consistency() {
   local expected_version="$1"
   local files=("${@:2}")
@@ -386,7 +402,7 @@ verify_version_consistency() {
       continue
     fi
 
-    if [[ "$(basename "$file")" == MILESTONE_* ]]; then
+    if _is_historical_record "$file"; then
       log_info "Skipping historical file: $file"
       continue
     fi

--- a/share/man/man1/dot.1
+++ b/share/man/man1/dot.1
@@ -6,7 +6,7 @@
 .\" tools/docs/generate-manpage.sh — edit THIS file for prose, edit
 .\" bin/dot (_dot_help_specs / _dot_help_details) for command text,
 .\" then run `make man`. CI fails when share/man/man1/dot.1 is stale.
-.TH DOT 1 "2026-08-13" "dotfiles v0.2.519" "User Commands"
+.TH DOT 1 "2026-08-13" "dotfiles v0.2.520" "User Commands"
 .SH NAME
 dot \- dotfiles management CLI
 .SH SYNOPSIS

--- a/share/man/man1/dot.1
+++ b/share/man/man1/dot.1
@@ -6,7 +6,7 @@
 .\" tools/docs/generate-manpage.sh — edit THIS file for prose, edit
 .\" bin/dot (_dot_help_specs / _dot_help_details) for command text,
 .\" then run `make man`. CI fails when share/man/man1/dot.1 is stale.
-.TH DOT 1 "2026-08-13" "dotfiles v0.2.520" "User Commands"
+.TH DOT 1 "2026-09-10" "dotfiles v0.2.520" "User Commands"
 .SH NAME
 dot \- dotfiles management CLI
 .SH SYNOPSIS

--- a/tests/regression/test_gate_integrity.sh
+++ b/tests/regression/test_gate_integrity.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright (c) 2015-2026 Sebastien Rousseau
+# shellcheck disable=SC1090,SC1091,SC2034
+#
+# Meta-gate: verify every ratchet script *actually fails* when its
+# invariant is violated. A gate that silently passes on regression
+# is worse than no gate — it lulls readers into false safety.
+#
+# For each critical gate, we:
+#   1. Confirm the gate exists.
+#   2. Confirm it passes today (control run).
+#   3. Deliberately violate its invariant in a sandbox copy.
+#   4. Confirm it FAILS (non-zero exit) on that copy.
+#   5. Confirm the failure message names the specific violation.
+#
+# If any gate silently passes on step 4, this test fails — surfacing
+# a broken gate immediately, on every regression run.
+#
+# Meta-gates covered:
+#   - scripts/qa/docs-coverage.sh (must fail below MIN_DOCS_COVERAGE)
+#   - scripts/qa/traceability-coverage.sh (same class of bug —
+#     both were silently passing before #1032 + #1035)
+#   - scripts/qa/check-version-consistency.sh (must detect drift)
+#   - tests/performance/test_perf_budgets.sh (must fail when a
+#     budget is exceeded)
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+source "$SCRIPT_DIR/../framework/assertions.sh"
+
+# ---------------------------------------------------------------------------
+# GATE 1: docs-coverage soft-gate.
+# Regression-tested here because it was silently a no-op before #1032.
+# ---------------------------------------------------------------------------
+test_start "docs_coverage_gate_fails_below_threshold"
+GATE="$REPO_ROOT/scripts/qa/docs-coverage.sh"
+if [[ ! -x "$GATE" ]]; then
+  ((TESTS_FAILED++)) || true
+  printf '  \033[0;31m✗\033[0m %s: gate missing at %s\n' "$CURRENT_TEST" "$GATE"
+else
+  # An impossible threshold must fail.
+  if MIN_DOCS_COVERAGE=999 bash "$GATE" >/dev/null 2>&1; then
+    ((TESTS_FAILED++)) || true
+    printf '  \033[0;31m✗\033[0m %s: exit 0 with impossible threshold — silent pass bug returned!\n' \
+      "$CURRENT_TEST"
+  else
+    ((TESTS_PASSED++)) || true
+    printf '  \033[0;32m✓\033[0m %s\n' "$CURRENT_TEST"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# GATE 2: traceability-coverage soft-gate. Same class of bug, same
+# fix (#1035). Verify.
+# ---------------------------------------------------------------------------
+test_start "traceability_coverage_gate_fails_below_threshold"
+GATE="$REPO_ROOT/scripts/qa/traceability-coverage.sh"
+if [[ ! -x "$GATE" ]]; then
+  ((TESTS_FAILED++)) || true
+  printf '  \033[0;31m✗\033[0m %s: gate missing at %s\n' "$CURRENT_TEST" "$GATE"
+else
+  if MIN_TRACEABILITY_COVERAGE=999 bash "$GATE" >/dev/null 2>&1; then
+    ((TESTS_FAILED++)) || true
+    printf '  \033[0;31m✗\033[0m %s: exit 0 with impossible threshold — silent pass bug returned!\n' \
+      "$CURRENT_TEST"
+  else
+    ((TESTS_PASSED++)) || true
+    printf '  \033[0;32m✓\033[0m %s\n' "$CURRENT_TEST"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# GATE 3: check-version-consistency must detect deliberate drift.
+# ---------------------------------------------------------------------------
+test_start "version_consistency_gate_detects_drift"
+sandbox="$(mktemp -d)"
+trap 'rm -rf "$sandbox"' EXIT
+# Copy the repo state that the script inspects into the sandbox
+mkdir -p "$sandbox/defaults" "$sandbox/scripts/qa" "$sandbox/share/man/man1"
+cp "$REPO_ROOT/defaults/.chezmoidata.toml" "$sandbox/defaults/"
+cp "$REPO_ROOT/scripts/qa/check-version-consistency.sh" "$sandbox/scripts/qa/"
+cp "$REPO_ROOT/share/man/man1/dot.1" "$sandbox/share/man/man1/"
+# Introduce drift: bump the .chezmoidata.toml canonical to a
+# version we KNOW the man page doesn't match.
+sed -i.bak 's/^dotfiles_version = .*/dotfiles_version = "99.99.99"/' \
+  "$sandbox/defaults/.chezmoidata.toml"
+rm -f "$sandbox/defaults/.chezmoidata.toml.bak"
+# Run the gate against the drifted copy.
+if (cd "$sandbox" && bash scripts/qa/check-version-consistency.sh --quiet >/dev/null 2>&1); then
+  ((TESTS_FAILED++)) || true
+  printf '  \033[0;31m✗\033[0m %s: exit 0 with deliberate drift — gate is broken\n' "$CURRENT_TEST"
+else
+  ((TESTS_PASSED++)) || true
+  printf '  \033[0;32m✓\033[0m %s\n' "$CURRENT_TEST"
+fi
+
+# ---------------------------------------------------------------------------
+# GATE 4: perf budget gate must fail if an impossibly tight budget
+# is set. Runs the perf test with a synthetic env override.
+# ---------------------------------------------------------------------------
+test_start "perf_budget_gate_fails_on_budget_violation"
+GATE="$REPO_ROOT/tests/performance/test_perf_budgets.sh"
+if [[ ! -x "$GATE" ]]; then
+  ((TESTS_FAILED++)) || true
+  printf '  \033[0;31m✗\033[0m %s: gate missing at %s\n' "$CURRENT_TEST" "$GATE"
+else
+  # We validate the gate structurally: it must contain the tier-based
+  # _gate calls with numeric budgets. If someone rewrites it to always
+  # pass, the structure check fails.
+  # Count gates defined with 500/2000/5000 budgets.
+  budget_count=$(grep -cE '_gate "\$CURRENT_TEST" (500|2000|5000)' "$GATE" || echo 0)
+  if [[ "$budget_count" -ge 15 ]]; then
+    ((TESTS_PASSED++)) || true
+    printf '  \033[0;32m✓\033[0m %s: %d tiered budgets defined\n' "$CURRENT_TEST" "$budget_count"
+  else
+    ((TESTS_FAILED++)) || true
+    printf '  \033[0;31m✗\033[0m %s: only %d budgets found (expected ≥ 15)\n' \
+      "$CURRENT_TEST" "$budget_count"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# GATE 5: iCloud regression safety test — must fail if a canary
+# file gets deleted. Verify the test's own "canary preservation"
+# assertion still exists and would fire.
+# ---------------------------------------------------------------------------
+test_start "icloud_safety_test_still_checks_canary"
+GATE="$REPO_ROOT/tests/regression/test_macos_icloud_symlinks_safety.sh"
+if grep -q "CANARY-DO-NOT-DELETE" "$GATE" \
+   && grep -qE 'canary\.txt' "$GATE"; then
+  ((TESTS_PASSED++)) || true
+  printf '  \033[0;32m✓\033[0m %s\n' "$CURRENT_TEST"
+else
+  ((TESTS_FAILED++)) || true
+  printf '  \033[0;31m✗\033[0m %s: canary check removed from safety test\n' "$CURRENT_TEST"
+fi
+
+# ---------------------------------------------------------------------------
+# GATE 6: iCloud script source is still free of destructive operations.
+# Independent of the assertion inside the unit test — this one runs on
+# every regression pass without needing the unit-test infrastructure.
+# ---------------------------------------------------------------------------
+test_start "icloud_script_source_still_free_of_destructive_ops"
+TMPL="$REPO_ROOT/defaults/run_once_before_macos-icloud-symlinks.sh.tmpl"
+body=$(grep -vE '^\s*#' "$TMPL" | grep -vE '^\s*_log ')
+found=()
+echo "$body" | grep -qE 'rm -rf'   && found+=("rm -rf")
+echo "$body" | grep -qE '^\s*mv\s' && found+=("mv")
+echo "$body" | grep -qE '^\s*chmod\s' && found+=("chmod")
+echo "$body" | grep -qE '^\s*chown\s' && found+=("chown")
+if [[ ${#found[@]} -eq 0 ]]; then
+  ((TESTS_PASSED++)) || true
+  printf '  \033[0;32m✓\033[0m %s\n' "$CURRENT_TEST"
+else
+  ((TESTS_FAILED++)) || true
+  printf '  \033[0;31m✗\033[0m %s: DANGEROUS OPS FOUND: %s\n' "$CURRENT_TEST" "${found[*]}"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+printf '\n  Tests: %d  \033[0;32mPassed: %d\033[0m  \033[0;31mFailed: %d\033[0m\n' \
+  "$TESTS_RUN" "$TESTS_PASSED" "$TESTS_FAILED"
+printf 'RESULTS:%d:%d:%d\n' "$TESTS_RUN" "$TESTS_PASSED" "$TESTS_FAILED"
+exit "$TESTS_FAILED"

--- a/tests/regression/test_gate_integrity.sh
+++ b/tests/regression/test_gate_integrity.sh
@@ -98,29 +98,62 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# GATE 4: perf budget gate must fail if an impossibly tight budget
-# is set. Runs the perf test with a synthetic env override.
+# GATE 4: the perf budget gate must actually FAIL when violated.
+#
+# This previously counted budget literals with a grep and asserted the count
+# was >= 15 — which verifies nothing about whether the gate fires, in a file
+# whose whole thesis is that a silently-passing gate is worse than none. It
+# was also brittle: the regex matched only 500|2000|5000, so a legitimate
+# recalibration to any other value made a real budget invisible to the count.
+#
+# It now executes the gate three ways, using PERF_GATE_FILTER to run a single
+# cheap budget so this stays fast:
+#   a) impossible budget          -> must exit non-zero
+#   b) normal budget              -> must exit zero (not always-failing)
+#   c) deliberately broken command -> must exit non-zero (breakage detection)
 # ---------------------------------------------------------------------------
-test_start "perf_budget_gate_fails_on_budget_violation"
 GATE="$REPO_ROOT/tests/performance/test_perf_budgets.sh"
-if [[ ! -x "$GATE" ]]; then
+PERF_PROBE="instant_dot_version"
+
+test_start "perf_gate_fails_on_budget_violation"
+if [[ ! -f "$GATE" ]]; then
   ((TESTS_FAILED++)) || true
   printf '  \033[0;31m✗\033[0m %s: gate missing at %s\n' "$CURRENT_TEST" "$GATE"
+elif PERF_GATE_FILTER="$PERF_PROBE" PERF_BUDGET_PERCENT=0 \
+  bash "$GATE" >/dev/null 2>&1; then
+  ((TESTS_FAILED++)) || true
+  printf '  \033[0;31m✗\033[0m %s: exit 0 with an impossible budget — gate does not fire\n' \
+    "$CURRENT_TEST"
 else
-  # We validate the gate structurally: it must contain the tier-based
-  # _gate calls with numeric budgets. If someone rewrites it to always
-  # pass, the structure check fails.
-  # Count gates defined with 500/2000/5000 budgets.
-  budget_count=$(grep -cE '_gate "\$CURRENT_TEST" (500|2000|5000)' "$GATE" || echo 0)
-  if [[ "$budget_count" -ge 15 ]]; then
-    ((TESTS_PASSED++)) || true
-    printf '  \033[0;32m✓\033[0m %s: %d tiered budgets defined\n' "$CURRENT_TEST" "$budget_count"
-  else
-    ((TESTS_FAILED++)) || true
-    printf '  \033[0;31m✗\033[0m %s: only %d budgets found (expected ≥ 15)\n' \
-      "$CURRENT_TEST" "$budget_count"
-  fi
+  ((TESTS_PASSED++)) || true
+  printf '  \033[0;32m✓\033[0m %s\n' "$CURRENT_TEST"
 fi
+
+test_start "perf_gate_passes_when_within_budget"
+if PERF_GATE_FILTER="$PERF_PROBE" bash "$GATE" >/dev/null 2>&1; then
+  ((TESTS_PASSED++)) || true
+  printf '  \033[0;32m✓\033[0m %s\n' "$CURRENT_TEST"
+else
+  ((TESTS_FAILED++)) || true
+  printf '  \033[0;31m✗\033[0m %s: gate fails even within budget — it is always-red, not a gate\n' \
+    "$CURRENT_TEST"
+fi
+
+test_start "perf_gate_rejects_a_broken_command"
+# A command that crashes instantly is FAST. Timing alone cannot tell the
+# difference, so the gate must check exit status too.
+_broken="$(mktemp)"
+printf '#!/usr/bin/env bash\nsyntax ( error\n' >"$_broken"
+if DOT_CLI="$_broken" PERF_GATE_FILTER="$PERF_PROBE" \
+  bash "$GATE" >/dev/null 2>&1; then
+  ((TESTS_FAILED++)) || true
+  printf '  \033[0;31m✗\033[0m %s: a broken CLI passed its budget — F2 regression\n' \
+    "$CURRENT_TEST"
+else
+  ((TESTS_PASSED++)) || true
+  printf '  \033[0;32m✓\033[0m %s\n' "$CURRENT_TEST"
+fi
+rm -f "$_broken"
 
 # ---------------------------------------------------------------------------
 # GATE 5: iCloud regression safety test — must fail if a canary
@@ -144,7 +177,7 @@ fi
 # every regression pass without needing the unit-test infrastructure.
 # ---------------------------------------------------------------------------
 test_start "icloud_script_source_still_free_of_destructive_ops"
-TMPL="$REPO_ROOT/defaults/run_once_before_macos-icloud-symlinks.sh.tmpl"
+TMPL="$REPO_ROOT/defaults/run_before_macos-icloud-symlinks.sh.tmpl"
 body=$(grep -vE '^\s*#' "$TMPL" | grep -vE '^\s*_log ')
 found=()
 echo "$body" | grep -qE 'rm -rf'   && found+=("rm -rf")

--- a/tests/regression/test_gate_integrity.sh
+++ b/tests/regression/test_gate_integrity.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright (c) 2015-2026 Sebastien Rousseau
+# Regression for: GH-1038
 # shellcheck disable=SC1090,SC1091,SC2034
 #
 # Meta-gate: verify every ratchet script *actually fails* when its

--- a/tests/regression/test_gate_integrity.sh
+++ b/tests/regression/test_gate_integrity.sh
@@ -22,7 +22,7 @@
 #   - scripts/qa/traceability-coverage.sh (same class of bug —
 #     both were silently passing before #1032 + #1035)
 #   - scripts/qa/check-version-consistency.sh (must detect drift)
-#   - tests/performance/test_perf_budgets.sh (must fail when a
+#   - benches/test_perf_budgets.sh (must fail when a
 #     budget is exceeded)
 
 set -u
@@ -112,7 +112,7 @@ fi
 #   b) normal budget              -> must exit zero (not always-failing)
 #   c) deliberately broken command -> must exit non-zero (breakage detection)
 # ---------------------------------------------------------------------------
-GATE="$REPO_ROOT/tests/performance/test_perf_budgets.sh"
+GATE="$REPO_ROOT/benches/test_perf_budgets.sh"
 PERF_PROBE="instant_dot_version"
 
 test_start "perf_gate_fails_on_budget_violation"

--- a/tests/regression/test_gate_integrity.sh
+++ b/tests/regression/test_gate_integrity.sh
@@ -156,6 +156,53 @@ fi
 rm -f "$_broken"
 
 # ---------------------------------------------------------------------------
+# GATE 4b: the gate must reach the same verdicts without a GNU clock.
+#
+# %N is a GNU extension. BSD date — macOS 14 and earlier — passes the literal
+# "N" through, which used to make every measurement fail to parse and every
+# budget compare as met, including for a CLI that could not parse. The gate
+# reported a clean pass on those machines and nothing said otherwise; only
+# macos-14 in the CI matrix was old enough to show it.
+#
+# Rather than assert which clock the gate uses, put a date without %N first on
+# PATH and require the same two verdicts as above. Any future timing rewrite
+# that reintroduces the dependency fails here.
+# ---------------------------------------------------------------------------
+_bsd_path="$(mktemp -d)"
+cat >"$_bsd_path/date" <<'BSDDATE'
+#!/bin/sh
+# BSD date: %N is not a conversion specifier, it is a literal N.
+case "$1" in
+  +%s%N) printf '%sN\n' "$(/bin/date +%s)" ;;
+  *) exec /bin/date "$@" ;;
+esac
+BSDDATE
+chmod +x "$_bsd_path/date"
+
+test_start "perf_gate_fires_without_a_gnu_clock"
+if PATH="$_bsd_path:$PATH" PERF_GATE_FILTER="$PERF_PROBE" PERF_BUDGET_PERCENT=0 \
+  bash "$GATE" >/dev/null 2>&1; then
+  ((TESTS_FAILED++)) || true
+  printf '  \033[0;31m✗\033[0m %s: impossible budget passed without a GNU date — the gate is blind here\n' \
+    "$CURRENT_TEST"
+else
+  ((TESTS_PASSED++)) || true
+  printf '  \033[0;32m✓\033[0m %s\n' "$CURRENT_TEST"
+fi
+
+test_start "perf_gate_measures_without_a_gnu_clock"
+if PATH="$_bsd_path:$PATH" PERF_GATE_FILTER="$PERF_PROBE" \
+  bash "$GATE" >/dev/null 2>&1; then
+  ((TESTS_PASSED++)) || true
+  printf '  \033[0;32m✓\033[0m %s\n' "$CURRENT_TEST"
+else
+  ((TESTS_FAILED++)) || true
+  printf '  \033[0;31m✗\033[0m %s: gate fails within budget without a GNU date — always-red there\n' \
+    "$CURRENT_TEST"
+fi
+rm -rf "$_bsd_path"
+
+# ---------------------------------------------------------------------------
 # GATE 5: iCloud regression safety test — must fail if a canary
 # file gets deleted. Verify the test's own "canary preservation"
 # assertion still exists and would fire.

--- a/tests/regression/test_macos_icloud_symlinks_manifest.sh
+++ b/tests/regression/test_macos_icloud_symlinks_manifest.sh
@@ -1,0 +1,306 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright (c) 2015-2026 Sebastien Rousseau
+# shellcheck disable=SC1090,SC1091,SC2034
+#
+# Regression: defaults/run_before_macos-icloud-symlinks.sh.tmpl must leave a
+# tree it refuses to act on BYTE-IDENTICAL.
+#
+# tests/regression/test_macos_icloud_symlinks_safety.sh already asserts that
+# named canary files survive. That catches the deletion we know to look for.
+# This test catches the one we do not: it hashes the WHOLE tree before and
+# after, so any file that disappears, any file whose contents change, any
+# directory that becomes a symlink, and any symlink that is repointed shows
+# up as a diff — including in a path nobody thought to name.
+#
+# The distinction matters because the bug this whole hook exists to prevent
+# (#1018) did not destroy a file anyone had listed. It destroyed a real
+# ~/Documents wholesale, because chezmoi's symlink_ mechanism is
+# `rm -rf $target; ln -s $source $target`. A test that only checks named
+# canaries would have passed against a variant that deleted everything else.
+#
+# Every scenario runs against a fresh $HOME under mktemp. The real home
+# directory is never read from or written to.
+#
+# bash 3.2 only (stock macOS): no mapfile, no associative arrays, and no
+# unguarded expansion of a possibly-empty array.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+source "$SCRIPT_DIR/../framework/assertions.sh"
+
+TEMPLATE="${TEMPLATE:-$REPO_ROOT/defaults/run_before_macos-icloud-symlinks.sh.tmpl}"
+
+CANDIDATES="Desktop Documents Downloads Movies Music Pictures Public"
+
+# ---------------------------------------------------------------------------
+# Render the template into a runnable script (strip the darwin guard), and
+# park the hook's own output OUTSIDE the tree under audit — writing it inside
+# would make the manifest report the hook's log as a change the hook made.
+# ---------------------------------------------------------------------------
+RENDERED="$(mktemp -t icloud-manifest.XXXXXX 2>/dev/null || mktemp)"
+HOOK_OUT="$(mktemp -t icloud-manifest-out.XXXXXX 2>/dev/null || mktemp)"
+SHIM_DIR="$(mktemp -d -t icloud-manifest-shim.XXXXXX 2>/dev/null || mktemp -d)"
+trap 'rm -f "$RENDERED" "$HOOK_OUT"; rm -rf "$SHIM_DIR"' EXIT
+
+sed -e '/^{{- if eq \.chezmoi\.os "darwin" -}}$/d' \
+    -e '/^{{- end -}}$/d' \
+    "$TEMPLATE" > "$RENDERED"
+
+# Same fallback order as lib/dot/verified-download.sh.
+if command -v sha256sum >/dev/null 2>&1; then
+  HASHER="sha256sum"
+elif command -v shasum >/dev/null 2>&1; then
+  HASHER="shasum -a 256"
+else
+  HASHER=""
+fi
+
+# ---------------------------------------------------------------------------
+# _manifest <root> — one line per entry, sorted:
+#
+#   D <path>              a directory
+#   L <path> -> <target>  a symlink, with what it points at
+#   F <sha256> <path>     a regular file, with the hash of its contents
+#
+# $HOME/state is pruned: it holds the hook's log, which is meant to grow on
+# every run. Everything else is fair game.
+# ---------------------------------------------------------------------------
+_manifest() {
+  local root="$1"
+  (
+    cd "$root" 2>/dev/null || return 0
+    find . -mindepth 1 -path ./state -prune -o \( -type d -o -type l \) -print 2>/dev/null |
+      while IFS= read -r p; do
+        if [[ -L "$p" ]]; then
+          printf 'L %s -> %s\n' "$p" "$(readlink "$p" 2>/dev/null)"
+        else
+          printf 'D %s\n' "$p"
+        fi
+      done
+    # One hasher invocation for the whole tree rather than one per file.
+    # Guarded on a cheap `-print -quit` because BSD xargs, unlike GNU, runs
+    # its utility even on empty input — and a hasher with no arguments reads
+    # stdin, which would hang the suite rather than fail it.
+    if [[ -n "$HASHER" ]] &&
+       [[ -n "$(find . -mindepth 1 -path ./state -prune -o -type f -print -quit 2>/dev/null)" ]]; then
+      find . -mindepth 1 -path ./state -prune -o -type f -print0 2>/dev/null |
+        _hash_many 2>/dev/null |
+        awk '{ h = $1; $1 = ""; sub(/^[ \t]+/, ""); sub(/^\*/, ""); print "F " h " " $0 }'
+    fi
+  ) | LC_ALL=C sort
+}
+
+# _hash_many — hash every NUL-delimited path arriving on stdin, one process
+# for the lot. Dispatching by name keeps both invocations fully quoted.
+_hash_many() {
+  if [[ "$HASHER" == "sha256sum" ]]; then
+    xargs -0 sha256sum
+  else
+    xargs -0 shasum -a 256
+  fi
+}
+
+_new_home() {
+  local sb
+  sb="$(mktemp -d -t icloud-manifest-home.XXXXXX 2>/dev/null || mktemp -d)"
+  mkdir -p "$sb/Library/Mobile Documents/com~apple~CloudDocs"
+  mkdir -p "$sb/state/dotfiles"
+  printf '%s\n' "$sb"
+}
+
+# _run <home> — drive the hook with a scrubbed environment so nothing about
+# the developer's shell can influence the outcome.
+_run() {
+  env -i PATH="$PATH" HOME="$1" XDG_STATE_HOME="$1/state" \
+    "${BASH:-bash}" "$RENDERED" >"$HOOK_OUT" 2>&1
+}
+
+# _assert_unchanged <label> <before> <after> — the whole point of this file.
+_assert_unchanged() {
+  local label="$1" before="$2" after="$3"
+  if [[ "$before" == "$after" ]]; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    printf '  \033[0;32m✓\033[0m %s\n' "$label"
+  else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    printf '  \033[0;31m✗\033[0m %s: the tree changed —\n' "$label"
+    diff <(printf '%s\n' "$before") <(printf '%s\n' "$after") 2>/dev/null |
+      sed 's/^/        /'
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# SANITY
+# ---------------------------------------------------------------------------
+test_start "icloud_manifest_has_a_hasher"
+if [[ -n "$HASHER" ]]; then
+  TESTS_PASSED=$((TESTS_PASSED + 1))
+  printf '  \033[0;32m✓\033[0m %s: %s\n' "$CURRENT_TEST" "$HASHER"
+else
+  # Without a hasher this file proves nothing, so say so rather than passing
+  # a test that checked directory structure alone.
+  TESTS_FAILED=$((TESTS_FAILED + 1))
+  printf '  \033[0;31m✗\033[0m %s: neither sha256sum nor shasum found\n' "$CURRENT_TEST"
+fi
+
+# ---------------------------------------------------------------------------
+# 1. THE #1018 SCENARIO — every candidate holds real content and every iCloud
+#    source exists. This is the exact state in which the old mechanism
+#    destroyed a user's data. Nothing at all may change.
+# ---------------------------------------------------------------------------
+test_start "icloud_manifest_unchanged_when_every_candidate_holds_data"
+H="$(_new_home)"
+IC="$H/Library/Mobile Documents/com~apple~CloudDocs"
+for c in $CANDIDATES; do
+  mkdir -p "$H/$c/nested/deeper" "$IC/$c"
+  printf 'CANARY-%s-DO-NOT-DELETE\n' "$c" >"$H/$c/canary.txt"
+  printf 'buried-%s\n' "$c" >"$H/$c/nested/deeper/buried.txt"
+  printf 'hidden\n' >"$H/$c/.DS_Store"
+done
+BEFORE="$(_manifest "$H")"
+_run "$H"
+AFTER="$(_manifest "$H")"
+_assert_unchanged "$CURRENT_TEST" "$BEFORE" "$AFTER"
+
+test_start "icloud_manifest_refusal_is_reported_for_every_candidate"
+REFUSALS="$(grep -c 'refusing (user data protection)' "$HOOK_OUT" 2>/dev/null || printf '0')"
+assert_equals "7" "$(printf '%s' "$REFUSALS" | tr -d ' ')" \
+  "each of the seven candidates should say why it was left alone"
+rm -rf "$H"
+
+# ---------------------------------------------------------------------------
+# 2. THE RACE — a file lands in the target between the emptiness check and
+#    the rmdir. `rmdir` must fail, and the hook must then take no action at
+#    all rather than pressing on to the symlink.
+#
+#    The race is made deterministic with a `rmdir` shim on PATH that creates
+#    the file itself, immediately before delegating to the real one. Timing a
+#    real race would be flaky; this reproduces its effect exactly.
+# ---------------------------------------------------------------------------
+test_start "icloud_manifest_survives_the_rmdir_race"
+H="$(_new_home)"
+IC="$H/Library/Mobile Documents/com~apple~CloudDocs"
+mkdir -p "$H/Documents" "$IC/Documents"
+cat >"$SHIM_DIR/rmdir" <<'SHIM'
+#!/bin/sh
+# Stand in for a process that writes into the directory a moment before the
+# rmdir lands. The real rmdir then fails with ENOTEMPTY, which is the
+# behaviour under test.
+printf 'RACED-CANARY-DO-NOT-DELETE\n' >"$1/raced.txt" 2>/dev/null
+exec /bin/rmdir "$@"
+SHIM
+chmod +x "$SHIM_DIR/rmdir"
+env -i PATH="$SHIM_DIR:$PATH" HOME="$H" XDG_STATE_HOME="$H/state" \
+  "${BASH:-bash}" "$RENDERED" >"$HOOK_OUT" 2>&1
+rm -f "$SHIM_DIR/rmdir"
+assert_file_exists "$H/Documents/raced.txt" \
+  "a file that appears mid-flight must survive the rmdir it caused to fail"
+
+# One assert per test_start: tests/regression/test_test_framework_invariants.sh
+# requires TESTS_RUN == TESTS_PASSED + TESTS_FAILED for every suite in this
+# directory, and test_start counts once while each assert counts once.
+test_start "icloud_manifest_raced_file_contents_are_intact"
+assert_equals "RACED-CANARY-DO-NOT-DELETE" "$(cat "$H/Documents/raced.txt" 2>/dev/null)" \
+  "surviving the deletion is not enough — the bytes must be unchanged too"
+
+test_start "icloud_manifest_no_link_over_a_lost_race"
+assert_false "[[ -L \"$H/Documents\" ]]" \
+  "losing the race must not leave a symlink where the directory was"
+rm -rf "$H"
+
+# ---------------------------------------------------------------------------
+# 3. THE ALREADY-MIGRATED MACHINE — every candidate is already a correct
+#    symlink and the iCloud side holds real content. Upgrading such a machine
+#    must be a pure no-op, on both sides of every link.
+# ---------------------------------------------------------------------------
+test_start "icloud_manifest_stable_when_already_migrated"
+H="$(_new_home)"
+IC="$H/Library/Mobile Documents/com~apple~CloudDocs"
+for c in $CANDIDATES; do
+  mkdir -p "$IC/$c/sub"
+  printf 'ICLOUD-%s\n' "$c" >"$IC/$c/sub/data.txt"
+  ln -s "$IC/$c" "$H/$c"
+done
+BEFORE="$(_manifest "$H")"
+_run "$H"
+_run "$H"
+_run "$H"
+AFTER="$(_manifest "$H")"
+_assert_unchanged "$CURRENT_TEST" "$BEFORE" "$AFTER"
+
+test_start "icloud_manifest_recognises_every_existing_link"
+OKS="$(grep -c 'already symlinked to iCloud' "$HOOK_OUT" 2>/dev/null || printf '0')"
+assert_equals "7" "$(printf '%s' "$OKS" | tr -d ' ')" \
+  "an already-correct link should be recognised, not re-made"
+rm -rf "$H"
+
+# ---------------------------------------------------------------------------
+# 4. BOTH SIDES POPULATED — the home folder and the iCloud folder each hold
+#    different data. Neither may be merged into the other, moved, or lost.
+# ---------------------------------------------------------------------------
+test_start "icloud_manifest_never_merges_two_populated_sides"
+H="$(_new_home)"
+IC="$H/Library/Mobile Documents/com~apple~CloudDocs"
+mkdir -p "$H/Documents" "$IC/Documents"
+printf 'LOCAL-ONLY\n' >"$H/Documents/local.txt"
+printf 'CLOUD-ONLY\n' >"$IC/Documents/cloud.txt"
+BEFORE="$(_manifest "$H")"
+_run "$H"
+AFTER="$(_manifest "$H")"
+_assert_unchanged "$CURRENT_TEST" "$BEFORE" "$AFTER"
+rm -rf "$H"
+
+# ---------------------------------------------------------------------------
+# 5. CONVERGENCE — a mixed tree. The hook may act once, on the candidates
+#    that are genuinely safe, and must then stop changing anything. This is
+#    what makes `run_before_` (every apply) rather than `run_once_before_`
+#    defensible, so it is worth asserting rather than assuming.
+# ---------------------------------------------------------------------------
+test_start "icloud_manifest_converges_then_stops_changing"
+H="$(_new_home)"
+IC="$H/Library/Mobile Documents/com~apple~CloudDocs"
+for c in $CANDIDATES; do mkdir -p "$IC/$c"; done
+mkdir -p "$H/Documents"
+printf 'KEEP\n' >"$H/Documents/keep.txt"   # non-empty  -> must be refused
+mkdir -p "$H/Desktop"                      # empty      -> may be linked
+mkdir -p "$H/Music"
+printf 'x\n' >"$H/Music/.DS_Store"         # hidden only-> must be refused
+printf 'file\n' >"$H/Public"               # a file     -> must be refused
+# Downloads, Movies and Pictures are absent -> may be linked
+_run "$H"
+SETTLED="$(_manifest "$H")"
+_run "$H"
+_run "$H"
+AFTER="$(_manifest "$H")"
+_assert_unchanged "$CURRENT_TEST" "$SETTLED" "$AFTER"
+
+test_start "icloud_manifest_acted_only_where_it_was_safe"
+if [[ -f "$H/Documents/keep.txt" ]] &&
+   [[ ! -L "$H/Documents" ]] &&
+   [[ -f "$H/Music/.DS_Store" ]] &&
+   [[ ! -L "$H/Music" ]] &&
+   [[ -f "$H/Public" ]] &&
+   [[ ! -L "$H/Public" ]] &&
+   [[ -L "$H/Desktop" ]] &&
+   [[ -L "$H/Downloads" ]] &&
+   [[ -L "$H/Movies" ]] &&
+   [[ -L "$H/Pictures" ]]; then
+  TESTS_PASSED=$((TESTS_PASSED + 1))
+  printf '  \033[0;32m✓\033[0m %s\n' "$CURRENT_TEST"
+else
+  TESTS_FAILED=$((TESTS_FAILED + 1))
+  printf '  \033[0;31m✗\033[0m %s: refused and linked candidates are not as expected\n' \
+    "$CURRENT_TEST"
+fi
+rm -rf "$H"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+printf '\n  Tests: %d  \033[0;32mPassed: %d\033[0m  \033[0;31mFailed: %d\033[0m\n' \
+  "$TESTS_RUN" "$TESTS_PASSED" "$TESTS_FAILED"
+printf 'RESULTS:%d:%d:%d\n' "$TESTS_RUN" "$TESTS_PASSED" "$TESTS_FAILED"
+exit "$TESTS_FAILED"

--- a/tests/regression/test_macos_icloud_symlinks_manifest.sh
+++ b/tests/regression/test_macos_icloud_symlinks_manifest.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright (c) 2015-2026 Sebastien Rousseau
+# Regression for: GH-1018
 # shellcheck disable=SC1090,SC1091,SC2034
 #
 # Regression: defaults/run_before_macos-icloud-symlinks.sh.tmpl must leave a

--- a/tests/regression/test_macos_icloud_symlinks_safety.sh
+++ b/tests/regression/test_macos_icloud_symlinks_safety.sh
@@ -120,22 +120,65 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# INVARIANT 3: a symlink pointing to somewhere the user chose is never
-# overwritten.
+# INVARIANT 3 + 7: how the script treats a symlink that ALREADY exists.
+#
+# Both invariants interrogate the same code path (the `-L "$target"`
+# branch), so they share one sandbox and one script run — the script
+# walks every candidate per invocation, and a second invocation would
+# push this file past its "instant" perf budget for no added coverage.
+#
+#   INVARIANT 3  a link the USER chose is never overwritten.
+#   INVARIANT 7  a link that is ALREADY correct is recognised as correct,
+#                whatever form it takes. Recognition was a literal string
+#                compare of `readlink` against "$ICLOUD_ROOT/$name", which
+#                misses three forms macOS and users produce routinely:
+#                  * trailing slash  ln -s ".../Downloads/" ~/Downloads
+#                  * relative        ln -s "Library/Mobile Documents/..." ~/Music
+#                  * multi-hop       ~/Desktop -> ~/hop -> .../Desktop
+#                All name the right directory but fail a string compare, so
+#                the script fell through to the "symlink to somewhere else"
+#                branch and reported a correct link as "(not iCloud)". Not
+#                data loss — the fallthrough still skips — but it defeats
+#                the idempotency contract and makes the audit log lie about
+#                the state of user data.
 # ---------------------------------------------------------------------------
-test_start "icloud_never_overrides_user_managed_symlink"
 _new_sandbox >/dev/null
-mkdir -p "$ICLOUD/Movies"
+mkdir -p "$ICLOUD/Movies" "$ICLOUD/Downloads" "$ICLOUD/Music" "$ICLOUD/Desktop"
+# Invariant 3 fixture: a link the user pointed at their own disk.
 mkdir -p "$HOME/external-drive"
 ln -s "$HOME/external-drive" "$HOME/Movies"
-bash "$RENDERED" >/dev/null 2>&1 || true
+# Invariant 7 fixtures: three spellings of an already-correct iCloud link.
+ln -s "$ICLOUD/Downloads/" "$HOME/Downloads"
+ln -s "Library/Mobile Documents/com~apple~CloudDocs/Music" "$HOME/Music"
+ln -s "$ICLOUD/Desktop" "$HOME/.desktop-hop"
+ln -s "$HOME/.desktop-hop" "$HOME/Desktop"
+symlink_run_out="$(bash "$RENDERED" 2>&1 || true)"
+
+test_start "icloud_never_overrides_user_managed_symlink"
 resolved="$(readlink "$HOME/Movies" 2>/dev/null || echo '')"
 if [[ "$resolved" == "$HOME/external-drive" ]]; then
   TESTS_PASSED=$((TESTS_PASSED + 1))
-  printf '  \033[0;32m✓\033[0m %s\n' "$CURRENT_TEST"
+  printf '  \033[0;32m\xe2\x9c\x93\033[0m %s\n' "$CURRENT_TEST"
 else
   TESTS_FAILED=$((TESTS_FAILED + 1))
-  printf '  \033[0;31m✗\033[0m %s: symlink now points to %s\n' "$CURRENT_TEST" "$resolved"
+  printf '  \033[0;31m\xe2\x9c\x97\033[0m %s: symlink now points to %s\n' "$CURRENT_TEST" "$resolved"
+fi
+
+test_start "icloud_recognises_existing_correct_link_regardless_of_link_form"
+mismatched_forms=()
+echo "$symlink_run_out" | grep -q "OK   'Downloads'" ||
+  mismatched_forms=("${mismatched_forms[@]}" "trailing-slash")
+echo "$symlink_run_out" | grep -q "OK   'Music'" ||
+  mismatched_forms=("${mismatched_forms[@]}" "relative")
+echo "$symlink_run_out" | grep -q "OK   'Desktop'" ||
+  mismatched_forms=("${mismatched_forms[@]}" "multi-hop")
+if [[ ${#mismatched_forms[@]} -eq 0 ]]; then
+  TESTS_PASSED=$((TESTS_PASSED + 1))
+  printf '  \033[0;32m\xe2\x9c\x93\033[0m %s\n' "$CURRENT_TEST"
+else
+  TESTS_FAILED=$((TESTS_FAILED + 1))
+  printf '  \033[0;31m\xe2\x9c\x97\033[0m %s: correct links misreported as non-iCloud: %s\n' \
+    "$CURRENT_TEST" "${mismatched_forms[*]}"
 fi
 
 # ---------------------------------------------------------------------------
@@ -210,6 +253,24 @@ else
     "$CURRENT_TEST" "${missing_from_ignore[*]}"
 fi
 
+# ---------------------------------------------------------------------------
+# INVARIANT 7: an existing correct link to iCloud is RECOGNISED as correct.
+#
+# The script's idempotency contract is "already symlinked to iCloud -> no-op,
+# logged OK". That recognition was a literal string compare of `readlink`
+# output against "$ICLOUD_ROOT/$name", which breaks for three link forms
+# macOS and users produce routinely:
+#
+#   * trailing slash   ln -s ".../CloudDocs/Downloads/" ~/Downloads
+#   * relative link    ln -s "Library/Mobile Documents/..." ~/Downloads
+#   * multi-hop link   ~/Downloads -> ~/link -> .../CloudDocs/Downloads
+#
+# All three point at exactly the right place, but a literal compare misses
+# and the script falls through to the "symlink to somewhere else" branch —
+# reporting a correctly-linked dir as "(not iCloud)". Not data loss (the
+# fallthrough still skips), but it defeats the idempotency contract and
+# makes the audit log actively misleading about the state of user data.
+# ---------------------------------------------------------------------------
 # ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------

--- a/tests/regression/test_macos_icloud_symlinks_safety.sh
+++ b/tests/regression/test_macos_icloud_symlinks_safety.sh
@@ -4,7 +4,7 @@
 # shellcheck disable=SC1090,SC1091,SC2034
 #
 # Regression: the 5 most critical safety invariants of
-# defaults/run_once_before_macos-icloud-symlinks.sh.tmpl.
+# defaults/run_before_macos-icloud-symlinks.sh.tmpl.
 #
 # This is a REGRESSION test — it runs on every commit as part of
 # the standard regression suite. Its job is not to be exhaustive
@@ -35,7 +35,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
 source "$SCRIPT_DIR/../framework/assertions.sh"
 
-TEMPLATE="$REPO_ROOT/defaults/run_once_before_macos-icloud-symlinks.sh.tmpl"
+# Overridable so the one-shot guard below can be proven to fail.
+TEMPLATE="${TEMPLATE:-$REPO_ROOT/defaults/run_before_macos-icloud-symlinks.sh.tmpl}"
 
 # ---------------------------------------------------------------------------
 # Render the template into a runnable bash script (strip darwin guard).
@@ -271,6 +272,52 @@ fi
 # fallthrough still skips), but it defeats the idempotency contract and
 # makes the audit log actively misleading about the state of user data.
 # ---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
+# INVARIANT 8: the script must CONVERGE, not fire once.
+#
+# On a fresh Mac, `chezmoi apply` runs while iCloud Drive is still syncing
+# the folder tree down. Every candidate then hits "iCloud source does not
+# exist yet" and skips. Under the old `run_once_before_` prefix that was
+# the single attempt chezmoi would ever make, so the links were never
+# created at all — the exact opposite of the script's purpose.
+#
+# Two assertions:
+#   a) the source file is not run_once_/run_onchange_ (a structural guard:
+#      renaming it back reintroduces the one-shot failure mode)
+#   b) a second run, after iCloud appears, does create the link
+# ---------------------------------------------------------------------------
+test_start "icloud_script_is_not_run_once"
+tmpl_name="$(basename "$TEMPLATE")"
+case "$tmpl_name" in
+  run_once_* | run_onchange_*)
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    printf '  \033[0;31m✗\033[0m %s: named %s — one attempt only; a fresh Mac whose iCloud has not synced yet never gets its links\n' \
+      "$CURRENT_TEST" "$tmpl_name"
+    ;;
+  *)
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    printf '  \033[0;32m✓\033[0m %s\n' "$CURRENT_TEST"
+    ;;
+esac
+
+test_start "icloud_converges_once_icloud_appears"
+_new_sandbox >/dev/null
+# Pass 1: iCloud container exists but the folder has not synced down.
+bash "$RENDERED" >/dev/null 2>&1 || true
+first_state="absent"
+[[ -L "$HOME/Downloads" ]] && first_state="linked"
+# iCloud finishes syncing, then the next apply runs the script again.
+mkdir -p "$ICLOUD/Downloads"
+bash "$RENDERED" >/dev/null 2>&1 || true
+if [[ "$first_state" == "absent" ]] && [[ -L "$HOME/Downloads" ]]; then
+  TESTS_PASSED=$((TESTS_PASSED + 1))
+  printf '  \033[0;32m✓\033[0m %s: skipped while syncing, linked on the next run\n' "$CURRENT_TEST"
+else
+  TESTS_FAILED=$((TESTS_FAILED + 1))
+  printf '  \033[0;31m✗\033[0m %s: first=%s second=%s\n' "$CURRENT_TEST" \
+    "$first_state" "$([[ -L "$HOME/Downloads" ]] && echo linked || echo absent)"
+fi
+
 # ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------

--- a/tests/regression/test_macos_icloud_symlinks_safety.sh
+++ b/tests/regression/test_macos_icloud_symlinks_safety.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright (c) 2015-2026 Sebastien Rousseau
+# shellcheck disable=SC1090,SC1091,SC2034
+#
+# Regression: the 5 most critical safety invariants of
+# defaults/run_once_before_macos-icloud-symlinks.sh.tmpl.
+#
+# This is a REGRESSION test — it runs on every commit as part of
+# the standard regression suite. Its job is not to be exhaustive
+# (that's what tests/unit/misc/test_macos_icloud_symlinks.sh does).
+# Its job is to CATCH THE ONE CLASS OF BUG WE CAN NEVER HAVE AGAIN:
+# accidentally deleting user data.
+#
+# Background: this script replaces defaults/symlink_*.tmpl entries
+# that were removed in #1018 after chezmoi's built-in symlink-
+# handling mechanism (`rm -rf $target; ln -s $source $target`)
+# destroyed a real user's ~/Documents.
+#
+# Anyone editing the script MUST keep these 5 invariants intact:
+#
+#   1. A directory with any content is never touched.
+#   2. A regular file at the target path is never touched.
+#   3. A pre-existing symlink pointing elsewhere is never overwritten.
+#   4. The source contains no `rm -rf`, `mv`, `chmod`, or `chown`.
+#   5. Kill-switches (touch-file, env var) work.
+#
+# This test uses only bash 3.2-compatible features (macOS stock shell)
+# and lives in tests/regression/ so it runs in the regression suite
+# on every commit — not just when the unit-test directory changes.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+source "$SCRIPT_DIR/../framework/assertions.sh"
+
+TEMPLATE="$REPO_ROOT/defaults/run_once_before_macos-icloud-symlinks.sh.tmpl"
+
+# ---------------------------------------------------------------------------
+# Render the template into a runnable bash script (strip darwin guard).
+# ---------------------------------------------------------------------------
+RENDERED="$(mktemp -t icloud-regr.XXXXXX 2>/dev/null || mktemp)"
+trap 'rm -f "$RENDERED"' EXIT
+sed -e '/^{{- if eq \.chezmoi\.os "darwin" -}}$/d' \
+    -e '/^{{- end -}}$/d' \
+    "$TEMPLATE" > "$RENDERED"
+
+_new_sandbox() {
+  local sb
+  sb="$(mktemp -d 2>/dev/null || mktemp -d -t 'icloud-regr')"
+  export HOME="$sb"
+  export XDG_STATE_HOME="$sb/state"
+  mkdir -p "$XDG_STATE_HOME/dotfiles"
+  mkdir -p "$HOME/Library/Mobile Documents/com~apple~CloudDocs"
+  export ICLOUD="$HOME/Library/Mobile Documents/com~apple~CloudDocs"
+  unset DOTFILES_ICLOUD_SYMLINKS DOTFILES_ICLOUD_DRY_RUN
+  printf '%s\n' "$sb"
+}
+
+# ---------------------------------------------------------------------------
+# SANITY: script exists and parses.
+# ---------------------------------------------------------------------------
+test_start "icloud_symlink_template_exists"
+if [[ -f "$TEMPLATE" ]]; then
+  TESTS_PASSED=$((TESTS_PASSED + 1))
+  printf '  \033[0;32m✓\033[0m %s\n' "$CURRENT_TEST"
+else
+  TESTS_FAILED=$((TESTS_FAILED + 1))
+  printf '  \033[0;31m✗\033[0m %s: %s missing\n' "$CURRENT_TEST" "$TEMPLATE"
+fi
+
+test_start "icloud_symlink_rendered_script_parses"
+if bash -n "$RENDERED" 2>/dev/null; then
+  TESTS_PASSED=$((TESTS_PASSED + 1))
+  printf '  \033[0;32m✓\033[0m %s\n' "$CURRENT_TEST"
+else
+  TESTS_FAILED=$((TESTS_FAILED + 1))
+  printf '  \033[0;31m✗\033[0m %s\n' "$CURRENT_TEST"
+fi
+
+# ---------------------------------------------------------------------------
+# INVARIANT 1: a directory with any content is never touched.
+# Seed a canary file with irreplaceable content; assert it survives.
+# ---------------------------------------------------------------------------
+test_start "icloud_never_touches_non_empty_dir"
+_new_sandbox >/dev/null
+mkdir -p "$ICLOUD/Documents"
+mkdir -p "$HOME/Documents"
+echo "CANARY-DO-NOT-DELETE" > "$HOME/Documents/canary.txt"
+mkdir -p "$HOME/Documents/deep/nested/dir"
+echo "also-canary" > "$HOME/Documents/deep/nested/dir/file.txt"
+bash "$RENDERED" >/dev/null 2>&1 || true
+if [[ -f "$HOME/Documents/canary.txt" ]] \
+   && [[ "$(cat "$HOME/Documents/canary.txt")" == "CANARY-DO-NOT-DELETE" ]] \
+   && [[ -f "$HOME/Documents/deep/nested/dir/file.txt" ]] \
+   && [[ ! -L "$HOME/Documents" ]]; then
+  TESTS_PASSED=$((TESTS_PASSED + 1))
+  printf '  \033[0;32m✓\033[0m %s: canary preserved\n' "$CURRENT_TEST"
+else
+  TESTS_FAILED=$((TESTS_FAILED + 1))
+  printf '  \033[0;31m✗\033[0m %s: DATA LOSS DETECTED — this script may destroy user files\n' "$CURRENT_TEST"
+fi
+
+# ---------------------------------------------------------------------------
+# INVARIANT 2: a regular file at the target path is never touched.
+# ---------------------------------------------------------------------------
+test_start "icloud_never_touches_regular_file"
+_new_sandbox >/dev/null
+mkdir -p "$ICLOUD/Public"
+echo "regular-file-canary" > "$HOME/Public"
+bash "$RENDERED" >/dev/null 2>&1 || true
+if [[ -f "$HOME/Public" ]] && [[ ! -L "$HOME/Public" ]] \
+   && [[ "$(cat "$HOME/Public")" == "regular-file-canary" ]]; then
+  TESTS_PASSED=$((TESTS_PASSED + 1))
+  printf '  \033[0;32m✓\033[0m %s\n' "$CURRENT_TEST"
+else
+  TESTS_FAILED=$((TESTS_FAILED + 1))
+  printf '  \033[0;31m✗\033[0m %s\n' "$CURRENT_TEST"
+fi
+
+# ---------------------------------------------------------------------------
+# INVARIANT 3: a symlink pointing to somewhere the user chose is never
+# overwritten.
+# ---------------------------------------------------------------------------
+test_start "icloud_never_overrides_user_managed_symlink"
+_new_sandbox >/dev/null
+mkdir -p "$ICLOUD/Movies"
+mkdir -p "$HOME/external-drive"
+ln -s "$HOME/external-drive" "$HOME/Movies"
+bash "$RENDERED" >/dev/null 2>&1 || true
+resolved="$(readlink "$HOME/Movies" 2>/dev/null || echo '')"
+if [[ "$resolved" == "$HOME/external-drive" ]]; then
+  TESTS_PASSED=$((TESTS_PASSED + 1))
+  printf '  \033[0;32m✓\033[0m %s\n' "$CURRENT_TEST"
+else
+  TESTS_FAILED=$((TESTS_FAILED + 1))
+  printf '  \033[0;31m✗\033[0m %s: symlink now points to %s\n' "$CURRENT_TEST" "$resolved"
+fi
+
+# ---------------------------------------------------------------------------
+# INVARIANT 4: source contains no destructive operations. Grep the
+# template for `rm -rf`, `mv`, `chmod`, `chown` outside comments and
+# log messages.
+# ---------------------------------------------------------------------------
+test_start "icloud_source_has_no_destructive_operations"
+# Strip comments (leading #) and _log messages before checking.
+body=$(grep -vE '^\s*#' "$TEMPLATE" | grep -vE '^\s*_log ')
+bad_ops=()
+echo "$body" | grep -qE 'rm -rf'   && bad_ops+=("rm -rf")
+echo "$body" | grep -qE '^\s*mv\s' && bad_ops+=("mv")
+echo "$body" | grep -qE '^\s*chmod\s' && bad_ops+=("chmod")
+echo "$body" | grep -qE '^\s*chown\s' && bad_ops+=("chown")
+if [[ ${#bad_ops[@]} -eq 0 ]]; then
+  TESTS_PASSED=$((TESTS_PASSED + 1))
+  printf '  \033[0;32m✓\033[0m %s\n' "$CURRENT_TEST"
+else
+  TESTS_FAILED=$((TESTS_FAILED + 1))
+  printf '  \033[0;31m✗\033[0m %s: DANGEROUS OPS FOUND: %s\n' "$CURRENT_TEST" "${bad_ops[*]}"
+fi
+
+# ---------------------------------------------------------------------------
+# INVARIANT 5: kill-switches work (both file and env).
+# ---------------------------------------------------------------------------
+test_start "icloud_kill_switch_file_short_circuits"
+_new_sandbox >/dev/null
+touch "$HOME/.dotfiles.icloud-skip"
+mkdir -p "$ICLOUD/Documents"
+bash "$RENDERED" >/dev/null 2>&1 || true
+if [[ ! -L "$HOME/Documents" ]]; then
+  TESTS_PASSED=$((TESTS_PASSED + 1))
+  printf '  \033[0;32m✓\033[0m %s\n' "$CURRENT_TEST"
+else
+  TESTS_FAILED=$((TESTS_FAILED + 1))
+  printf '  \033[0;31m✗\033[0m %s\n' "$CURRENT_TEST"
+fi
+
+test_start "icloud_kill_switch_env_short_circuits"
+_new_sandbox >/dev/null
+mkdir -p "$ICLOUD/Documents"
+env DOTFILES_ICLOUD_SYMLINKS=0 bash "$RENDERED" >/dev/null 2>&1 || true
+if [[ ! -L "$HOME/Documents" ]]; then
+  TESTS_PASSED=$((TESTS_PASSED + 1))
+  printf '  \033[0;32m✓\033[0m %s\n' "$CURRENT_TEST"
+else
+  TESTS_FAILED=$((TESTS_FAILED + 1))
+  printf '  \033[0;31m✗\033[0m %s\n' "$CURRENT_TEST"
+fi
+
+# ---------------------------------------------------------------------------
+# INVARIANT 6: chezmoi ignore list still matches script candidates.
+# Belt-and-braces protection — if the script were ever deleted, chezmoi
+# apply must still refuse to touch these paths on macOS.
+# ---------------------------------------------------------------------------
+test_start "icloud_candidates_are_in_chezmoiignore_darwin_block"
+IGNORE="$REPO_ROOT/defaults/.chezmoiignore.tmpl"
+darwin_block=$(awk '/if eq .chezmoi.os "darwin"/,/^{{- end/' "$IGNORE")
+missing_from_ignore=()
+for name in Desktop Documents Downloads Movies Music Pictures Public; do
+  if ! echo "$darwin_block" | grep -qE "^${name}$"; then
+    missing_from_ignore=("${missing_from_ignore[@]}" "$name")
+  fi
+done
+if [[ ${#missing_from_ignore[@]} -eq 0 ]]; then
+  TESTS_PASSED=$((TESTS_PASSED + 1))
+  printf '  \033[0;32m✓\033[0m %s\n' "$CURRENT_TEST"
+else
+  TESTS_FAILED=$((TESTS_FAILED + 1))
+  printf '  \033[0;31m✗\033[0m %s: missing from ignore: %s\n' \
+    "$CURRENT_TEST" "${missing_from_ignore[*]}"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+printf '\n  Tests: %d  \033[0;32mPassed: %d\033[0m  \033[0;31mFailed: %d\033[0m\n' \
+  "$TESTS_RUN" "$TESTS_PASSED" "$TESTS_FAILED"
+printf 'RESULTS:%d:%d:%d\n' "$TESTS_RUN" "$TESTS_PASSED" "$TESTS_FAILED"
+exit "$TESTS_FAILED"

--- a/tests/regression/test_macos_icloud_symlinks_safety.sh
+++ b/tests/regression/test_macos_icloud_symlinks_safety.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright (c) 2015-2026 Sebastien Rousseau
+# Regression for: GH-1018
 # shellcheck disable=SC1090,SC1091,SC2034
 #
 # Regression: the 5 most critical safety invariants of

--- a/tests/unit/misc/test_macos_icloud_symlinks.sh
+++ b/tests/unit/misc/test_macos_icloud_symlinks.sh
@@ -2,8 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright (c) 2015-2026 Sebastien Rousseau
 #
-# Behavioural + safety tests for defaults/run_once_before_macos-
-# icloud-symlinks.sh.tmpl. The script's contract is:
+# Exhaustive behavioural + safety tests for
+# defaults/run_once_before_macos-icloud-symlinks.sh.tmpl.
+#
+# This is the most destructive-adjacent script in the repo — its
+# predecessor (chezmoi's symlink_*.tmpl mechanism) destroyed real
+# user data. Every branch of the new script must be exercised.
+#
+# The contract:
 #
 #   1. NEVER remove non-empty directories.
 #   2. NEVER touch a symlink pointing to somewhere the user chose.
@@ -11,12 +17,24 @@
 #   4. Idempotent: running twice on the same state is a no-op.
 #   5. Silent skip when iCloud isn't set up (no error).
 #   6. Kill-switch (env or touch-file) short-circuits everything.
+#   7. Failure of one candidate MUST NOT abort the others.
+#   8. Every decision is logged persistently.
 #
-# Each contract clause has at least one test.
+# Test enumeration philosophy:
 #
-# The tests render the .tmpl into a plain bash script by stripping
-# the darwin-guard, then run it in a sandbox with $HOME pointing to
-# a tmpdir. iCloud paths are mocked as regular dirs.
+#   * Every `_log` message in the script has at least one test
+#     that triggers it. The meta-test at the end asserts this
+#     invariant by parsing the script + collecting captured logs.
+#
+#   * The tests use only `bash -n`-compatible rendering (strip
+#     the outer darwin OS-guard) and mock the iCloud path with
+#     a plain tmpdir. All FS mutations happen inside a per-test
+#     sandbox that gets cleaned up.
+#
+#   * Data-destruction contracts (Contract 1, 2, 3) are verified
+#     by seeding sentinel files/content and asserting they survive
+#     — not just by log-message inspection. Log inspection can lie;
+#     a surviving canary cannot.
 
 set -u
 
@@ -27,18 +45,21 @@ source "$REPO_ROOT/tests/framework/assertions.sh"
 TEMPLATE="$REPO_ROOT/defaults/run_once_before_macos-icloud-symlinks.sh.tmpl"
 
 # ---------------------------------------------------------------------------
-# Render the template into a runnable bash script. We strip only the
-# darwin OS-guard (the outermost {{- if ... -}} ... {{- end -}}). The
-# body must be valid bash even in isolation.
+# Render the template into a runnable bash script. Strip only the
+# outermost darwin OS-guard. The body must be valid bash in isolation.
 # ---------------------------------------------------------------------------
 RENDERED="$(mktemp -t icloud-render.XXXXXX)"
-trap 'rm -f "$RENDERED"' EXIT
+CAPTURED_LOG_FILE="$(mktemp -t icloud-capture.XXXXXX)"
+trap 'rm -f "$RENDERED" "$CAPTURED_LOG_FILE"' EXIT
 sed -e '/^{{- if eq \.chezmoi\.os "darwin" -}}$/d' \
     -e '/^{{- end -}}$/d' \
     "$TEMPLATE" > "$RENDERED"
 
 # ---------------------------------------------------------------------------
-# Sandbox per test.
+# _new_sandbox — fresh $HOME per test. Sets iCloud root as a real
+# dir (tests can undo). Also captures the script's output for later
+# meta-analysis (every _log message that fires anywhere in the
+# suite is appended to CAPTURED_LOG_FILE).
 # ---------------------------------------------------------------------------
 _new_sandbox() {
   local sb
@@ -46,20 +67,32 @@ _new_sandbox() {
   export HOME="$sb"
   export XDG_STATE_HOME="$sb/state"
   mkdir -p "$XDG_STATE_HOME/dotfiles"
-  # Default: iCloud is set up. Tests can un-set to test the missing-iCloud path.
   mkdir -p "$HOME/Library/Mobile Documents/com~apple~CloudDocs"
   export ICLOUD="$HOME/Library/Mobile Documents/com~apple~CloudDocs"
-  # Reset any test-inherited env toggles.
   unset DOTFILES_ICLOUD_SYMLINKS DOTFILES_ICLOUD_DRY_RUN
   printf '%s\n' "$sb"
 }
 
 _run_script() {
-  bash "$RENDERED" 2>&1
+  local out
+  out="$(bash "$RENDERED" 2>&1)"
+  local rc=$?
+  printf '%s\n' "$out" >> "$CAPTURED_LOG_FILE"
+  printf '%s\n' "$out"
+  return "$rc"
+}
+
+_run_script_with_env() {
+  local out
+  out="$(env "$@" bash "$RENDERED" 2>&1)"
+  local rc=$?
+  printf '%s\n' "$out" >> "$CAPTURED_LOG_FILE"
+  printf '%s\n' "$out"
+  return "$rc"
 }
 
 # ---------------------------------------------------------------------------
-# Sanity: script exists + parses.
+# 0. Sanity: script exists + parses.
 # ---------------------------------------------------------------------------
 test_start "template_exists"
 assert_file_exists "$TEMPLATE" "iCloud symlink template must exist"
@@ -69,6 +102,7 @@ assert_exit_code 0 "bash -n '$RENDERED'"
 
 # ---------------------------------------------------------------------------
 # CONTRACT 5: silent skip when iCloud isn't set up.
+# LOG BRANCH: SKIP-ALL: iCloud Drive not initialised
 # ---------------------------------------------------------------------------
 test_start "skips_silently_when_icloud_missing"
 _new_sandbox >/dev/null
@@ -85,11 +119,12 @@ fi
 
 # ---------------------------------------------------------------------------
 # CONTRACT 6: kill-switch (touch-file).
+# LOG BRANCH: SKIP-ALL: found kill-switch file
 # ---------------------------------------------------------------------------
 test_start "kill_switch_file_short_circuits"
 _new_sandbox >/dev/null
 touch "$HOME/.dotfiles.icloud-skip"
-mkdir -p "$ICLOUD/Documents"                                    # would otherwise link
+mkdir -p "$ICLOUD/Documents"
 out="$(_run_script)"
 if [[ "$out" == *"kill-switch"* ]] && [[ ! -L "$HOME/Documents" ]]; then
   ((TESTS_PASSED++)) || true
@@ -101,11 +136,12 @@ fi
 
 # ---------------------------------------------------------------------------
 # CONTRACT 6: kill-switch (env var).
+# LOG BRANCH: SKIP-ALL: DOTFILES_ICLOUD_SYMLINKS=0
 # ---------------------------------------------------------------------------
 test_start "kill_switch_env_short_circuits"
 _new_sandbox >/dev/null
 mkdir -p "$ICLOUD/Documents"
-out="$(DOTFILES_ICLOUD_SYMLINKS=0 bash "$RENDERED" 2>&1)"
+out="$(_run_script_with_env DOTFILES_ICLOUD_SYMLINKS=0)"
 if [[ "$out" == *"DOTFILES_ICLOUD_SYMLINKS=0"* ]] && [[ ! -L "$HOME/Documents" ]]; then
   ((TESTS_PASSED++)) || true
   printf '  \033[0;32m✓\033[0m %s\n' "$CURRENT_TEST"
@@ -115,7 +151,8 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# CONTRACT 1 (THE MOST IMPORTANT ONE): NEVER destroy non-empty user data.
+# CONTRACT 1 (THE MOST IMPORTANT): NEVER destroy non-empty user data.
+# LOG BRANCH: SKIP '$name': target dir has $count entries, refusing
 # ---------------------------------------------------------------------------
 test_start "refuses_to_touch_non_empty_dir"
 _new_sandbox >/dev/null
@@ -125,7 +162,6 @@ echo "IRREPLACEABLE USER DATA" > "$HOME/Documents/thesis.txt"
 mkdir -p "$HOME/Documents/subdir"
 echo "more data" > "$HOME/Documents/subdir/notes.md"
 out="$(_run_script)"
-# Post-condition: files MUST still exist untouched.
 if [[ -f "$HOME/Documents/thesis.txt" ]] \
    && [[ "$(cat "$HOME/Documents/thesis.txt")" == "IRREPLACEABLE USER DATA" ]] \
    && [[ -f "$HOME/Documents/subdir/notes.md" ]] \
@@ -142,7 +178,7 @@ test_start "refuses_even_a_single_hidden_file"
 _new_sandbox >/dev/null
 mkdir -p "$ICLOUD/Downloads"
 mkdir -p "$HOME/Downloads"
-touch "$HOME/Downloads/.DS_Store"   # macOS ubiquity — must still be treated as "has data"
+touch "$HOME/Downloads/.DS_Store"
 _run_script >/dev/null
 if [[ ! -L "$HOME/Downloads" ]] && [[ -f "$HOME/Downloads/.DS_Store" ]]; then
   ((TESTS_PASSED++)) || true
@@ -152,8 +188,23 @@ else
   printf '  \033[0;31m✗\033[0m %s\n' "$CURRENT_TEST"
 fi
 
+test_start "refuses_when_target_has_hidden_git_dir"
+_new_sandbox >/dev/null
+mkdir -p "$ICLOUD/Documents"
+mkdir -p "$HOME/Documents/.git/objects"
+echo "chain content" > "$HOME/Documents/.git/HEAD"
+_run_script >/dev/null
+if [[ ! -L "$HOME/Documents" ]] && [[ -f "$HOME/Documents/.git/HEAD" ]]; then
+  ((TESTS_PASSED++)) || true
+  printf '  \033[0;32m✓\033[0m %s\n' "$CURRENT_TEST"
+else
+  ((TESTS_FAILED++)) || true
+  printf '  \033[0;31m✗\033[0m %s\n' "$CURRENT_TEST"
+fi
+
 # ---------------------------------------------------------------------------
 # CONTRACT 2: NEVER touch a symlink the user set up.
+# LOG BRANCH: SKIP '$name': is a symlink to '$current' (not iCloud)
 # ---------------------------------------------------------------------------
 test_start "leaves_user_managed_symlink_alone"
 _new_sandbox >/dev/null
@@ -172,6 +223,7 @@ fi
 
 # ---------------------------------------------------------------------------
 # CONTRACT 3: NEVER touch a regular file.
+# LOG BRANCH: SKIP '$name': target is a regular file, refusing to touch
 # ---------------------------------------------------------------------------
 test_start "refuses_when_target_is_regular_file"
 _new_sandbox >/dev/null
@@ -188,7 +240,41 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# ICLOUD SOURCE EDGE CASE: source is a symlink (unexpected iCloud state).
+# LOG BRANCH: SKIP '$name': iCloud source is itself a symlink
+# ---------------------------------------------------------------------------
+test_start "skips_when_icloud_source_is_a_symlink"
+_new_sandbox >/dev/null
+mkdir -p "$HOME/some-other-place"
+ln -s "$HOME/some-other-place" "$ICLOUD/Documents"
+out="$(_run_script)"
+if [[ ! -L "$HOME/Documents" ]] && [[ "$out" == *"source is itself a symlink"* ]]; then
+  ((TESTS_PASSED++)) || true
+  printf '  \033[0;32m✓\033[0m %s\n' "$CURRENT_TEST"
+else
+  ((TESTS_FAILED++)) || true
+  printf '  \033[0;31m✗\033[0m %s\n' "$CURRENT_TEST"
+fi
+
+# ---------------------------------------------------------------------------
+# ICLOUD SOURCE EDGE CASE: source is a regular file (not a directory).
+# LOG BRANCH: SKIP '$name': iCloud source exists but is not a directory
+# ---------------------------------------------------------------------------
+test_start "skips_when_icloud_source_is_regular_file"
+_new_sandbox >/dev/null
+echo "not a directory" > "$ICLOUD/Music"
+out="$(_run_script)"
+if [[ ! -L "$HOME/Music" ]] && [[ "$out" == *"source exists but is not a directory"* ]]; then
+  ((TESTS_PASSED++)) || true
+  printf '  \033[0;32m✓\033[0m %s\n' "$CURRENT_TEST"
+else
+  ((TESTS_FAILED++)) || true
+  printf '  \033[0;31m✗\033[0m %s\n' "$CURRENT_TEST"
+fi
+
+# ---------------------------------------------------------------------------
 # HAPPY PATH: target doesn't exist, iCloud does → create the link.
+# LOG BRANCH: LINK '$name': created symlink -> iCloud (target didn't exist)
 # ---------------------------------------------------------------------------
 test_start "creates_symlink_when_target_missing"
 _new_sandbox >/dev/null
@@ -205,11 +291,12 @@ fi
 
 # ---------------------------------------------------------------------------
 # HAPPY PATH: target is empty dir → rmdir + link.
+# LOG BRANCH: LINK '$name': created symlink -> iCloud
 # ---------------------------------------------------------------------------
 test_start "converts_empty_dir_to_symlink"
 _new_sandbox >/dev/null
 mkdir -p "$ICLOUD/Desktop"
-mkdir -p "$HOME/Desktop"   # empty
+mkdir -p "$HOME/Desktop"
 _run_script >/dev/null
 if [[ -L "$HOME/Desktop" ]] && [[ "$(readlink "$HOME/Desktop")" == "$ICLOUD/Desktop" ]]; then
   ((TESTS_PASSED++)) || true
@@ -220,7 +307,8 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# CONTRACT 4: idempotent. Run twice → no different final state.
+# CONTRACT 4: idempotent.
+# LOG BRANCH: OK '$name': already symlinked to iCloud
 # ---------------------------------------------------------------------------
 test_start "idempotent_second_run_is_noop"
 _new_sandbox >/dev/null
@@ -236,12 +324,12 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# ICLOUD SIDE: source doesn't exist for one candidate → skip that ONLY.
+# ICLOUD SOURCE MISSING for one candidate → skip only that.
+# LOG BRANCH: SKIP '$name': iCloud source does not exist yet
 # ---------------------------------------------------------------------------
 test_start "skips_only_candidates_without_icloud_source"
 _new_sandbox >/dev/null
-mkdir -p "$ICLOUD/Documents"       # only this one has an iCloud source
-# Desktop, Downloads, etc. — no iCloud source
+mkdir -p "$ICLOUD/Documents"
 _run_script >/dev/null
 if [[ -L "$HOME/Documents" ]] && [[ ! -L "$HOME/Desktop" ]] && [[ ! -L "$HOME/Downloads" ]]; then
   ((TESTS_PASSED++)) || true
@@ -252,13 +340,17 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# DRY-RUN: no filesystem mutations.
+# DRY-RUN: no filesystem mutations, target missing.
+# LOG BRANCH: DRY '$name': would create symlink to iCloud (target missing)
+#             DRY-RUN: no changes will be applied
 # ---------------------------------------------------------------------------
-test_start "dry_run_makes_no_changes"
+test_start "dry_run_when_target_missing_takes_no_action"
 _new_sandbox >/dev/null
 mkdir -p "$ICLOUD/Documents"
-out="$(DOTFILES_ICLOUD_DRY_RUN=1 bash "$RENDERED" 2>&1)"
-if [[ ! -e "$HOME/Documents" ]] && [[ "$out" == *"DRY-RUN"* ]]; then
+out="$(_run_script_with_env DOTFILES_ICLOUD_DRY_RUN=1)"
+if [[ ! -e "$HOME/Documents" ]] \
+   && [[ "$out" == *"DRY-RUN"* ]] \
+   && [[ "$out" == *"would create symlink"* ]]; then
   ((TESTS_PASSED++)) || true
   printf '  \033[0;32m✓\033[0m %s\n' "$CURRENT_TEST"
 else
@@ -267,7 +359,91 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# LOGGING: log file gets an entry per run.
+# DRY-RUN: no filesystem mutations, empty target dir present.
+# LOG BRANCH: DRY '$name': would rmdir empty target + create symlink
+# ---------------------------------------------------------------------------
+test_start "dry_run_when_target_empty_takes_no_action"
+_new_sandbox >/dev/null
+mkdir -p "$ICLOUD/Music"
+mkdir -p "$HOME/Music"
+out="$(_run_script_with_env DOTFILES_ICLOUD_DRY_RUN=1)"
+if [[ -d "$HOME/Music" ]] && [[ ! -L "$HOME/Music" ]] \
+   && [[ "$out" == *"would rmdir empty target"* ]]; then
+  ((TESTS_PASSED++)) || true
+  printf '  \033[0;32m✓\033[0m %s\n' "$CURRENT_TEST"
+else
+  ((TESTS_FAILED++)) || true
+  printf '  \033[0;31m✗\033[0m %s\n' "$CURRENT_TEST"
+fi
+
+# ---------------------------------------------------------------------------
+# RACE PROTECTION: what if rmdir fails? (permission or TOCTOU)
+# We simulate by making the parent dir non-writable so rmdir will fail.
+# LOG BRANCH: SKIP '$name': rmdir of empty dir failed
+# ---------------------------------------------------------------------------
+test_start "handles_rmdir_failure_without_data_loss"
+_new_sandbox >/dev/null
+mkdir -p "$ICLOUD/Movies"
+mkdir -p "$HOME/Movies"
+# Make $HOME non-writable — rmdir needs write on parent
+chmod 555 "$HOME"
+out="$(_run_script 2>&1)" || true
+chmod 755 "$HOME"   # always restore, even if test fails
+# Post-condition: no symlink created, dir still exists
+if [[ -d "$HOME/Movies" ]] && [[ ! -L "$HOME/Movies" ]] \
+   && ([[ "$out" == *"rmdir of empty dir failed"* ]] || [[ "$out" == *"race"* ]]); then
+  ((TESTS_PASSED++)) || true
+  printf '  \033[0;32m✓\033[0m %s\n' "$CURRENT_TEST"
+else
+  ((TESTS_FAILED++)) || true
+  printf '  \033[0;31m✗\033[0m %s: out=%s\n' "$CURRENT_TEST" "$(echo "$out" | head -3)"
+fi
+
+# ---------------------------------------------------------------------------
+# CONTRACT 7: a candidate whose subshell errors out MUST NOT stop the
+# others. Every branch of _link_if_safe currently ends in `return 0`
+# under normal FS state, so the only way to trigger the ERR handler
+# in the outer loop is to introduce a set -e violation inside the
+# subshell — which we cover via source inspection (the wrapper
+# `( _link_if_safe "$name" ) || _log "ERR"` provably contains any
+# failure), plus the positive-path test below that verifies mixed
+# states iterate correctly.
+#
+# See DEFENSIVE_BRANCHES allowlist in the meta-test below.
+# ---------------------------------------------------------------------------
+test_start "subshell_wrapper_is_present_and_isolates_failures"
+if grep -qE '^\s*\(\s*_link_if_safe.*\)\s*\|\|\s*_log' "$TEMPLATE"; then
+  ((TESTS_PASSED++)) || true
+  printf '  \033[0;32m✓\033[0m %s\n' "$CURRENT_TEST"
+else
+  ((TESTS_FAILED++)) || true
+  printf '  \033[0;31m✗\033[0m %s: subshell isolation wrapper missing from source\n' "$CURRENT_TEST"
+fi
+
+# ---------------------------------------------------------------------------
+# CONTRACT 7 (positive path): a candidate that legitimately skips MUST
+# NOT stop the others. Verifies loop continues across mixed states.
+# ---------------------------------------------------------------------------
+test_start "one_candidate_skip_does_not_stop_others"
+_new_sandbox >/dev/null
+mkdir -p "$ICLOUD/Documents"
+mkdir -p "$ICLOUD/Music"
+# Make Movies a symlink loop scenario: source is a symlink → will skip
+mkdir -p "$HOME/somewhere-else"
+ln -s "$HOME/somewhere-else" "$ICLOUD/Movies"
+_run_script >/dev/null
+# Post-condition: Documents + Music linked despite Movies triggering skip
+if [[ -L "$HOME/Documents" ]] && [[ -L "$HOME/Music" ]] && [[ ! -L "$HOME/Movies" ]]; then
+  ((TESTS_PASSED++)) || true
+  printf '  \033[0;32m✓\033[0m %s\n' "$CURRENT_TEST"
+else
+  ((TESTS_FAILED++)) || true
+  printf '  \033[0;31m✗\033[0m %s\n' "$CURRENT_TEST"
+fi
+
+# ---------------------------------------------------------------------------
+# CONTRACT 8: log file gets an entry per run, and PERSISTS across runs.
+# LOG BRANCH: == BEGIN run ==, == END run ==
 # ---------------------------------------------------------------------------
 test_start "writes_persistent_log"
 _new_sandbox >/dev/null
@@ -282,10 +458,121 @@ else
   printf '  \033[0;31m✗\033[0m %s\n' "$CURRENT_TEST"
 fi
 
+test_start "log_appends_across_multiple_runs"
+_new_sandbox >/dev/null
+mkdir -p "$ICLOUD/Documents"
+_run_script >/dev/null
+_run_script >/dev/null
+_run_script >/dev/null
+LOG="$XDG_STATE_HOME/dotfiles/icloud-symlinks.log"
+begin_count="$(grep -c "BEGIN run" "$LOG" 2>/dev/null || echo 0)"
+end_count="$(grep -c "END run" "$LOG" 2>/dev/null || echo 0)"
+if [[ "$begin_count" == "3" ]] && [[ "$end_count" == "3" ]]; then
+  ((TESTS_PASSED++)) || true
+  printf '  \033[0;32m✓\033[0m %s: 3 BEGIN + 3 END entries\n' "$CURRENT_TEST"
+else
+  ((TESTS_FAILED++)) || true
+  printf '  \033[0;31m✗\033[0m %s: BEGIN=%s END=%s\n' "$CURRENT_TEST" "$begin_count" "$end_count"
+fi
+
 # ---------------------------------------------------------------------------
-# INVARIANT: every candidate we handle is also in .chezmoiignore.tmpl.
-# This is the belt-and-braces guarantee — the script and the ignore
-# list can't drift.
+# EDGE: XDG_STATE_HOME unset — should fall back to ~/.local/state.
+# ---------------------------------------------------------------------------
+test_start "xdg_state_home_unset_falls_back_to_default"
+_new_sandbox >/dev/null
+unset XDG_STATE_HOME
+mkdir -p "$ICLOUD/Documents"
+_run_script >/dev/null
+if [[ -f "$HOME/.local/state/dotfiles/icloud-symlinks.log" ]]; then
+  ((TESTS_PASSED++)) || true
+  printf '  \033[0;32m✓\033[0m %s\n' "$CURRENT_TEST"
+else
+  ((TESTS_FAILED++)) || true
+  printf '  \033[0;31m✗\033[0m %s\n' "$CURRENT_TEST"
+fi
+
+# ---------------------------------------------------------------------------
+# EDGE: $HOME path contains a space — no accidental word-splitting.
+# ---------------------------------------------------------------------------
+test_start "handles_home_path_with_spaces"
+sb="$(mktemp -d -t 'icloud test with spaces.XXXXXX' 2>/dev/null || mktemp -d)"
+# On Linux, mktemp -t template can't have spaces; force one manually
+sb2="$sb/dir with space"
+mkdir -p "$sb2"
+export HOME="$sb2"
+export XDG_STATE_HOME="$sb2/state"
+mkdir -p "$XDG_STATE_HOME/dotfiles"
+mkdir -p "$HOME/Library/Mobile Documents/com~apple~CloudDocs/Documents"
+ICLOUD="$HOME/Library/Mobile Documents/com~apple~CloudDocs"
+_run_script >/dev/null
+if [[ -L "$HOME/Documents" ]]; then
+  ((TESTS_PASSED++)) || true
+  printf '  \033[0;32m✓\033[0m %s\n' "$CURRENT_TEST"
+else
+  ((TESTS_FAILED++)) || true
+  printf '  \033[0;31m✗\033[0m %s\n' "$CURRENT_TEST"
+fi
+rm -rf "$sb"
+
+# ---------------------------------------------------------------------------
+# MIXED STATES: one run handles candidates in various states independently.
+# ---------------------------------------------------------------------------
+test_start "mixed_candidate_states_in_single_run"
+_new_sandbox >/dev/null
+# Desktop: no iCloud source → skip
+# Documents: iCloud source + non-empty target → refuse
+# Downloads: iCloud source + empty target → link
+# Movies: iCloud source + already-linked → no-op
+# Music: iCloud source + missing target → link
+# Pictures: iCloud source + user-managed symlink → skip
+# Public: iCloud source + regular file → skip
+mkdir -p "$ICLOUD/Documents"
+mkdir -p "$HOME/Documents"
+echo "user data" > "$HOME/Documents/keep.txt"
+
+mkdir -p "$ICLOUD/Downloads"
+mkdir -p "$HOME/Downloads"   # empty
+
+mkdir -p "$ICLOUD/Movies"
+ln -s "$ICLOUD/Movies" "$HOME/Movies"   # already linked
+
+mkdir -p "$ICLOUD/Music"    # target missing
+
+mkdir -p "$ICLOUD/Pictures"
+mkdir -p "$HOME/user-pics"
+ln -s "$HOME/user-pics" "$HOME/Pictures"
+
+mkdir -p "$ICLOUD/Public"
+echo "content" > "$HOME/Public"
+
+out="$(_run_script)"
+pass=1
+# Desktop: no source → not linked
+[[ -L "$HOME/Desktop" ]] && { echo "  Desktop unexpectedly linked"; pass=0; }
+# Documents: still has user data, not linked
+[[ -f "$HOME/Documents/keep.txt" ]] || { echo "  Documents data lost"; pass=0; }
+[[ -L "$HOME/Documents" ]] && { echo "  Documents unexpectedly linked"; pass=0; }
+# Downloads: was empty → linked
+[[ -L "$HOME/Downloads" ]] || { echo "  Downloads should be linked"; pass=0; }
+# Movies: was pre-linked → still linked
+[[ -L "$HOME/Movies" ]] || { echo "  Movies should still be a symlink"; pass=0; }
+# Music: was missing → created
+[[ -L "$HOME/Music" ]] || { echo "  Music should be linked"; pass=0; }
+# Pictures: user's symlink preserved
+[[ "$(readlink "$HOME/Pictures")" == "$HOME/user-pics" ]] || { echo "  Pictures symlink changed"; pass=0; }
+# Public: still regular file
+[[ -f "$HOME/Public" && ! -L "$HOME/Public" ]] || { echo "  Public regular file lost"; pass=0; }
+if [[ $pass -eq 1 ]]; then
+  ((TESTS_PASSED++)) || true
+  printf '  \033[0;32m✓\033[0m %s: all 7 candidates behaved correctly\n' "$CURRENT_TEST"
+else
+  ((TESTS_FAILED++)) || true
+  printf '  \033[0;31m✗\033[0m %s\n' "$CURRENT_TEST"
+fi
+
+# ---------------------------------------------------------------------------
+# INVARIANT: every candidate handled by the script is also in
+# .chezmoiignore.tmpl. This is the belt-and-braces guarantee.
 # ---------------------------------------------------------------------------
 test_start "every_candidate_is_in_chezmoiignore_darwin_block"
 IGNORE="$REPO_ROOT/defaults/.chezmoiignore.tmpl"
@@ -301,6 +588,106 @@ else
   ((TESTS_FAILED++)) || true
   printf '  \033[0;31m✗\033[0m %s: missing from chezmoiignore darwin block: %s\n' \
     "$CURRENT_TEST" "${missing[*]}"
+fi
+
+# ---------------------------------------------------------------------------
+# SOURCE INVARIANT: no `rm -rf`, no `mv`, no `chmod` in the actual script.
+# Defence in depth against future edits reintroducing the data-loss vector.
+# ---------------------------------------------------------------------------
+test_start "source_has_no_destructive_operations"
+# Strip comments before grepping — the safety comment mentions rm -rf as an
+# example command to run manually, and that reference is educational, not code.
+body="$(grep -vE '^\s*#' "$TEMPLATE" 2>/dev/null | grep -vE '^\s*_log ')"
+bad=()
+echo "$body" | grep -qE 'rm -rf'   && bad+=("rm -rf found")
+echo "$body" | grep -qE '^\s*mv\s' && bad+=("mv found")
+echo "$body" | grep -qE '^\s*chmod\s' && bad+=("chmod found")
+echo "$body" | grep -qE '^\s*chown\s' && bad+=("chown found")
+if [[ ${#bad[@]} -eq 0 ]]; then
+  ((TESTS_PASSED++)) || true
+  printf '  \033[0;32m✓\033[0m %s: only rmdir is used for deletion\n' "$CURRENT_TEST"
+else
+  ((TESTS_FAILED++)) || true
+  printf '  \033[0;31m✗\033[0m %s: DANGEROUS OPS FOUND: %s\n' "$CURRENT_TEST" "${bad[*]}"
+fi
+
+# ---------------------------------------------------------------------------
+# META-TEST: 100% branch coverage (defensive branches allow-listed).
+#
+# Enumerates every distinct _log-message prefix in the script. Asserts
+# each one either:
+#   (a) has appeared at least once in test output (exercised), or
+#   (b) is in the DEFENSIVE_BRANCHES allowlist with a documented reason.
+#
+# Adding a new _log without a corresponding test — OR without adding it
+# to the allowlist with a justification — fails this assertion.
+#
+# The point: no branch silently escapes coverage. Either you tested it
+# or you consciously exempted it with a reason a reviewer can audit.
+# ---------------------------------------------------------------------------
+
+# DEFENSIVE_BRANCHES: log messages that fire only under conditions we
+# cannot construct in a userland test (kernel-level failures, resource
+# exhaustion, or set -e violations that require broken execution state).
+# Each entry MUST document why it's here.
+DEFENSIVE_BRANCHES=(
+  # ERR is fired by the outer loop's `( _link_if_safe ) || _log "ERR"`
+  # wrapper. Every path in _link_if_safe explicitly `return 0`s, so the
+  # subshell never legitimately fails under normal FS conditions.
+  # This is pure defence-in-depth: if a future edit accidentally lets
+  # set -e trip inside the subshell, ERR ensures the other candidates
+  # still iterate. Presence of the wrapper is asserted by the test
+  # `subshell_wrapper_is_present_and_isolates_failures` above.
+  "ERR  '\$name': subshell failed (see above)"
+)
+
+_is_defensive() {
+  local branch="$1"
+  for defensive in "${DEFENSIVE_BRANCHES[@]}"; do
+    [[ "$branch" == "$defensive" ]] && return 0
+  done
+  return 1
+}
+
+test_start "every_log_branch_exercised_by_suite"
+mapfile -t branches < <(
+  grep -oE '_log "[^"]*"' "$TEMPLATE" \
+    | sed 's/_log "//; s/"$//' \
+    | grep -v "^     to link this dir manually" \
+    | grep -v "^       rm -rf" \
+    | grep -v "^== BEGIN run" \
+    | grep -v "^== END run" \
+    | sort -u
+)
+missing_branches=()
+allowlisted_count=0
+for branch in "${branches[@]}"; do
+  static_prefix="${branch%%\$*}"
+  static_prefix="${static_prefix% \'}"
+  static_prefix="${static_prefix%% }"
+  if [[ -z "$static_prefix" ]]; then
+    continue
+  fi
+  if grep -qF "$static_prefix" "$CAPTURED_LOG_FILE"; then
+    continue                        # exercised
+  fi
+  if _is_defensive "$branch"; then
+    allowlisted_count=$((allowlisted_count + 1))
+    continue                        # documented defensive exception
+  fi
+  missing_branches+=("$branch")
+done
+if [[ ${#missing_branches[@]} -eq 0 ]]; then
+  ((TESTS_PASSED++)) || true
+  printf '  \033[0;32m✓\033[0m %s: %d branches (%d exercised, %d allowlisted-defensive)\n' \
+    "$CURRENT_TEST" "${#branches[@]}" $((${#branches[@]} - allowlisted_count)) "$allowlisted_count"
+else
+  ((TESTS_FAILED++)) || true
+  printf '  \033[0;31m✗\033[0m %s: %d branch(es) untested and not allowlisted:\n' \
+    "$CURRENT_TEST" "${#missing_branches[@]}"
+  for b in "${missing_branches[@]}"; do
+    printf '     - %s\n' "$b"
+  done
 fi
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/misc/test_macos_icloud_symlinks.sh
+++ b/tests/unit/misc/test_macos_icloud_symlinks.sh
@@ -240,15 +240,26 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# ICLOUD SOURCE EDGE CASE: source is a symlink (unexpected iCloud state).
+# ICLOUD SOURCE EDGE CASE: source is a symlink.
 # LOG BRANCH: SKIP '$name': iCloud source is itself a symlink
+#
+# This is NOT an exotic state: when macOS's native "Desktop & Documents
+# Folders" sync is on (System Settings > iCloud > iCloud Drive), macOS
+# itself puts CloudDocs/Desktop -> ~/Desktop and CloudDocs/Documents ->
+# ~/Documents. Those folders are already fully iCloud-synced by macOS,
+# and symlinking them by hand would fight the native feature.
+#
+# So the log line must not describe this as "unexpected" — on a data-
+# safety tool, calling a correct configuration unexpected invites the
+# user to "fix" it and lose data. Assert the message explains itself.
 # ---------------------------------------------------------------------------
 test_start "skips_when_icloud_source_is_a_symlink"
 _new_sandbox >/dev/null
 mkdir -p "$HOME/some-other-place"
 ln -s "$HOME/some-other-place" "$ICLOUD/Documents"
 out="$(_run_script)"
-if [[ ! -L "$HOME/Documents" ]] && [[ "$out" == *"source is itself a symlink"* ]]; then
+if [[ ! -L "$HOME/Documents" ]] && [[ "$out" == *"source is itself a symlink"* ]] &&
+  [[ "$out" != *"unexpected"* ]] && [[ "$out" == *"Desktop & Documents"* ]]; then
   ((TESTS_PASSED++)) || true
   printf '  \033[0;32m✓\033[0m %s\n' "$CURRENT_TEST"
 else

--- a/tests/unit/misc/test_macos_icloud_symlinks.sh
+++ b/tests/unit/misc/test_macos_icloud_symlinks.sh
@@ -3,7 +3,7 @@
 # Copyright (c) 2015-2026 Sebastien Rousseau
 #
 # Exhaustive behavioural + safety tests for
-# defaults/run_once_before_macos-icloud-symlinks.sh.tmpl.
+# defaults/run_before_macos-icloud-symlinks.sh.tmpl.
 #
 # This is the most destructive-adjacent script in the repo — its
 # predecessor (chezmoi's symlink_*.tmpl mechanism) destroyed real
@@ -42,7 +42,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
 source "$REPO_ROOT/tests/framework/assertions.sh"
 
-TEMPLATE="$REPO_ROOT/defaults/run_once_before_macos-icloud-symlinks.sh.tmpl"
+TEMPLATE="$REPO_ROOT/defaults/run_before_macos-icloud-symlinks.sh.tmpl"
 
 # ---------------------------------------------------------------------------
 # Render the template into a runnable bash script. Strip only the

--- a/tests/unit/misc/test_macos_icloud_symlinks.sh
+++ b/tests/unit/misc/test_macos_icloud_symlinks.sh
@@ -1,0 +1,312 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright (c) 2015-2026 Sebastien Rousseau
+#
+# Behavioural + safety tests for defaults/run_once_before_macos-
+# icloud-symlinks.sh.tmpl. The script's contract is:
+#
+#   1. NEVER remove non-empty directories.
+#   2. NEVER touch a symlink pointing to somewhere the user chose.
+#   3. NEVER touch a regular file.
+#   4. Idempotent: running twice on the same state is a no-op.
+#   5. Silent skip when iCloud isn't set up (no error).
+#   6. Kill-switch (env or touch-file) short-circuits everything.
+#
+# Each contract clause has at least one test.
+#
+# The tests render the .tmpl into a plain bash script by stripping
+# the darwin-guard, then run it in a sandbox with $HOME pointing to
+# a tmpdir. iCloud paths are mocked as regular dirs.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+source "$REPO_ROOT/tests/framework/assertions.sh"
+
+TEMPLATE="$REPO_ROOT/defaults/run_once_before_macos-icloud-symlinks.sh.tmpl"
+
+# ---------------------------------------------------------------------------
+# Render the template into a runnable bash script. We strip only the
+# darwin OS-guard (the outermost {{- if ... -}} ... {{- end -}}). The
+# body must be valid bash even in isolation.
+# ---------------------------------------------------------------------------
+RENDERED="$(mktemp -t icloud-render.XXXXXX)"
+trap 'rm -f "$RENDERED"' EXIT
+sed -e '/^{{- if eq \.chezmoi\.os "darwin" -}}$/d' \
+    -e '/^{{- end -}}$/d' \
+    "$TEMPLATE" > "$RENDERED"
+
+# ---------------------------------------------------------------------------
+# Sandbox per test.
+# ---------------------------------------------------------------------------
+_new_sandbox() {
+  local sb
+  sb="$(mktemp -d -t icloud-test.XXXXXX)"
+  export HOME="$sb"
+  export XDG_STATE_HOME="$sb/state"
+  mkdir -p "$XDG_STATE_HOME/dotfiles"
+  # Default: iCloud is set up. Tests can un-set to test the missing-iCloud path.
+  mkdir -p "$HOME/Library/Mobile Documents/com~apple~CloudDocs"
+  export ICLOUD="$HOME/Library/Mobile Documents/com~apple~CloudDocs"
+  # Reset any test-inherited env toggles.
+  unset DOTFILES_ICLOUD_SYMLINKS DOTFILES_ICLOUD_DRY_RUN
+  printf '%s\n' "$sb"
+}
+
+_run_script() {
+  bash "$RENDERED" 2>&1
+}
+
+# ---------------------------------------------------------------------------
+# Sanity: script exists + parses.
+# ---------------------------------------------------------------------------
+test_start "template_exists"
+assert_file_exists "$TEMPLATE" "iCloud symlink template must exist"
+
+test_start "rendered_script_syntax_valid"
+assert_exit_code 0 "bash -n '$RENDERED'"
+
+# ---------------------------------------------------------------------------
+# CONTRACT 5: silent skip when iCloud isn't set up.
+# ---------------------------------------------------------------------------
+test_start "skips_silently_when_icloud_missing"
+_new_sandbox >/dev/null
+rm -rf "$HOME/Library/Mobile Documents/com~apple~CloudDocs"
+out="$(_run_script)"
+rc=$?
+if [[ $rc -eq 0 ]] && [[ "$out" == *"iCloud Drive not initialised"* ]]; then
+  ((TESTS_PASSED++)) || true
+  printf '  \033[0;32m✓\033[0m %s\n' "$CURRENT_TEST"
+else
+  ((TESTS_FAILED++)) || true
+  printf '  \033[0;31m✗\033[0m %s: rc=%s\n' "$CURRENT_TEST" "$rc"
+fi
+
+# ---------------------------------------------------------------------------
+# CONTRACT 6: kill-switch (touch-file).
+# ---------------------------------------------------------------------------
+test_start "kill_switch_file_short_circuits"
+_new_sandbox >/dev/null
+touch "$HOME/.dotfiles.icloud-skip"
+mkdir -p "$ICLOUD/Documents"                                    # would otherwise link
+out="$(_run_script)"
+if [[ "$out" == *"kill-switch"* ]] && [[ ! -L "$HOME/Documents" ]]; then
+  ((TESTS_PASSED++)) || true
+  printf '  \033[0;32m✓\033[0m %s\n' "$CURRENT_TEST"
+else
+  ((TESTS_FAILED++)) || true
+  printf '  \033[0;31m✗\033[0m %s\n' "$CURRENT_TEST"
+fi
+
+# ---------------------------------------------------------------------------
+# CONTRACT 6: kill-switch (env var).
+# ---------------------------------------------------------------------------
+test_start "kill_switch_env_short_circuits"
+_new_sandbox >/dev/null
+mkdir -p "$ICLOUD/Documents"
+out="$(DOTFILES_ICLOUD_SYMLINKS=0 bash "$RENDERED" 2>&1)"
+if [[ "$out" == *"DOTFILES_ICLOUD_SYMLINKS=0"* ]] && [[ ! -L "$HOME/Documents" ]]; then
+  ((TESTS_PASSED++)) || true
+  printf '  \033[0;32m✓\033[0m %s\n' "$CURRENT_TEST"
+else
+  ((TESTS_FAILED++)) || true
+  printf '  \033[0;31m✗\033[0m %s\n' "$CURRENT_TEST"
+fi
+
+# ---------------------------------------------------------------------------
+# CONTRACT 1 (THE MOST IMPORTANT ONE): NEVER destroy non-empty user data.
+# ---------------------------------------------------------------------------
+test_start "refuses_to_touch_non_empty_dir"
+_new_sandbox >/dev/null
+mkdir -p "$ICLOUD/Documents"
+mkdir -p "$HOME/Documents"
+echo "IRREPLACEABLE USER DATA" > "$HOME/Documents/thesis.txt"
+mkdir -p "$HOME/Documents/subdir"
+echo "more data" > "$HOME/Documents/subdir/notes.md"
+out="$(_run_script)"
+# Post-condition: files MUST still exist untouched.
+if [[ -f "$HOME/Documents/thesis.txt" ]] \
+   && [[ "$(cat "$HOME/Documents/thesis.txt")" == "IRREPLACEABLE USER DATA" ]] \
+   && [[ -f "$HOME/Documents/subdir/notes.md" ]] \
+   && [[ ! -L "$HOME/Documents" ]] \
+   && [[ "$out" == *"refusing"* ]]; then
+  ((TESTS_PASSED++)) || true
+  printf '  \033[0;32m✓\033[0m %s: user data preserved, symlink not created\n' "$CURRENT_TEST"
+else
+  ((TESTS_FAILED++)) || true
+  printf '  \033[0;31m✗\033[0m %s: USER DATA MAY HAVE BEEN LOST\n' "$CURRENT_TEST"
+fi
+
+test_start "refuses_even_a_single_hidden_file"
+_new_sandbox >/dev/null
+mkdir -p "$ICLOUD/Downloads"
+mkdir -p "$HOME/Downloads"
+touch "$HOME/Downloads/.DS_Store"   # macOS ubiquity — must still be treated as "has data"
+_run_script >/dev/null
+if [[ ! -L "$HOME/Downloads" ]] && [[ -f "$HOME/Downloads/.DS_Store" ]]; then
+  ((TESTS_PASSED++)) || true
+  printf '  \033[0;32m✓\033[0m %s\n' "$CURRENT_TEST"
+else
+  ((TESTS_FAILED++)) || true
+  printf '  \033[0;31m✗\033[0m %s\n' "$CURRENT_TEST"
+fi
+
+# ---------------------------------------------------------------------------
+# CONTRACT 2: NEVER touch a symlink the user set up.
+# ---------------------------------------------------------------------------
+test_start "leaves_user_managed_symlink_alone"
+_new_sandbox >/dev/null
+mkdir -p "$ICLOUD/Movies"
+mkdir -p "$HOME/external-movies"
+ln -s "$HOME/external-movies" "$HOME/Movies"
+_run_script >/dev/null
+resolved="$(readlink "$HOME/Movies" 2>/dev/null || echo '')"
+if [[ "$resolved" == "$HOME/external-movies" ]]; then
+  ((TESTS_PASSED++)) || true
+  printf '  \033[0;32m✓\033[0m %s\n' "$CURRENT_TEST"
+else
+  ((TESTS_FAILED++)) || true
+  printf '  \033[0;31m✗\033[0m %s: symlink now points to %s\n' "$CURRENT_TEST" "$resolved"
+fi
+
+# ---------------------------------------------------------------------------
+# CONTRACT 3: NEVER touch a regular file.
+# ---------------------------------------------------------------------------
+test_start "refuses_when_target_is_regular_file"
+_new_sandbox >/dev/null
+mkdir -p "$ICLOUD/Public"
+echo "hello" > "$HOME/Public"
+_run_script >/dev/null
+if [[ -f "$HOME/Public" ]] && [[ ! -L "$HOME/Public" ]] \
+   && [[ "$(cat "$HOME/Public")" == "hello" ]]; then
+  ((TESTS_PASSED++)) || true
+  printf '  \033[0;32m✓\033[0m %s\n' "$CURRENT_TEST"
+else
+  ((TESTS_FAILED++)) || true
+  printf '  \033[0;31m✗\033[0m %s\n' "$CURRENT_TEST"
+fi
+
+# ---------------------------------------------------------------------------
+# HAPPY PATH: target doesn't exist, iCloud does → create the link.
+# ---------------------------------------------------------------------------
+test_start "creates_symlink_when_target_missing"
+_new_sandbox >/dev/null
+mkdir -p "$ICLOUD/Music"
+[[ -e "$HOME/Music" ]] && rm -rf "$HOME/Music"
+_run_script >/dev/null
+if [[ -L "$HOME/Music" ]] && [[ "$(readlink "$HOME/Music")" == "$ICLOUD/Music" ]]; then
+  ((TESTS_PASSED++)) || true
+  printf '  \033[0;32m✓\033[0m %s\n' "$CURRENT_TEST"
+else
+  ((TESTS_FAILED++)) || true
+  printf '  \033[0;31m✗\033[0m %s\n' "$CURRENT_TEST"
+fi
+
+# ---------------------------------------------------------------------------
+# HAPPY PATH: target is empty dir → rmdir + link.
+# ---------------------------------------------------------------------------
+test_start "converts_empty_dir_to_symlink"
+_new_sandbox >/dev/null
+mkdir -p "$ICLOUD/Desktop"
+mkdir -p "$HOME/Desktop"   # empty
+_run_script >/dev/null
+if [[ -L "$HOME/Desktop" ]] && [[ "$(readlink "$HOME/Desktop")" == "$ICLOUD/Desktop" ]]; then
+  ((TESTS_PASSED++)) || true
+  printf '  \033[0;32m✓\033[0m %s\n' "$CURRENT_TEST"
+else
+  ((TESTS_FAILED++)) || true
+  printf '  \033[0;31m✗\033[0m %s\n' "$CURRENT_TEST"
+fi
+
+# ---------------------------------------------------------------------------
+# CONTRACT 4: idempotent. Run twice → no different final state.
+# ---------------------------------------------------------------------------
+test_start "idempotent_second_run_is_noop"
+_new_sandbox >/dev/null
+mkdir -p "$ICLOUD/Pictures"
+_run_script >/dev/null
+out2="$(_run_script)"
+if [[ -L "$HOME/Pictures" ]] && [[ "$out2" == *"already symlinked"* ]]; then
+  ((TESTS_PASSED++)) || true
+  printf '  \033[0;32m✓\033[0m %s\n' "$CURRENT_TEST"
+else
+  ((TESTS_FAILED++)) || true
+  printf '  \033[0;31m✗\033[0m %s\n' "$CURRENT_TEST"
+fi
+
+# ---------------------------------------------------------------------------
+# ICLOUD SIDE: source doesn't exist for one candidate → skip that ONLY.
+# ---------------------------------------------------------------------------
+test_start "skips_only_candidates_without_icloud_source"
+_new_sandbox >/dev/null
+mkdir -p "$ICLOUD/Documents"       # only this one has an iCloud source
+# Desktop, Downloads, etc. — no iCloud source
+_run_script >/dev/null
+if [[ -L "$HOME/Documents" ]] && [[ ! -L "$HOME/Desktop" ]] && [[ ! -L "$HOME/Downloads" ]]; then
+  ((TESTS_PASSED++)) || true
+  printf '  \033[0;32m✓\033[0m %s\n' "$CURRENT_TEST"
+else
+  ((TESTS_FAILED++)) || true
+  printf '  \033[0;31m✗\033[0m %s\n' "$CURRENT_TEST"
+fi
+
+# ---------------------------------------------------------------------------
+# DRY-RUN: no filesystem mutations.
+# ---------------------------------------------------------------------------
+test_start "dry_run_makes_no_changes"
+_new_sandbox >/dev/null
+mkdir -p "$ICLOUD/Documents"
+out="$(DOTFILES_ICLOUD_DRY_RUN=1 bash "$RENDERED" 2>&1)"
+if [[ ! -e "$HOME/Documents" ]] && [[ "$out" == *"DRY-RUN"* ]]; then
+  ((TESTS_PASSED++)) || true
+  printf '  \033[0;32m✓\033[0m %s\n' "$CURRENT_TEST"
+else
+  ((TESTS_FAILED++)) || true
+  printf '  \033[0;31m✗\033[0m %s\n' "$CURRENT_TEST"
+fi
+
+# ---------------------------------------------------------------------------
+# LOGGING: log file gets an entry per run.
+# ---------------------------------------------------------------------------
+test_start "writes_persistent_log"
+_new_sandbox >/dev/null
+mkdir -p "$ICLOUD/Documents"
+_run_script >/dev/null
+LOG="$XDG_STATE_HOME/dotfiles/icloud-symlinks.log"
+if [[ -f "$LOG" ]] && grep -q "BEGIN run" "$LOG" && grep -q "END run" "$LOG"; then
+  ((TESTS_PASSED++)) || true
+  printf '  \033[0;32m✓\033[0m %s\n' "$CURRENT_TEST"
+else
+  ((TESTS_FAILED++)) || true
+  printf '  \033[0;31m✗\033[0m %s\n' "$CURRENT_TEST"
+fi
+
+# ---------------------------------------------------------------------------
+# INVARIANT: every candidate we handle is also in .chezmoiignore.tmpl.
+# This is the belt-and-braces guarantee — the script and the ignore
+# list can't drift.
+# ---------------------------------------------------------------------------
+test_start "every_candidate_is_in_chezmoiignore_darwin_block"
+IGNORE="$REPO_ROOT/defaults/.chezmoiignore.tmpl"
+darwin_block="$(awk '/if eq .chezmoi.os "darwin"/,/^{{- end/' "$IGNORE")"
+missing=()
+for name in Desktop Documents Downloads Movies Music Pictures Public; do
+  echo "$darwin_block" | grep -qE "^${name}$" || missing+=("$name")
+done
+if [[ ${#missing[@]} -eq 0 ]]; then
+  ((TESTS_PASSED++)) || true
+  printf '  \033[0;32m✓\033[0m %s\n' "$CURRENT_TEST"
+else
+  ((TESTS_FAILED++)) || true
+  printf '  \033[0;31m✗\033[0m %s: missing from chezmoiignore darwin block: %s\n' \
+    "$CURRENT_TEST" "${missing[*]}"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+printf '\n  Tests: %d  \033[0;32mPassed: %d\033[0m  \033[0;31mFailed: %d\033[0m\n' \
+  "$TESTS_RUN" "$TESTS_PASSED" "$TESTS_FAILED"
+printf 'RESULTS:%d:%d:%d\n' "$TESTS_RUN" "$TESTS_PASSED" "$TESTS_FAILED"
+exit "$TESTS_FAILED"

--- a/tests/unit/misc/test_macos_icloud_symlinks.sh
+++ b/tests/unit/misc/test_macos_icloud_symlinks.sh
@@ -654,14 +654,22 @@ DEFENSIVE_BRANCHES=(
 
 _is_defensive() {
   local branch="$1"
-  for defensive in "${DEFENSIVE_BRANCHES[@]}"; do
+  for defensive in ${DEFENSIVE_BRANCHES[@]+"${DEFENSIVE_BRANCHES[@]}"}; do
     [[ "$branch" == "$defensive" ]] && return 0
   done
   return 1
 }
 
 test_start "every_log_branch_exercised_by_suite"
-mapfile -t branches < <(
+# Read the branch list line by line rather than with mapfile: macOS ships
+# bash 3.2, where mapfile does not exist. There it failed as "command not
+# found", left `branches` unset, and the `for` below then aborted the whole
+# file on an unbound variable — which is why the CI runner saw this suite
+# exit 1 while every assertion above it had passed.
+branches=()
+while IFS= read -r _branch_line; do
+  branches+=("$_branch_line")
+done < <(
   grep -oE '_log "[^"]*"' "$TEMPLATE" \
     | sed 's/_log "//; s/"$//' \
     | grep -v "^     to link this dir manually" \
@@ -672,7 +680,7 @@ mapfile -t branches < <(
 )
 missing_branches=()
 allowlisted_count=0
-for branch in "${branches[@]}"; do
+for branch in ${branches[@]+"${branches[@]}"}; do
   static_prefix="${branch%%\$*}"
   static_prefix="${static_prefix% \'}"
   static_prefix="${static_prefix%% }"

--- a/tests/unit/misc/test_macos_icloud_symlinks.sh
+++ b/tests/unit/misc/test_macos_icloud_symlinks.sh
@@ -402,7 +402,7 @@ out="$(_run_script 2>&1)" || true
 chmod 755 "$HOME"   # always restore, even if test fails
 # Post-condition: no symlink created, dir still exists
 if [[ -d "$HOME/Movies" ]] && [[ ! -L "$HOME/Movies" ]] \
-   && ([[ "$out" == *"rmdir of empty dir failed"* ]] || [[ "$out" == *"race"* ]]); then
+   && { [[ "$out" == *"rmdir of empty dir failed"* ]] || [[ "$out" == *"race"* ]]; }; then
   ((TESTS_PASSED++)) || true
   printf '  \033[0;32m✓\033[0m %s\n' "$CURRENT_TEST"
 else


### PR DESCRIPTION
## Summary

Reintroduces the macOS iCloud Drive symlinks that #1018 had to remove, because chezmoi's built-in `symlink_*.tmpl` mechanism is `rm -rf $target; ln -s $source $target` — which destroyed a user's real `~/Documents` when it had content.

The replacement is `defaults/run_before_macos-icloud-symlinks.sh.tmpl`: a hook that decides per directory and refuses anything it cannot prove is safe.

Everything else in this PR grew out of that script needing to be provable rather than merely careful: a coverage suite, a performance gate so the hook cannot silently become slow on every apply, and meta-tests asserting those gates actually fire.

## Safety contract

Every action the script can take, and every state it refuses to touch:

| Target `$HOME/$name` state | Action |
|---|---|
| Already a symlink → iCloud | no-op |
| Symlink → somewhere else | **SKIP + log** (never overwrite your link) |
| Regular file | **SKIP + log** (never touch) |
| Directory with any content (incl. `.DS_Store`) | **SKIP + log** (data protection) |
| Empty directory | `rmdir` (fails safely on race) + create symlink |
| Does not exist | create symlink directly |

| iCloud source state | Action |
|---|---|
| Does not exist | SKIP + log (iCloud may still be syncing) |
| Is a symlink | SKIP + log |
| Is a directory | proceed |

Candidates: `Desktop`, `Documents`, `Downloads`, `Movies`, `Music`, `Pictures`, `Public`.

### On destructive operations — corrected

An earlier version of this description claimed **"No `rm -rf` anywhere."** That is not literally true and the claim is withdrawn. The string appears twice, and neither occurrence executes:

- **Line 17**, in the header comment, describing the chezmoi mechanism this script exists to replace.
- **Line 222**, inside a `_log` message, printing the command *you* could run by hand if you decide to override a refusal.

The only deletion the script performs is `rmdir`, which cannot remove a non-empty directory and fails safely if a file appears mid-flight. There is no `mv` and no `chmod`. `icloud_script_source_still_free_of_destructive_ops` in `tests/regression/test_gate_integrity.sh` asserts this against the source and fails if a real destructive call is introduced.

### On the hook's name — settled, and the description was the thing that was wrong

The file is `run_before_`, **not** `run_once_before_`, so it runs on every `chezmoi apply` rather than once per machine. An earlier version of this description called it `run_once_before_` and raised the difference as an open question. It is not open: the script's own header states the choice and the reason for it.

> This deliberately is NOT `run_once_before_`. A run-once script gets exactly one attempt, and on a fresh Mac that attempt lands while iCloud Drive is still syncing the folder tree down — so every candidate hits "iCloud source does not exist yet", skips, and the one chance is spent. The links would then never be created, which is precisely the opposite of what this script is for.

Converging on every apply is what makes the hook work on a machine where iCloud has not finished syncing. The cost of that choice is covered: `idempotent_second_run_is_noop` and `icloud_manifest_converges_then_stops_changing` assert that repeat runs change nothing, and `instant_icloud_script_single_run` (≤ 500 ms) keeps the per-apply price in the budget gate.

## Kill-switches (either short-circuits the whole run)

- `touch ~/.dotfiles.icloud-skip` — permanent per-machine opt-out
- `DOTFILES_ICLOUD_SYMLINKS=0` — env var, one run only

## Dry-run

- `DOTFILES_ICLOUD_DRY_RUN=1` — log every decision, take no filesystem action

## Belt-and-braces protection

The candidate names stay in `.chezmoiignore.tmpl`'s Darwin block. Even if this script never ran, a regular `chezmoi apply` would still refuse to touch these paths on macOS. Two independent layers, and `every_candidate_is_in_chezmoiignore_darwin_block` asserts the two lists cannot drift.

## Logging

Every run appends to `$XDG_STATE_HOME/dotfiles/icloud-symlinks.log` (`~/.local/state/dotfiles/icloud-symlinks.log` by default), one decision per candidate. `grep SKIP` to see why something was not linked, `grep LINK` for what was created.

## Tests

| Suite | Assertions | Covers |
|---|---:|---|
| `tests/unit/misc/test_macos_icloud_symlinks.sh` | 29 | Every branch of the refusal matrix, both happy paths, idempotence, both kill-switches, dry-run, logging across runs, `XDG_STATE_HOME` unset, a `$HOME` containing spaces, a read-only `$HOME`, and a mixed run where all seven candidates are in different states at once |
| `tests/regression/test_macos_icloud_symlinks_safety.sh` | 12 | The canary tests: a real file placed in a target directory must survive, verified by content and not merely by existence |
| `tests/regression/test_macos_icloud_symlinks_manifest.sh` | 11 | A sha256 manifest of the whole sandbox tree before and after each scenario, so any file lost, any byte changed, any directory turned into a symlink shows up — including in a path nobody thought to name. Verified to drop from 11/11 to 4/11 against a mutant that reintroduces the #1018 bug |
| `tests/regression/test_gate_integrity.sh` | 10 | That the gates themselves fail when they should — see below |

All pass under `/bin/bash` 3.2.57, which is what macOS ships and what CI runs, not only under a Homebrew bash 5.

## Performance budgets

`benches/test_perf_budgets.sh` — 19 gates across four tiers, wired into CI as `Quality / Performance budgets` on both `ubuntu-latest` and `macos-latest`, with no `|| true`. `docs/operations/PERFORMANCE_BUDGETS.md` carries the tier table, every baseline, and the reasoning.

Two properties that took several rounds to get right, both worth knowing about:

- **Exit status is checked, not just elapsed time.** A command that crashes instantly is *fast*. Timing alone cannot tell the difference, so a non-zero exit fails the gate and re-runs the command to print what it said.
- **The gate refuses to report a pass it cannot justify.** Timing uses the `time` keyword rather than `date +%s%N`, which is a GNU extension: BSD `date` (macOS 14 and earlier) copies the literal `N` through, every measurement failed to parse, and an empty median compares as `0` against any budget — so the gate reported every budget met, for any command, on those machines. A non-numeric median is now a failure, and a meta-test puts a `date` without `%N` first on `PATH` and requires the same verdicts.

`tests/regression/test_gate_integrity.sh` exists for that class of problem: it drives each gate with a deliberately impossible budget, a deliberately broken CLI, and a crippled clock, and fails if any of them still passes. It caught three separate defects in this branch that the gate itself reported as green.

## v0.2.520 version bump

The canonical version lives in `defaults/.chezmoidata.toml`; `scripts/verify-release-versions` checks 17 live surfaces against it and `scripts/version-sync.sh --verify` checks 32 markdown files. Both are clean.

`scripts/version-sync.sh` gained one fix: its updater and its verifier disagreed about scope — the updater skipped the root README's release links while the verifier failed on them, so the tool could not satisfy itself. Both now consult one helper, which also exempts `docs/GOLD-STANDARD-AUDIT.md`. That document records which tag `git tag -v` was run against and what it printed; rewriting it to the version being prepared would assert a verification nobody performed against a tag that does not exist.

## What's changed vs `main`

**New**

- `defaults/run_before_macos-icloud-symlinks.sh.tmpl` — the hook
- `docs/guides/MACOS_ICLOUD_SYMLINKS.md` — what it does, what it refuses, how to resolve each refusal by hand
- `tests/unit/misc/test_macos_icloud_symlinks.sh`, `tests/regression/test_macos_icloud_symlinks_safety.sh`, `tests/regression/test_gate_integrity.sh`
- `benches/test_perf_budgets.sh`, `docs/operations/PERFORMANCE_BUDGETS.md`
- `.github/workflows/ci.yml` — the `Quality / Performance budgets` matrix job

**Changed**

- `scripts/version-sync.sh` — one scope helper shared by the updater and the verifier
- `CHANGELOG.md` — one `v0.2.520` section dated 2026-09-10, folding in what was previously a separate `Unreleased` heading. Everything unreleased ships in the next tag and the next tag is v0.2.520, so two headings claimed a split that does not exist. The date is load-bearing: `tools/docs/generate-manpage.sh` reads the top `## vX.Y.Z` heading for the man page's `.TH` date, and `CITATION.cff`'s `date-released` follows it
- `share/man/man1/dot.1` — regenerated (190 entries, picking up `dot attest --verify` from #1074)
- `README.md`, `docs/packaging.md` — install and verification examples moved to v0.2.520

**Version surfaces** — `defaults/.chezmoidata.toml`, `bin/dot`, `install.sh`, `package.json`, `CITATION.cff`, `llms.txt`, both `.well-known` cards, `defaults/dot_local/share/dot-mcp/{main.go,example_test.go}`, `lib/dot/bento.sh`, `docs/COPYRIGHT`, `AGENTS.md`, `CLAUDE.md`, `scripts/git-hooks/pre-commit-audit.sh`, `docs/manual/00-introduction.md`, and four nested `README.md` files.

## Manual verification recipe (before merging)

On a Mac with real iCloud Drive. The template renders through chezmoi, so drive the rendered script rather than the `.tmpl`:

```bash
# Render the template once; drive the rendered script from here on.
chezmoi execute-template \
  < defaults/run_before_macos-icloud-symlinks.sh.tmpl > /tmp/icloud-hook.sh
bash -n /tmp/icloud-hook.sh

# 1. Kill-switch first — the safest possible starting state
touch ~/.dotfiles.icloud-skip
bash /tmp/icloud-hook.sh
# expect: "SKIP-ALL: found kill-switch file ~/.dotfiles.icloud-skip", nothing else

# 2. Dry-run: every decision logged, no filesystem action
rm ~/.dotfiles.icloud-skip
DOTFILES_ICLOUD_DRY_RUN=1 bash /tmp/icloud-hook.sh
cat ~/.local/state/dotfiles/icloud-symlinks.log

# 3. Read the log before doing anything real. Each candidate should show a
#    decision you agree with — in particular, every directory of yours that
#    has content must appear as SKIP.

# 4. Real run, only once step 3 reads correctly
bash /tmp/icloud-hook.sh
cat ~/.local/state/dotfiles/icloud-symlinks.log
```

## Test plan checklist

- [x] 29/29 unit, 12/12 safety regression, 11/11 tree-manifest regression, 10/10 gate integrity
- [x] All of the above under `/bin/bash` 3.2.57 as well as bash 5
- [x] 20/20 performance budgets, on Linux and macOS in CI
- [x] Docs accuracy 71/71, readability 92/92
- [x] `verify-release-versions` 17/17 surfaces; `version-sync --verify` 32 files; man page and command index regenerated and in sync
- [x] Changelog is a single dated `v0.2.520` section
- [x] Rendered template passes `bash -n`; hook source free of destructive calls
- [x] Full CI matrix green (125 checks, 0 failing) and up to date with `main`
- [x] Dry-run of the PR-head template on a real Mac (macOS 26.6.2, `/bin/bash` 3.2.57), log reviewed per candidate — all seven report `OK … already symlinked to iCloud`, the read-only branch
- [x] `run_before_` vs `run_once_before_` — settled; the script documents the choice, see above
- [ ] Dry-run on a Mac where the hook would **act** (see the caveat below)
- [ ] User sign-off before merge

> **Release note scope.** This section covers the iCloud/performance work and the WebAssembly verifier. Roughly sixty PRs have merged since the `v0.2.519` tag — the MCP server, twelve bug fixes, the coverage programme, the gold-standard pass — and most have no changelog entry. Writing them is release-note authoring rather than anything this branch changed, so it is left to whoever cuts the tag, but the notes will be thin until it is done.

> The dry-run above was performed on a machine whose seven folders are *already* symlinked, so the hook took its no-op path and the acting branches were not exercised against live iCloud Drive. Those branches are covered by 52 assertions across three suites and by a mutation test, but against a directory standing in for `CloudDocs` rather than a real one with evicted files and `.icloud` placeholders. The hook only ever calls `-e`, `-L`, `-d`, `-f` and `ls -A` on those paths, so a placeholder still counts as an entry and still triggers the refusal — but that is reasoning, not a measurement, and it is the one claim in this PR that has not been measured.

Signed-off-by: Sebastien Rousseau <sebastian.rousseau@gmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GkTMSRzg9EVUd11XZ9bbHC

---

THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co
