### PR TITLE
chore(brew): drop mise from the Brewfiles

### DIFF
--- a/defaults/dot_config/shell/Brewfile
+++ b/defaults/dot_config/shell/Brewfile
@@ -55,7 +55,6 @@ brew "shfmt"
 # -----------------------------------------------------------------------------
 # Languages & Runtimes (Cross-Platform)
 # -----------------------------------------------------------------------------
-brew "mise"                    # Universal version manager
 brew "uv"                      # Fast Python package manager
 brew "rustup"
 brew "go"

--- a/defaults/dot_config/shell/Brewfile.cli
+++ b/defaults/dot_config/shell/Brewfile.cli
@@ -52,9 +52,8 @@ brew "shellcheck"
 brew "shfmt"
 
 # -----------------------------------------------------------------------------
-# Languages & Runtimes (managed by mise)
+# Languages & Runtimes (mise itself is the standalone build, see mise.run)
 # -----------------------------------------------------------------------------
-brew "mise"
 brew "uv"                    # Fast Python package manager
 brew "rustup"
 brew "go"


### PR DESCRIPTION
The Homebrew build of mise is compiled without self-update, so this laptop now runs the standalone build from mise.run in `~/.local/bin`.

Keeping `brew "mise"` in the Brewfiles would let a future `brew bundle` reinstall the Homebrew copy behind it, and `ai-update` would then go back to `brew upgrade mise` instead of `mise self-update`.

## Scope

Two lines removed, one section comment reworded. No behaviour change for machines that never had the Homebrew mise.

Signed-off-by: Sebastien Rousseau <sebastian.rousseau@gmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GkTMSRzg9EVUd11XZ9bbHC

---

THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co
