### PR TITLE
fix(ci): correct the bash coverage measurement

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -103,8 +103,44 @@ jobs:
           #   Release hardening: 59.32% (7523/12682) after including the
           #             mandatory regression suite and replaying function-probe
           #             xtrace into the aggregator. floor=58.
+          #   Measurement fix: 70.15% (7700/10977). NOT new tests — the two
+          #             defects below made every previous figure an
+          #             understatement, so this entry corrects the metric
+          #             rather than improving the code.
+          #             (a) Denominator: bash `set -x` emits no trace record
+          #             for function-definition headers, `case` labels, the
+          #             interior of a multi-line `$( )` / `<( )` / array /
+          #             quoted string, plain backslash continuations, or a
+          #             compound terminator carrying only a redirection
+          #             (`done <file`). Those lines were permanently
+          #             unhittable yet sat in the denominator, capping real
+          #             files at 86-97%. They are now excluded, and a
+          #             multi-line statement folds onto ONE denominator entry
+          #             (bash reports it at the first physical line for some
+          #             constructs and the last for others). Denominator
+          #             12679 -> 10977; +8.99 pt.
+          #             (b) Per-test timeout: at 60s the heavier suites were
+          #             SIGTERMed mid-run and contributed nothing, so the
+          #             number tracked machine load. Budget raised to 300s
+          #             and a kill is now a hard error (exit 3, named files).
+          #             +1.80 pt (measured by re-aggregating the corrected
+          #             trace set with the OLD aggregator: 61.16%).
+          #             (c) Landed after that measurement, so NOT in the
+          #             70.15%: xtrace now goes to a dedicated descriptor
+          #             instead of fd 2, so a test that captures or discards
+          #             a child's stderr no longer throws that child's
+          #             coverage away (540 of 706 test files have such a
+          #             redirection on an invocation line); and the record
+          #             carries a repo-relative path, so bash 3.2's 100-char
+          #             PS4 truncation can no longer mangle records from a
+          #             deep checkout. Both only ever recover records, so
+          #             70.15% is a lower bound on what CI will measure.
+          #             floor=68 — ~2 pt of cushion for local<->CI drift and
+          #             run-to-run xtrace variance, matching the margin the
+          #             previous entries carried. Ratchet again once CI has
+          #             reported a figure that includes (c).
           # Bump in lockstep with the slice that lands the bump.
-          MIN_COVERAGE_PCT: '58'
+          MIN_COVERAGE_PCT: '68'
         run: bash tools/ci/run-coverage.sh
 
       - name: Upload lcov.info artifact

--- a/tests/unit/ci/test_run_coverage_aggregator.sh
+++ b/tests/unit/ci/test_run_coverage_aggregator.sh
@@ -276,6 +276,73 @@ for name in $FIXTURES; do
     "${name}.sh must reach 100% — uncovered lines are unhittable, not untested"
 done
 
+# -----------------------------------------------------------------------------
+# The runner must refuse to report a number when a test was killed.
+# -----------------------------------------------------------------------------
+test_start "timeout_kill_is_a_hard_error"
+mkdir -p "$SANDBOX/tests-hang/unit" "$SANDBOX/tests-hang/regression"
+cat >"$SANDBOX/tests-hang/unit/test_hangs.sh" <<'EOF'
+#!/usr/bin/env bash
+sleep 60
+EOF
+cat >"$SANDBOX/tests-hang/unit/test_quick.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "RESULTS:1:1:0"
+EOF
+set +e
+env REPO_ROOT="$SANDBOX" \
+  TESTS_DIR="$SANDBOX/tests-hang" \
+  COVERAGE_DIR="$SANDBOX/coverage2" \
+  COVERAGE_OUT="$SANDBOX/coverage2/lcov.info" \
+  COV_INCLUDE_DIRS="$SANDBOX/src" \
+  MIN_COVERAGE_PCT=0 \
+  COV_TEST_TIMEOUT=2 \
+  JOBS=2 \
+  bash "$RUNNER" >"$SANDBOX/runner-timeout.log" 2>&1
+timeout_ec=$?
+if [[ "$timeout_ec" -ne 0 ]] &&
+  grep -q "killed by coverage timeout: unit/test_hangs.sh" "$SANDBOX/runner-timeout.log"; then
+  ((TESTS_PASSED++)) || true
+  printf '%b\n' "  ${GREEN}✓${NC} $CURRENT_TEST"
+else
+  ((TESTS_FAILED++)) || true
+  printf '%b\n' "  ${RED}✗${NC} $CURRENT_TEST: expected non-zero exit naming the killed test (got $timeout_ec)"
+fi
+
+test_start "policy_skip_is_explicit_and_announced"
+# The escape hatch for a test that no budget can fit is an explicit,
+# printed list — never a silent kill.
+set +e
+env REPO_ROOT="$SANDBOX" \
+  TESTS_DIR="$SANDBOX/tests-hang" \
+  COVERAGE_DIR="$SANDBOX/coverage3" \
+  COVERAGE_OUT="$SANDBOX/coverage3/lcov.info" \
+  COV_INCLUDE_DIRS="$SANDBOX/src" \
+  MIN_COVERAGE_PCT=0 \
+  COV_TEST_TIMEOUT=2 \
+  COV_SKIP_TESTS="unit/test_hangs.sh:unit/test_other.sh" \
+  JOBS=2 \
+  bash "$RUNNER" >"$SANDBOX/runner-skip.log" 2>&1
+skip_ec=$?
+rm -rf "$SANDBOX/tests-hang"
+if [[ "$skip_ec" -eq 0 ]] &&
+  grep -q "skipped-by-policy: 1 test(s): unit/test_hangs.sh" "$SANDBOX/runner-skip.log" &&
+  grep -q "killed-by-timeout: 0 test(s)" "$SANDBOX/runner-skip.log"; then
+  ((TESTS_PASSED++)) || true
+  printf '%b\n' "  ${GREEN}✓${NC} $CURRENT_TEST"
+else
+  ((TESTS_FAILED++)) || true
+  printf '%b\n' "  ${RED}✗${NC} $CURRENT_TEST: expected a clean run naming the skipped test (got $skip_ec)"
+fi
+
+test_start "timeout_default_is_documented"
+assert_file_contains "$RUNNER" 'COV_TEST_TIMEOUT:-300' \
+  "the per-test budget must stay above the slowest real suite"
+
+test_start "killed_tests_are_summarised"
+assert_file_contains "$RUNNER" "killed-by-timeout:" \
+  "the runner must print a summary line naming any killed file"
+
 # Note: do NOT add cov_exercise_script here. This test asserts properties of
 # the coverage runner itself; running the runner during a coverage run would
 # spawn nested traces and pollute the parent's aggregation.

--- a/tests/unit/ci/test_run_coverage_aggregator.sh
+++ b/tests/unit/ci/test_run_coverage_aggregator.sh
@@ -129,11 +129,17 @@ mapfile -t collected < <(
 )
 echo "${collected[0]}" >/dev/null
 FIXTURE
-EXPECT_subst="2 6 7 11 12 15 16 19 20 23 24 25 26 29 32"
+EXPECT_subst="2 6 7 11 12 15 16 19 20 23 24 25 29 32"
 
 # Continuations: plain backslash-joined words (untraceable) versus a
 # continuation that starts a new command (traced at its own line), plus a
 # multi-line double-quoted string.
+#
+# Lines 6 and 8 — the heads of `true \` / `&& …` and `false \` / `|| …` —
+# are deliberately absent from the expectation. bash 5.3 traces them at
+# their own line; bash 5.2 (every current Linux runner) traces them at the
+# operator line instead, leaving them permanently unhittable there. The
+# classifier drops them so the denominator is the same on both.
 cat >"$SANDBOX/src/contin.sh" <<'FIXTURE'
 #!/usr/bin/env bash
 printf '%s %s %s\n' \
@@ -153,7 +159,7 @@ echo "$message" >/dev/null
 true && \
   echo "tail-operator" >/dev/null
 FIXTURE
-EXPECT_contin="2 6 7 8 9 10 11 12 15 16 17"
+EXPECT_contin="2 7 9 10 11 12 15 16 17"
 
 # Compound terminators carrying a redirection are not traced; a
 # terminator that starts a pipeline element is.
@@ -258,6 +264,15 @@ else
   sed -n '1,40p' "$runner_log" >&2
 fi
 
+# Which bash will actually drive the traced children decides whether the
+# dedicated xtrace descriptor is available at all (BASH_XTRACEFD is 4.1+).
+DRIVER_BASH_VERSION="$(bash -c 'echo "${BASH_VERSINFO[0]}.${BASH_VERSINFO[1]}"' 2>/dev/null || echo "0.0")"
+DRIVER_BASH_HAS_XTRACEFD=0
+case "$DRIVER_BASH_VERSION" in
+  0.* | 1.* | 2.* | 3.* | 4.0) : ;;
+  *) DRIVER_BASH_HAS_XTRACEFD=1 ;;
+esac
+
 # Extract "<lineno> <hits>" for one SF: block.
 lcov_block() {
   awk -v want="$1" '
@@ -287,6 +302,19 @@ for name in $FIXTURES; do
   test_start "fully_covered_${name}"
   # Every fixture executes all of its own statements, so anything left at
   # zero hits is a line the classifier kept that bash cannot report.
+  #
+  # captured.sh is the exception: it is driven with `>/dev/null 2>&1`, and
+  # only BASH_XTRACEFD keeps its records out of that redirection. On a
+  # bash older than 4.1 — /bin/bash on macOS, which is what `bash`
+  # resolves to on a stock macOS runner — there is no such descriptor and
+  # the records genuinely are lost. That is a documented limitation of the
+  # mechanism on bash 3.x, not a classifier defect, so record a skip
+  # rather than a failure the fixture cannot control.
+  if [[ "$name" == "captured" ]] && [[ "$DRIVER_BASH_HAS_XTRACEFD" != "1" ]]; then
+    ((TESTS_PASSED++)) || true
+    printf '%b\n' "  ${GREEN}✓${NC} $CURRENT_TEST: skipped (bash ${DRIVER_BASH_VERSION} has no BASH_XTRACEFD)"
+    continue
+  fi
   uncovered="$(lcov_block "$sf" | awk '$2 == 0 {print $1}' | tr '\n' ' ')"
   uncovered="${uncovered% }"
   assert_equals "" "$uncovered" \
@@ -355,7 +383,7 @@ fi
 test_start "trace_records_survive_a_long_path_under_bash32"
 # macOS /bin/bash is 3.2 and truncates the expanded PS4 at 100 characters.
 # The runner's record format must stay short enough that a deep checkout
-# cannot cut the `:@` terminator off and make the record unparseable.
+# cannot cut the `:@` terminator off and make the record unparsable.
 if [[ -x /bin/bash ]] && /bin/bash --version 2>/dev/null | head -1 | grep -q 'version 3\.'; then
   deep="$SANDBOX/aaaaaaaaaa/bbbbbbbbbb/cccccccccc/dddddddddd/eeeeeeeeee/ffffffffff"
   mkdir -p "$deep"
@@ -426,39 +454,56 @@ test_start "incomplete_sweep_is_a_hard_error"
 # A worker that dies before recording a status leaves the sweep short, and
 # `xargs … || true` hides it. The runner must refuse to report a
 # percentage computed from a fraction of the suite.
-mkdir -p "$SANDBOX/tests-partial/unit" "$SANDBOX/tests-partial/regression"
-printf '#!/usr/bin/env bash\necho "RESULTS:1:1:0"\n' \
-  >"$SANDBOX/tests-partial/unit/test_ok.sh"
-cat >"$SANDBOX/tests-partial/unit/test_kills_its_worker.sh" <<'EOF'
+#
+# The fixture has to find its grandparent to kill it; without /proc or
+# `ps` there is no portable way, so record a skip rather than a false
+# failure (a slim container is the case that hits this).
+if [[ ! -r /proc/self/stat ]] && ! command -v ps >/dev/null 2>&1; then
+  ((TESTS_PASSED++)) || true
+  printf '%b\n' "  ${GREEN}✓${NC} $CURRENT_TEST: skipped (no /proc and no ps to find the worker)"
+else
+  mkdir -p "$SANDBOX/tests-partial/unit" "$SANDBOX/tests-partial/regression"
+  printf '#!/usr/bin/env bash\necho "RESULTS:1:1:0"\n' \
+    >"$SANDBOX/tests-partial/unit/test_ok.sh"
+  cat >"$SANDBOX/tests-partial/unit/test_kills_its_worker.sh" <<'EOF'
 #!/usr/bin/env bash
 # Kill the xargs worker two levels up (this shell <- timeout <- worker),
 # reproducing "xargs: bash: terminated with signal 15": the worker dies
 # before it can record a status, so this test leaves no result behind.
-worker="$(ps -o ppid= -p "$PPID" 2>/dev/null | tr -d ' ')"
-[[ -n "$worker" ]] && kill -TERM "$worker" 2>/dev/null
+# /proc first (Linux, and present even in images without procps), `ps`
+# second (macOS and anything else).
+worker=""
+if [[ -r "/proc/$PPID/stat" ]]; then
+  worker="$(awk '{print $4}' "/proc/$PPID/stat" 2>/dev/null)"
+fi
+if [[ -z "$worker" ]] && command -v ps >/dev/null 2>&1; then
+  worker="$(ps -o ppid= -p "$PPID" 2>/dev/null | tr -d ' ')"
+fi
+[[ -n "$worker" && "$worker" != "0" ]] && kill -TERM "$worker" 2>/dev/null
 sleep 5
 EOF
-set +e
-env REPO_ROOT="$SANDBOX" \
-  TESTS_DIR="$SANDBOX/tests-partial" \
-  COVERAGE_DIR="$SANDBOX/coverage5" \
-  COVERAGE_OUT="$SANDBOX/coverage5/lcov.info" \
-  COV_INCLUDE_DIRS="$SANDBOX/src" \
-  MIN_COVERAGE_PCT=0 \
-  COV_TEST_TIMEOUT=30 \
-  JOBS=1 \
-  bash "$RUNNER" >"$SANDBOX/runner-partial.log" 2>&1
-partial_ec=$?
-rm -rf "$SANDBOX/tests-partial"
-if [[ "$partial_ec" -ne 0 ]] &&
-  grep -qE "tests-completed: [01]/2" "$SANDBOX/runner-partial.log" &&
-  grep -q "no result recorded for: unit/test_kills_its_worker.sh" "$SANDBOX/runner-partial.log"; then
-  ((TESTS_PASSED++)) || true
-  printf '%b\n' "  ${GREEN}✓${NC} $CURRENT_TEST"
-else
-  ((TESTS_FAILED++)) || true
-  printf '%b\n' "  ${RED}✗${NC} $CURRENT_TEST: expected a non-zero exit naming the test with no result (got $partial_ec)"
-  grep -E 'tests-completed|no result' "$SANDBOX/runner-partial.log" >&2 || true
+  set +e
+  env REPO_ROOT="$SANDBOX" \
+    TESTS_DIR="$SANDBOX/tests-partial" \
+    COVERAGE_DIR="$SANDBOX/coverage5" \
+    COVERAGE_OUT="$SANDBOX/coverage5/lcov.info" \
+    COV_INCLUDE_DIRS="$SANDBOX/src" \
+    MIN_COVERAGE_PCT=0 \
+    COV_TEST_TIMEOUT=30 \
+    JOBS=1 \
+    bash "$RUNNER" >"$SANDBOX/runner-partial.log" 2>&1
+  partial_ec=$?
+  rm -rf "$SANDBOX/tests-partial"
+  if [[ "$partial_ec" -ne 0 ]] &&
+    grep -qE "tests-completed: [01]/2" "$SANDBOX/runner-partial.log" &&
+    grep -q "no result recorded for: unit/test_kills_its_worker.sh" "$SANDBOX/runner-partial.log"; then
+    ((TESTS_PASSED++)) || true
+    printf '%b\n' "  ${GREEN}✓${NC} $CURRENT_TEST"
+  else
+    ((TESTS_FAILED++)) || true
+    printf '%b\n' "  ${RED}✗${NC} $CURRENT_TEST: expected a non-zero exit naming the test with no result (got $partial_ec)"
+    grep -E 'tests-completed|no result' "$SANDBOX/runner-partial.log" >&2 || true
+  fi
 fi
 
 test_start "xtrace_uses_a_dedicated_descriptor"

--- a/tests/unit/ci/test_run_coverage_aggregator.sh
+++ b/tests/unit/ci/test_run_coverage_aggregator.sh
@@ -1,0 +1,283 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2015-2026 Sebastien Rousseau
+# shellcheck disable=SC1090,SC1091,SC2034
+# =============================================================================
+# Regression test for the tools/ci/run-coverage.sh aggregator.
+#
+# The runner decides which physical lines belong in the lcov denominator.
+# Bash's `set -x` never emits a record for several kinds of line even when
+# the code runs (function headers, `case` labels, the interior of a
+# multi-line `$( )` / array / quoted string, plain backslash continuations,
+# `done <file`), so counting them made per-file coverage permanently
+# unreachable and capped real files at 86-97%.
+#
+# This test pins that decision. It builds a sandbox of fixtures — one per
+# construct, written so that EVERY statement in them executes — drives the
+# REAL runner over them, and asserts:
+#
+#   1. the emitted denominator (the DA: line numbers) matches an
+#      expected set exactly, so a change to the classifier is visible; and
+#   2. every one of those lines is hit, i.e. each fixture measures 100%.
+#
+# (2) is the load-bearing half: if the classifier ever re-admits a line
+# that bash cannot emit a record for, that fixture stops being 100% and
+# this test fails, naming the line.
+# =============================================================================
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+source "$SCRIPT_DIR/../../framework/assertions.sh"
+
+RUNNER="$REPO_ROOT/tools/ci/run-coverage.sh"
+
+test_start "runner_exists"
+assert_file_exists "$RUNNER" "run-coverage.sh must exist"
+
+SANDBOX="$(mktemp -d)"
+trap 'rm -rf "$SANDBOX"' EXIT
+# Resolve symlinks (/tmp -> /private/tmp on macOS) so the paths the
+# aggregator resolves match the ones this test compares against.
+SANDBOX="$(cd "$SANDBOX" && pwd -P)"
+mkdir -p "$SANDBOX/src" "$SANDBOX/tests/unit" "$SANDBOX/tests/regression"
+
+# -----------------------------------------------------------------------------
+# Fixtures. Each one exercises every statement it contains, so anything left
+# uncovered is a line bash cannot trace and the classifier wrongly kept.
+# -----------------------------------------------------------------------------
+
+# Function-definition headers: `name() {`, `function name {`, the split
+# `name()` + `{` form. Only the one-liner form is traceable, because its
+# body sits on the header line.
+cat >"$SANDBOX/src/funcs.sh" <<'FIXTURE'
+#!/usr/bin/env bash
+# headers below are never traced by `set -x`
+greet() {
+  echo "hi"
+}
+function fdecl {
+  echo "fdecl"
+}
+split()
+{
+  echo "split"
+}
+oneline() { echo "oneline"; }
+greet
+fdecl
+split
+oneline
+FIXTURE
+EXPECT_funcs="4 7 11 13 14 15 16 17"
+
+# `case` labels: quoted, alternation, star, and the same-line arm (which
+# IS traced, because the body runs on that line).
+cat >"$SANDBOX/src/cases.sh" <<'FIXTURE'
+#!/usr/bin/env bash
+for word in "hello world" alpha beta gamma "x y"; do
+  case "$word" in
+    "hello world")
+      echo "quoted"
+      ;;
+    alpha | beta)
+      echo "alternation"
+      ;;
+    gamma) echo "same line" ;;
+    *)
+      echo "star"
+      ;;
+  esac
+done
+echo "cases done"
+FIXTURE
+EXPECT_cases="2 3 5 8 10 12 16"
+
+# Multi-line words: command substitution, array assignment, arithmetic
+# substitution, backticks, nested substitution, and process substitution
+# in both `done <` and simple-command positions.
+cat >"$SANDBOX/src/subst.sh" <<'FIXTURE'
+#!/usr/bin/env bash
+value=$(
+  echo "one"
+  echo "two"
+)
+echo "$value" >/dev/null
+items=(
+  alpha
+  beta
+)
+echo "${items[1]}" >/dev/null
+total=$((
+  1 + 2
+))
+echo "$total" >/dev/null
+legacy=`
+echo "legacy"
+`
+echo "$legacy" >/dev/null
+printed=$(echo "$(
+  echo "nested"
+)")
+echo "$printed" >/dev/null
+while IFS= read -r entry; do
+  echo "entry=$entry" >/dev/null
+done < <(
+  printf '%s\n' a b
+)
+mapfile -t collected < <(
+  printf '%s\n' c
+)
+echo "${collected[0]}" >/dev/null
+FIXTURE
+EXPECT_subst="2 6 7 11 12 15 16 19 20 23 24 25 26 29 32"
+
+# Continuations: plain backslash-joined words (untraceable) versus a
+# continuation that starts a new command (traced at its own line), plus a
+# multi-line double-quoted string.
+cat >"$SANDBOX/src/contin.sh" <<'FIXTURE'
+#!/usr/bin/env bash
+printf '%s %s %s\n' \
+  "one" \
+  "two" \
+  "three" >/dev/null
+true \
+  && echo "and-then" >/dev/null
+false \
+  || echo "or-else" >/dev/null
+echo "first" \
+  | cat >/dev/null
+message="line-one
+line-two
+line-three"
+echo "$message" >/dev/null
+true && \
+  echo "tail-operator" >/dev/null
+FIXTURE
+EXPECT_contin="2 6 7 8 9 10 11 12 15 16 17"
+
+# Compound terminators carrying a redirection are not traced; a
+# terminator that starts a pipeline element is.
+cat >"$SANDBOX/src/terminators.sh" <<'FIXTURE'
+#!/usr/bin/env bash
+src="$(mktemp)"
+printf 'a\nb\n' >"$src"
+while IFS= read -r line; do
+  echo "read=$line" >/dev/null
+done <"$src"
+if true; then
+  echo "in-if" >/dev/null
+fi >/dev/null
+{
+  echo "in-brace"
+} >/dev/null
+for i in 1 2; do
+  echo "loop=$i"
+done | cat >/dev/null
+rm -f "$src"
+FIXTURE
+EXPECT_terminators="2 3 4 5 7 8 11 13 14 15 16"
+
+# Ordinary code plus here-documents, to prove the classifier still counts
+# real statements and still drops here-doc bodies.
+cat >"$SANDBOX/src/plain.sh" <<'FIXTURE'
+#!/usr/bin/env bash
+# a comment
+
+set -u
+count=0
+for i in 1 2 3; do
+  if [[ $((i % 2)) -eq 0 ]]; then
+    count=$((count + 1))
+  else
+    count=$((count + 10))
+  fi
+done
+cat >/dev/null <<'EOF'
+heredoc body line
+not code
+EOF
+cat >/dev/null <<-EOT
+  indented body
+EOT
+echo "count=$count" >/dev/null
+FIXTURE
+EXPECT_plain="4 5 6 7 8 10 13 17 20"
+
+FIXTURES="funcs cases subst contin terminators plain"
+
+# Driver: runs every fixture so that all of their statements execute.
+{
+  echo '#!/usr/bin/env bash'
+  echo '# SPDX-License-Identifier: MIT'
+  echo 'SRC="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../src" && pwd)"'
+  for name in $FIXTURES; do
+    echo "bash \"\$SRC/${name}.sh\" >/dev/null || true"
+  done
+  echo 'echo "RESULTS:1:1:0"'
+} >"$SANDBOX/tests/unit/test_drive_fixtures.sh"
+
+# -----------------------------------------------------------------------------
+# Drive the real runner over the sandbox.
+# -----------------------------------------------------------------------------
+test_start "aggregator_runs_over_fixtures"
+runner_log="$SANDBOX/runner.log"
+set +e
+env -u COV_TEST_TIMEOUT \
+  REPO_ROOT="$SANDBOX" \
+  TESTS_DIR="$SANDBOX/tests" \
+  COVERAGE_DIR="$SANDBOX/coverage" \
+  COVERAGE_OUT="$SANDBOX/coverage/lcov.info" \
+  COV_INCLUDE_DIRS="$SANDBOX/src" \
+  MIN_COVERAGE_PCT=0 \
+  JOBS=2 \
+  bash "$RUNNER" >"$runner_log" 2>&1
+runner_ec=$?
+if [[ "$runner_ec" -eq 0 && -s "$SANDBOX/coverage/lcov.info" ]]; then
+  ((TESTS_PASSED++)) || true
+  printf '%b\n' "  ${GREEN}✓${NC} $CURRENT_TEST"
+else
+  ((TESTS_FAILED++)) || true
+  printf '%b\n' "  ${RED}✗${NC} $CURRENT_TEST: runner exit $runner_ec"
+  sed -n '1,40p' "$runner_log" >&2
+fi
+
+# Extract "<lineno> <hits>" for one SF: block.
+lcov_block() {
+  awk -v want="$1" '
+    $0 == "SF:" want { inblock = 1; next }
+    inblock && /^end_of_record/ { inblock = 0 }
+    inblock && /^DA:/ {
+      sub(/^DA:/, "")
+      split($0, parts, ",")
+      print parts[1], parts[2]
+    }
+  ' "$SANDBOX/coverage/lcov.info"
+}
+
+for name in $FIXTURES; do
+  sf="$SANDBOX/src/${name}.sh"
+  expected_var="EXPECT_${name}"
+  expected="${!expected_var}"
+
+  test_start "denominator_exact_${name}"
+  actual="$(lcov_block "$sf" | awk '{print $1}' | sort -n | tr '\n' ' ')"
+  actual="${actual% }"
+  expected_norm="$(printf '%s\n' $expected | sort -n | tr '\n' ' ')"
+  expected_norm="${expected_norm% }"
+  assert_equals "$expected_norm" "$actual" \
+    "${name}.sh denominator must be exactly the traceable lines"
+
+  test_start "fully_covered_${name}"
+  # Every fixture executes all of its own statements, so anything left at
+  # zero hits is a line the classifier kept that bash cannot report.
+  uncovered="$(lcov_block "$sf" | awk '$2 == 0 {print $1}' | tr '\n' ' ')"
+  uncovered="${uncovered% }"
+  assert_equals "" "$uncovered" \
+    "${name}.sh must reach 100% — uncovered lines are unhittable, not untested"
+done
+
+# Note: do NOT add cov_exercise_script here. This test asserts properties of
+# the coverage runner itself; running the runner during a coverage run would
+# spawn nested traces and pollute the parent's aggregation.
+
+echo "RESULTS:$TESTS_RUN:$TESTS_PASSED:$TESTS_FAILED"

--- a/tests/unit/ci/test_run_coverage_aggregator.sh
+++ b/tests/unit/ci/test_run_coverage_aggregator.sh
@@ -203,7 +203,20 @@ echo "count=$count" >/dev/null
 FIXTURE
 EXPECT_plain="4 5 6 7 8 10 13 17 20"
 
-FIXTURES="funcs cases subst contin terminators plain"
+# Driven with its stderr captured AND discarded — the pattern that used to
+# throw a child's whole contribution away, because xtrace writes to fd 2.
+cat >"$SANDBOX/src/captured.sh" <<'FIXTURE'
+#!/usr/bin/env bash
+emit() {
+  echo "captured-stdout"
+  echo "captured-stderr" >&2
+}
+emit
+echo "captured-done"
+FIXTURE
+EXPECT_captured="3 4 6 7"
+
+FIXTURES="funcs cases subst contin terminators plain captured"
 
 # Driver: runs every fixture so that all of their statements execute.
 {
@@ -211,7 +224,11 @@ FIXTURES="funcs cases subst contin terminators plain"
   echo '# SPDX-License-Identifier: MIT'
   echo 'SRC="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../src" && pwd)"'
   for name in $FIXTURES; do
-    echo "bash \"\$SRC/${name}.sh\" >/dev/null || true"
+    if [[ "$name" == "captured" ]]; then
+      echo "bash \"\$SRC/${name}.sh\" >/dev/null 2>&1 || true"
+    else
+      echo "bash \"\$SRC/${name}.sh\" >/dev/null || true"
+    fi
   done
   echo 'echo "RESULTS:1:1:0"'
 } >"$SANDBOX/tests/unit/test_drive_fixtures.sh"
@@ -334,6 +351,76 @@ else
   ((TESTS_FAILED++)) || true
   printf '%b\n' "  ${RED}✗${NC} $CURRENT_TEST: expected a clean run naming the skipped test (got $skip_ec)"
 fi
+
+test_start "trace_records_survive_a_long_path_under_bash32"
+# macOS /bin/bash is 3.2 and truncates the expanded PS4 at 100 characters.
+# The runner's record format must stay short enough that a deep checkout
+# cannot cut the `:@` terminator off and make the record unparseable.
+if [[ -x /bin/bash ]] && /bin/bash --version 2>/dev/null | head -1 | grep -q 'version 3\.'; then
+  deep="$SANDBOX/aaaaaaaaaa/bbbbbbbbbb/cccccccccc/dddddddddd/eeeeeeeeee/ffffffffff"
+  mkdir -p "$deep"
+  printf '#!/usr/bin/env bash\necho deep\n' >"$deep/deep.sh"
+  cov_ps4="$(grep -m1 '^COV_PS4=' "$RUNNER" | cut -d= -f2- | sed "s/^'//; s/'$//")"
+  deep_trace="$SANDBOX/deep.trace"
+  COV_ROOT="$SANDBOX" PS4="$cov_ps4" /bin/bash -xu "$deep/deep.sh" \
+    2>"$deep_trace" >/dev/null || true
+  intact="$(grep -cE '^\+@COV@:[0-9]+:[^:]*:@' "$deep_trace" 2>/dev/null)" || intact=0
+  allrec="$(grep -cE '^\++@COV@:[0-9]+:' "$deep_trace" 2>/dev/null)" || allrec=0
+  if [[ "$intact" -gt 0 && "$intact" -eq "$allrec" ]]; then
+    ((TESTS_PASSED++)) || true
+    printf '%b\n' "  ${GREEN}✓${NC} $CURRENT_TEST"
+  else
+    ((TESTS_FAILED++)) || true
+    printf '%b\n' "  ${RED}✗${NC} $CURRENT_TEST: ${intact}/${allrec} records intact from a ${#deep} char path"
+  fi
+else
+  ((TESTS_PASSED++)) || true
+  printf '%b\n' "  ${GREEN}✓${NC} $CURRENT_TEST: skipped (no bash 3.x at /bin/bash)"
+fi
+
+test_start "silent_trace_is_reported"
+# A test whose stderr goes nowhere yields an empty trace while exiting 0.
+# That must be named, not absorbed.
+mkdir -p "$SANDBOX/tests-silent/unit" "$SANDBOX/tests-silent/regression"
+cat >"$SANDBOX/tests-silent/unit/test_silent.sh" <<'EOF'
+#!/usr/bin/env bash
+# Synthetic stand-in for the real shape of this failure: a suite whose
+# stderr is redirected away on a shell too old for BASH_XTRACEFD, so the
+# runner is handed an empty trace and a clean exit status. Pointing
+# BASH_XTRACEFD at the discarded descriptor and clearing what was written
+# before that reproduces the same end state on a modern bash.
+exec 2>/dev/null
+BASH_XTRACEFD=2
+: >"${COV_TRACE_FILE:-/dev/null}"
+echo "RESULTS:1:1:0"
+EOF
+set +e
+env REPO_ROOT="$SANDBOX" \
+  TESTS_DIR="$SANDBOX/tests-silent" \
+  COVERAGE_DIR="$SANDBOX/coverage4" \
+  COVERAGE_OUT="$SANDBOX/coverage4/lcov.info" \
+  COV_INCLUDE_DIRS="$SANDBOX/src" \
+  MIN_COVERAGE_PCT=0 \
+  JOBS=2 \
+  bash "$RUNNER" >"$SANDBOX/runner-silent.log" 2>&1
+silent_ec=$?
+rm -rf "$SANDBOX/tests-silent"
+if grep -q "no coverage captured from: unit/test_silent.sh" "$SANDBOX/runner-silent.log" &&
+  grep -q "silent-traces: 1 test(s)" "$SANDBOX/runner-silent.log"; then
+  ((TESTS_PASSED++)) || true
+  printf '%b\n' "  ${GREEN}✓${NC} $CURRENT_TEST"
+else
+  ((TESTS_FAILED++)) || true
+  printf '%b\n' "  ${RED}✗${NC} $CURRENT_TEST: runner did not name the silent test (exit $silent_ec)"
+fi
+
+test_start "xtrace_uses_a_dedicated_descriptor"
+assert_file_contains "$RUNNER" "BASH_XTRACEFD=" \
+  "xtrace must not be written to fd 2, where a test's redirection can eat it"
+
+test_start "truncated_records_are_audited"
+assert_file_contains "$RUNNER" "truncated-trace-records:" \
+  "a record that lost its terminator must be counted and reported"
 
 test_start "timeout_default_is_documented"
 assert_file_contains "$RUNNER" 'COV_TEST_TIMEOUT:-300' \

--- a/tests/unit/ci/test_run_coverage_aggregator.sh
+++ b/tests/unit/ci/test_run_coverage_aggregator.sh
@@ -414,6 +414,53 @@ else
   printf '%b\n' "  ${RED}✗${NC} $CURRENT_TEST: runner did not name the silent test (exit $silent_ec)"
 fi
 
+test_start "empty_bash_source_is_not_mistaken_for_truncation"
+# `bash -c` has no BASH_SOURCE[0], so records legitimately carry an empty
+# file field. Those must parse (and then be skipped for having no file),
+# not be counted as mangled — otherwise the truncation audit cries wolf on
+# every run and the real signal is lost in the noise.
+assert_file_contains "$RUNNER" 'hit_re = re.compile(r"^\++@COV@:(\d+):([^:]*):@")' \
+  "the record pattern must accept an empty BASH_SOURCE field"
+
+test_start "incomplete_sweep_is_a_hard_error"
+# A worker that dies before recording a status leaves the sweep short, and
+# `xargs … || true` hides it. The runner must refuse to report a
+# percentage computed from a fraction of the suite.
+mkdir -p "$SANDBOX/tests-partial/unit" "$SANDBOX/tests-partial/regression"
+printf '#!/usr/bin/env bash\necho "RESULTS:1:1:0"\n' \
+  >"$SANDBOX/tests-partial/unit/test_ok.sh"
+cat >"$SANDBOX/tests-partial/unit/test_kills_its_worker.sh" <<'EOF'
+#!/usr/bin/env bash
+# Kill the xargs worker two levels up (this shell <- timeout <- worker),
+# reproducing "xargs: bash: terminated with signal 15": the worker dies
+# before it can record a status, so this test leaves no result behind.
+worker="$(ps -o ppid= -p "$PPID" 2>/dev/null | tr -d ' ')"
+[[ -n "$worker" ]] && kill -TERM "$worker" 2>/dev/null
+sleep 5
+EOF
+set +e
+env REPO_ROOT="$SANDBOX" \
+  TESTS_DIR="$SANDBOX/tests-partial" \
+  COVERAGE_DIR="$SANDBOX/coverage5" \
+  COVERAGE_OUT="$SANDBOX/coverage5/lcov.info" \
+  COV_INCLUDE_DIRS="$SANDBOX/src" \
+  MIN_COVERAGE_PCT=0 \
+  COV_TEST_TIMEOUT=30 \
+  JOBS=1 \
+  bash "$RUNNER" >"$SANDBOX/runner-partial.log" 2>&1
+partial_ec=$?
+rm -rf "$SANDBOX/tests-partial"
+if [[ "$partial_ec" -ne 0 ]] &&
+  grep -qE "tests-completed: [01]/2" "$SANDBOX/runner-partial.log" &&
+  grep -q "no result recorded for: unit/test_kills_its_worker.sh" "$SANDBOX/runner-partial.log"; then
+  ((TESTS_PASSED++)) || true
+  printf '%b\n' "  ${GREEN}✓${NC} $CURRENT_TEST"
+else
+  ((TESTS_FAILED++)) || true
+  printf '%b\n' "  ${RED}✗${NC} $CURRENT_TEST: expected a non-zero exit naming the test with no result (got $partial_ec)"
+  grep -E 'tests-completed|no result' "$SANDBOX/runner-partial.log" >&2 || true
+fi
+
 test_start "xtrace_uses_a_dedicated_descriptor"
 assert_file_contains "$RUNNER" "BASH_XTRACEFD=" \
   "xtrace must not be written to fd 2, where a test's redirection can eat it"

--- a/tools/ci/run-coverage.sh
+++ b/tools/ci/run-coverage.sh
@@ -343,6 +343,34 @@ elapsed=$(($(date +%s) - start_ts))
 echo "trace phase done in ${elapsed}s" >&2
 
 # -----------------------------------------------------------------------------
+# Completeness audit — did every discovered test actually run?
+#
+# `xargs … || true` swallows a worker that died before it could record a
+# status: `xargs: bash: terminated with signal 15` scrolls past, the sweep
+# stops early, and the aggregator happily prints a percentage computed
+# from a fraction of the suite. That is the same silent-wrong-number
+# failure as the timeout kill, arriving by a different door — a sweep
+# interrupted at 230 of 670 tests reported 47.28% and exited 0 — so the
+# count of status records is checked against the count of tests dispatched.
+# -----------------------------------------------------------------------------
+ran_count=$(find "$status_dir" -name '*.status' -type f | wc -l | tr -d ' ')
+echo "tests-completed: ${ran_count}/${#test_files[@]}" >&2
+cov_incomplete=0
+if [[ "$ran_count" -ne "${#test_files[@]}" ]]; then
+  cov_incomplete=1
+  echo "::error::only ${ran_count} of ${#test_files[@]} tests recorded a result — the sweep did not finish, so any percentage below is computed from a fraction of the suite" >&2
+  missing=0
+  for f in "${test_files[@]}"; do
+    rel="${f#"$TESTS_DIR"/}"
+    if [[ ! -e "$status_dir/${rel//\//__}.status" ]]; then
+      missing=$((missing + 1))
+      [[ "$missing" -le 10 ]] && echo "::error::no result recorded for: $rel" >&2
+    fi
+  done
+  [[ "$missing" -gt 10 ]] && echo "::error::… and $((missing - 10)) more" >&2
+fi
+
+# -----------------------------------------------------------------------------
 # Timeout audit — a killed test contributes no trace records, so it silently
 # removes its share of the numerator while leaving the denominator intact.
 # That made the reported percentage a function of machine load: two runs over
@@ -523,7 +551,11 @@ def is_skipped(abs_path: Path) -> bool:
 # Bash adds one xtrace prefix for each nested execution context. Count both
 # top-level `+@COV@` records and `++@COV@`/`+++@COV@` records emitted from
 # functions inside command substitutions and subshells.
-hit_re = re.compile(r"^\++@COV@:(\d+):([^:]+):@")
+# `[^:]*` (not `[^:]+`): a `bash -c` top level has no BASH_SOURCE[0], so
+# the field is legitimately empty. Those records name no file and are
+# skipped below — but they must still MATCH here, or the truncation audit
+# would mistake every one of them for a mangled record.
+hit_re = re.compile(r"^\++@COV@:(\d+):([^:]*):@")
 
 # A record that starts like ours but has lost its `:@ ` terminator was
 # truncated in flight — bash 3.2 cuts the expanded PS4 at 100 characters.
@@ -1147,6 +1179,11 @@ fi
 # Reported last so the coverage number is still visible above it: a killed
 # test or a mangled record invalidates the measurement even when the
 # surviving tests clear the floor.
+if [[ "$cov_incomplete" -eq 1 ]]; then
+  echo "::error::coverage measurement is invalid — the sweep ran ${ran_count} of ${#test_files[@]} tests" >&2
+  exit 5
+fi
+
 if [[ "$cov_timeout_failure" -eq 1 ]]; then
   echo "::error::coverage measurement is invalid — ${#killed_tests[@]} test(s) killed by COV_TEST_TIMEOUT" >&2
   exit 3

--- a/tools/ci/run-coverage.sh
+++ b/tools/ci/run-coverage.sh
@@ -295,8 +295,8 @@ def is_skipped(abs_path: Path) -> bool:
 # functions inside command substitutions and subshells.
 hit_re = re.compile(r"^\++@COV@:(\d+):([^:]+):@")
 
-# files[abs_path][line] = total hits
-files = defaultdict(lambda: defaultdict(int))
+# raw_hits[abs_path][line] = total trace records seen for that physical line
+raw_hits = defaultdict(lambda: defaultdict(int))
 source_cache = {}
 
 def in_includes(path: Path) -> bool:
@@ -346,137 +346,485 @@ for trace_path in sorted(trace_dir.glob("*.trace")):
                 source_path = normalized_source(src)
                 if source_path is None:
                     continue
-                files[source_path][lineno] += 1
+                raw_hits[source_path][lineno] += 1
     except OSError as e:
         print(f"warn: read error {trace_path}: {e}", file=sys.stderr)
 
-# Sweep through include-dirs and add executable lines for files we never
-# touched, so lcov coverage % reflects total source surface, not just
-# touched files.
-ws_re = re.compile(r"^\s*$")
-comment_re = re.compile(r"^\s*#")
-shebang_re = re.compile(r"^\s*#!")
+# -----------------------------------------------------------------------------
+# Source analysis — which physical lines can bash xtrace ever report, and
+# which physical line does it report a multi-line statement on?
+#
+# `set -x` does NOT emit a record for every line that runs. Several
+# constructs execute perfectly well and never produce a `+@COV@:` record at
+# their own line number, so counting them as "executable" put permanently
+# unhittable lines in the denominator and capped per-file coverage well
+# below 100%. Every exclusion below was established by running a fixture
+# under this runner's own PS4 + `set -x` and observing that no record
+# appears for the line; the fixtures live in
+# tests/unit/ci/test_run_coverage_aggregator.sh and are asserted on every
+# run so this classifier cannot silently drift.
+#
+# Observed (bash 5.3, and the same on 5.2):
+#
+#   1. Function-definition headers. `greet() {`, `greet()` + `{` on the
+#      next line, and `function greet {` all emit nothing; only the body
+#      is traced. A one-line definition (`f() { echo hi; }`) IS traced,
+#      because the body is on that line — so it stays in the denominator.
+#
+#   2. `case` pattern labels. `a | x)`, `"hello world")`, `'')` and `*)`
+#      emit nothing even when the arm matches; the arm's body is what
+#      gets traced. The old `case_pattern` regex only recognised bare
+#      `foo)`, so every label with alternation, quoting or a space was
+#      still counted. A label with its body on the same line
+#      (`x) echo x ;;`) IS traced and stays.
+#
+#   3. Interior lines of a multi-line *word*: an unterminated `$( )`,
+#      `<( )`, `>( )`, backtick, `name=( )` array assignment, `$(( ))`,
+#      or an unterminated quoted string. Nothing inside is ever reported
+#      at its own line; bash attributes the whole statement to ONE
+#      physical line of the construct — sometimes the first, sometimes
+#      the last:
+#
+#        a=$(          -> record lands on the closing `)` line
+#          echo A
+#        )
+#        echo "$(      -> record lands on the `echo` line
+#          echo B
+#        )"
+#
+#      Guessing which end would risk dropping a genuinely covered line,
+#      so instead the statement is *folded*: the first physical line is
+#      the single denominator entry, and a record on any later physical
+#      line of the same statement counts as a hit on it (`alias` below).
+#      That is exact — one logical statement, one denominator slot, hit
+#      iff bash traced it anywhere — and needs no guess.
+#
+#   4. Backslash-continuation lines that carry only more words of the
+#      same command (`printf '%s' \` / `"one" \` / `"two"`): only the
+#      first line is traced. But a continuation that STARTS a new
+#      command is traced at its own line (`true && \` / `  echo x`, or
+#      `cmd \` / `  || echo fallback`), so those are kept. The
+#      discriminator is an operator at the head of the continuation or
+#      at the tail of the line before it.
+#
+#   5. Compound terminators carrying only a redirection: `done <"$f"`,
+#      `fi >/dev/null`, `} >/dev/null` emit nothing — the redirection is
+#      set up by the compound command, which was already traced at its
+#      head. `done | cat` IS traced (the pipeline's next element runs
+#      there) and `done < <(cmd)` IS traced (the process substitution's
+#      body runs there), so both stay.
+#
+# Deliberately NOT excluded — see the report in #883 for the evidence:
+#   * `(` / `)` of a bare subshell group and `{` / `}` of a brace group:
+#     already dropped by the structural rule, and the statements INSIDE
+#     such a group are traced at their own lines, so they stay.
+#   * Lines that are merely untested (an `if` branch never taken, a
+#     function never called). Those are the thing coverage is for.
+#   * `x) ;;` — a case label with an empty body on the same line emits
+#     nothing, but the shape is indistinguishable from `x) cmd ;;`
+#     without a real parser. Left in the denominator; it understates.
+# -----------------------------------------------------------------------------
+heredoc_re = re.compile(
+    r"""<<(-?)\s*(?:"([^"]*)"|'([^']*)'|\\?([A-Za-z_][A-Za-z0-9_.\-]*))"""
+)
+excl_line_re = re.compile(r"#\s*LCOV_EXCL_LINE")
+excl_start_re = re.compile(r"#\s*LCOV_EXCL_START")
+excl_stop_re = re.compile(r"#\s*LCOV_EXCL_STOP")
+# Scripts that explicitly turn off xtrace can't be measured by this
+# mechanism — the bash runtime simply stops emitting trace records.
+# Treat everything after `set +x` / `set +o xtrace` as excluded so it
+# doesn't sink the denominator.
+xtrace_off_re = re.compile(r"^\s*set\s+(\+x|\+o\s+xtrace)\b")
+structural_re = re.compile(
+    r"^\s*("
+    r"fi|done|else|elif|esac|then|do|in|"
+    r"\}|\{|\(|"
+    r"\)\s*;?;?\s*$|"  # bare `)` (subshell / case-pattern close)
+    r";;&?\s*$|"       # `;;` / `;;&` case-clause terminators
+    r";&\s*$"          # `;&` fallthrough terminator
+    r")\s*(#.*)?$"
+)
+func_hdr_re = re.compile(
+    r"^\s*(function\s+)?[A-Za-z_][A-Za-z0-9_:.+\-]*\s*\(\s*\)\s*(\{\s*)?(#.*)?$"
+)
+func_hdr_kw_re = re.compile(
+    r"^\s*function\s+[A-Za-z_][A-Za-z0-9_:.+\-]*\s*(\{\s*)?(#.*)?$"
+)
+case_open_re = re.compile(r"^\s*case\b")
+esac_re = re.compile(r"^\s*esac\b")
+terminator_redir_re = re.compile(
+    r"^\s*(done|fi|esac|\}|\))\s+(?P<rest>[0-9]*[<>].*)$"
+)
+cont_op_head_re = re.compile(r"^\s*(\|\||&&|\||;;?|&)")
+cont_op_tail_re = re.compile(
+    r"(\|\||&&|\||;|&|\(|\{|!|\bthen\b|\bdo\b|\belse\b)\s*$"
+)
+WORDISH = ("word", "arith", "btick")
 
-def executable_lines(path: Path):
-    """Lines that bash xtrace can plausibly emit.
+def scan_line(line, st):
+    """Advance the shell lexer state across one physical line.
 
-    Excludes:
-      - blanks / shebangs / comments (already)
-      - structural-only keywords (`fi`, `done`, `else`, `esac`, `then`,
-        `do`, `in`, bare `{`/`}` braces) — these are syntax, not
-        commands; xtrace never traces them
-      - heredoc body lines (between `<<EOF` and `EOF`) — content, not
-        executed
-      - `case` pattern labels (`foo)`) — the matched body executes,
-        not the pattern itself
-
-    This matches what `bash -x` actually produces a `+`-prefixed
-    line for, so the denominator reflects measurable lines.
-
-    Honor LCOV_EXCL_LINE / LCOV_EXCL_START / LCOV_EXCL_STOP markers
-    so authors can exempt genuinely unreachable lines (platform-
-    gated branches, root-only paths, dead-code stubs).
+    `st` carries `quote` (None / `'` / `"`) and `stack` (open word-level
+    or command-level groupings) across lines, which is what tells us
+    whether the next physical line continues this statement.
     """
-    import re as _re
-    structural = _re.compile(
-        r"^\s*("
-        r"fi|done|else|elif|esac|then|do|in|"
-        r"\}|\{|"
-        r"\)\s*;?;?\s*$|"        # bare `)` (case pattern close)
-        r";;\s*$"                # `;;` case-clause terminator
-        r")\s*(#.*)?$"
-    )
-    case_pattern = _re.compile(r"^\s*[a-zA-Z0-9_\*\?\[\|/\-\.+]+\)\s*(#.*)?$")
-    heredoc_open = _re.compile(r"<<-?\s*[\"\']?([A-Za-z_][A-Za-z0-9_]*)[\"\']?")
-    excl_line = _re.compile(r"#\s*LCOV_EXCL_LINE")
-    excl_start = _re.compile(r"#\s*LCOV_EXCL_START")
-    excl_stop = _re.compile(r"#\s*LCOV_EXCL_STOP")
-    # Scripts that explicitly turn off xtrace can't be measured by
-    # this mechanism — the bash runtime simply stops emitting trace
-    # records. Treat everything after `set +x` / `set +o xtrace`
-    # as excluded so it doesn't sink the denominator.
-    xtrace_off = _re.compile(r"^\s*set\s+(\+x|\+o\s+xtrace)\b")
+    quote = st["quote"]
+    stack = st["stack"]
+    heredocs = []
+    has_subst = False
+    unmatched_close = 0
+    ends_with_backslash = False
 
+    i = 0
+    n = len(line)
+    while i < n:
+        c = line[i]
+
+        if quote == "'":
+            if c == "'":
+                quote = None
+            i += 1
+            continue
+
+        if c == "\\":
+            # A trailing backslash continues the line everywhere except
+            # inside single quotes (handled above).
+            if i + 1 >= n:
+                ends_with_backslash = True
+                i += 1
+            else:
+                i += 2
+            continue
+
+        if quote == '"':
+            # `$(`, `$((` and backticks re-open command context inside a
+            # double-quoted word; remember the quote so it is restored
+            # when the substitution closes.
+            if c == '"':
+                quote = None
+                i += 1
+                continue
+            if c == "$" and i + 1 < n and line[i + 1] == "(":
+                if i + 2 < n and line[i + 2] == "(":
+                    stack.append(("arith", quote))
+                    i += 3
+                else:
+                    stack.append(("word", quote))
+                    has_subst = True
+                    i += 2
+                quote = None
+                continue
+            if c == "`":
+                stack.append(("btick", quote))
+                has_subst = True
+                quote = None
+                i += 1
+                continue
+            i += 1
+            continue
+
+        # Unquoted.
+        if c == "#" and (i == 0 or line[i - 1] in " \t;&|("):
+            break  # comment runs to end of line
+
+        if c == "'":
+            quote = "'"
+            i += 1
+            continue
+        if c == '"':
+            quote = '"'
+            i += 1
+            continue
+        if c == "`":
+            if stack and stack[-1][0] == "btick":
+                quote = stack.pop()[1]
+            else:
+                stack.append(("btick", None))
+                has_subst = True
+            i += 1
+            continue
+
+        if c == "$" and i + 1 < n and line[i + 1] == "(":
+            if i + 2 < n and line[i + 2] == "(":
+                stack.append(("arith", None))
+                i += 3
+            else:
+                stack.append(("word", None))
+                has_subst = True
+                i += 2
+            continue
+
+        if c in "<>" and i + 1 < n and line[i + 1] == "(":
+            stack.append(("word", None))  # process substitution
+            has_subst = True
+            i += 2
+            continue
+
+        if c == "=" and i + 1 < n and line[i + 1] == "(":
+            stack.append(("word", None))  # `name=(` / `name+=(` array
+            i += 2
+            continue
+
+        if c == "(":
+            if i + 1 < n and line[i + 1] == "(":
+                stack.append(("arith", None))
+                i += 2
+            else:
+                stack.append(("cmd", None))  # subshell group
+                i += 1
+            continue
+
+        if c == ")":
+            if stack:
+                kind, saved = stack.pop()
+                if kind == "arith" and i + 1 < n and line[i + 1] == ")":
+                    i += 1
+                quote = saved
+            else:
+                unmatched_close += 1
+            i += 1
+            continue
+
+        # `<<<` is a here-string, not a here-document: consume it whole so
+        # its word is never mistaken for a here-doc terminator.
+        if c == "<" and line[i + 1:i + 3] == "<<":
+            i += 3
+            continue
+
+        # `<<` opens a here-document, but `1 << 2` inside `$(( ))` is a
+        # left shift — the arith guard keeps the two apart.
+        if (
+            c == "<"
+            and i + 1 < n
+            and line[i + 1] == "<"
+            and not any(k == "arith" for k, _ in stack)
+        ):
+            m = heredoc_re.match(line, i)
+            if m:
+                heredocs.append((m.group(2) or m.group(3) or m.group(4),
+                                 m.group(1) == "-"))
+                i = m.end()
+                continue
+            i += 2
+            continue
+
+        i += 1
+
+    st["quote"] = quote
+    return {
+        "heredocs": heredocs,
+        "has_subst": has_subst,
+        "unmatched_close": unmatched_close,
+        "ends_with_backslash": ends_with_backslash and quote != "'",
+    }
+
+def strip_comment(line):
+    """Drop a trailing unquoted `#` comment."""
+    quote = None
+    for i, c in enumerate(line):
+        if quote:
+            if c == quote:
+                quote = None
+            continue
+        if c in "\"'":
+            quote = c
+        elif c == "#" and (i == 0 or line[i - 1] in " \t;&|("):
+            return line[:i]
+    return line
+
+def is_case_label(line):
+    """True for a `case` pattern label with no command on the line.
+
+    Quote-aware: the line must close exactly one paren it never opened
+    and end there, which covers `*)`, `a | x)`, `"hello world")`, `'')`
+    and the `(a|b)` form, while rejecting `x) echo x ;;` (traced) and
+    ordinary code containing balanced parens.
+    """
+    body = strip_comment(line).rstrip()
+    if not body.endswith(")"):
+        return False
+    probe = body.strip()
+    if probe.startswith("("):
+        probe = probe[1:]
+    st = {"quote": None, "stack": []}
+    info = scan_line(probe, st)
+    if st["quote"] or st["stack"]:
+        return False
+    return info["unmatched_close"] == 1
+
+def classify(line, is_start, cont_reason, prev_code, logical_has_subst,
+             case_depth, excluding, xtrace_disabled):
+    """Return "exec" (denominator entry), "alias" (fold onto the
+    statement's first line) or "skip" (not measurable at all)."""
+    if excluding or excl_start_re.search(line) or excl_stop_re.search(line):
+        return "skip"
+    if excl_line_re.search(line):
+        return "skip"
+    if xtrace_disabled:
+        return "skip"
+
+    if not is_start:
+        if cont_reason == "quote":
+            return "alias"
+        # Backslash continuation: traced only when it begins a new
+        # command, which an operator at either join point signals.
+        if cont_op_head_re.match(line):
+            return "exec"
+        tail = strip_comment(prev_code).rstrip()
+        if tail.endswith("\\"):
+            tail = tail[:-1].rstrip()
+        if cont_op_tail_re.search(tail):
+            return "exec"
+        return "alias"
+
+    if not line or not line.strip():
+        return "skip"
+    if line.lstrip().startswith("#"):
+        return "skip"
+    if xtrace_off_re.match(line):
+        return "skip"
+    if structural_re.match(line):
+        return "skip"
+    if func_hdr_re.match(line) or func_hdr_kw_re.match(line):
+        return "skip"
+    if case_depth > 0 and is_case_label(line):
+        return "skip"
+    m = terminator_redir_re.match(strip_comment(line))
+    if m and not logical_has_subst and not re.search(r"(\|\||&&|\||;)",
+                                                     m.group("rest")):
+        return "skip"
+    return "exec"
+
+analysis_cache = {}
+
+def analyze(path):
+    """Return (executable_lines, alias) for one shell file.
+
+    `executable_lines` is the set of physical lines that belong in the
+    lcov denominator. `alias` maps every other physical line of a
+    multi-line statement (and here-doc bodies) onto that statement's
+    denominator line, so a trace record landing on a later physical line
+    still counts as a hit for the statement.
+    """
+    key = str(path)
+    if key in analysis_cache:
+        return analysis_cache[key]
     try:
-        with open(path, "r", errors="replace") as f:
+        with open(key, "r", errors="replace") as f:
             text = f.read().splitlines()
     except OSError:
-        return []
+        analysis_cache[key] = (set(), {})
+        return analysis_cache[key]
 
-    out = []
-    in_heredoc = None  # the terminator we're waiting for
+    exec_lines = set()
+    alias = {}
+    st = {"quote": None, "stack": []}
+    heredoc_queue = []
+    in_heredoc = None
+    stmt_start = 1
+    cont_reason = None
+    prev_code = ""
+    logical_has_subst = False
+    case_depth = 0
     excluding = False
     xtrace_disabled = False
-    for i, line in enumerate(text, 1):
-        # LCOV_EXCL handling
-        if excl_start.search(line):
-            excluding = True
-            continue
-        if excl_stop.search(line):
-            excluding = False
-            continue
-        if excluding:
-            continue
-        if excl_line.search(line):
-            continue
 
-        # Once a script disables xtrace, no further lines can be
-        # measured by this mechanism — drop them from the denominator.
-        if xtrace_disabled:
-            continue
-        if xtrace_off.match(line):
-            xtrace_disabled = True
-            continue
+    for i, line in enumerate(text):
+        lineno = i + 1
 
-        # Heredoc body — track and skip
         if in_heredoc is not None:
-            if line.strip() == in_heredoc:
-                in_heredoc = None
+            # Here-doc bodies are data, not commands. Fold them onto the
+            # statement that opened them so a stray record can't invent
+            # a denominator entry.
+            alias[lineno] = stmt_start
+            term, strip_tabs = in_heredoc
+            probe = line.lstrip("\t") if strip_tabs else line
+            if probe.strip() == term:
+                in_heredoc = heredoc_queue.pop(0) if heredoc_queue else None
             continue
-        hd = heredoc_open.search(line)
-        if hd and not comment_re.match(line):
-            in_heredoc = hd.group(1)
 
-        if not line or ws_re.match(line):
-            continue
-        if shebang_re.match(line):
-            continue
-        if comment_re.match(line):
-            continue
-        if structural.match(line):
-            continue
-        if case_pattern.match(line):
-            continue
-        out.append(i)
-    return out
+        is_start = cont_reason is None
+        if is_start:
+            stmt_start = lineno
+            logical_has_subst = False
 
+        info = scan_line(line, st)
+        logical_has_subst = logical_has_subst or info["has_subst"]
+
+        verdict = classify(line, is_start, cont_reason, prev_code,
+                           logical_has_subst, case_depth, excluding,
+                           xtrace_disabled)
+
+        if excl_start_re.search(line):
+            excluding = True
+        elif excl_stop_re.search(line):
+            excluding = False
+        if is_start and xtrace_off_re.match(line):
+            xtrace_disabled = True
+
+        if is_start and not excluding:
+            if case_open_re.match(line):
+                case_depth += 1
+            elif esac_re.match(line):
+                case_depth = max(0, case_depth - 1)
+
+        if verdict == "exec":
+            exec_lines.add(lineno)
+            stmt_start = lineno
+        elif verdict == "alias":
+            alias[lineno] = stmt_start
+
+        if info["heredocs"]:
+            heredoc_queue.extend(info["heredocs"])
+
+        if st["quote"] or any(k in WORDISH for k, _ in st["stack"]):
+            cont_reason = "quote"
+        elif info["ends_with_backslash"]:
+            cont_reason = "backslash"
+        else:
+            cont_reason = None
+
+        if heredoc_queue:
+            in_heredoc = heredoc_queue.pop(0)
+
+        prev_code = line
+
+    analysis_cache[key] = (exec_lines, alias)
+    return analysis_cache[key]
+
+# Sweep through include-dirs so the lcov percentage reflects the total
+# source surface, not just the files a test happened to touch.
+candidates = set(raw_hits)
 for inc in include_dirs:
     if not inc.exists():
         continue
     for path in inc.rglob("*.sh"):
+        if not is_skipped(path):
+            candidates.add(str(path.resolve()))
+    for path in inc.rglob("*"):
+        # also include shebanged shell scripts without an extension
+        if not path.is_file() or path.suffix or path.stat().st_size == 0:
+            continue
         if is_skipped(path):
             continue
-        ap = str(path.resolve())
-        existing = files[ap]  # creates the entry on touch
-        for ln in executable_lines(path):
-            if ln not in existing:
-                existing[ln] = 0
-    for path in inc.rglob("*"):
-        # also include shebanged shell scripts without .sh
-        if path.is_file() and not path.suffix and path.stat().st_size > 0:
-            if is_skipped(path):
-                continue
-            try:
-                with open(path, "r", errors="replace") as f:
-                    first = f.readline()
-            except OSError:
-                continue
-            if first.startswith("#!") and ("bash" in first or "sh" in first):
-                ap = str(path.resolve())
-                existing = files[ap]
-                for ln in executable_lines(path):
-                    if ln not in existing:
-                        existing[ln] = 0
+        try:
+            with open(path, "r", errors="replace") as f:
+                first = f.readline()
+        except OSError:
+            continue
+        if first.startswith("#!") and ("bash" in first or "sh" in first):
+            candidates.add(str(path.resolve()))
+
+# files[abs_path][line] = hits, restricted to the measurable denominator.
+files = {}
+for ap in candidates:
+    exec_lines, alias = analyze(ap)
+    counts = dict.fromkeys(exec_lines, 0)
+    for lineno, n_hits in raw_hits.get(ap, {}).items():
+        target = alias.get(lineno, lineno)
+        if target in counts:
+            counts[target] += n_hits
+    files[ap] = counts
 
 # Emit lcov.info
 with open(out_path, "w") as out:

--- a/tools/ci/run-coverage.sh
+++ b/tools/ci/run-coverage.sh
@@ -21,9 +21,11 @@
 #   Then we parse all traces with regex and write lcov.info. This is
 #   the same mechanism bashcov uses, minus the Ruby runtime.
 #
-# Linux + macOS both work (macOS bash 3.2 supports BASH_XTRACEFD as
-# well — verified locally on bash 5.3 via Homebrew). The pre-commit
-# hook in this repo can invoke this on any platform.
+# Linux + macOS both work. macOS is the awkward one: /bin/bash is 3.2,
+# which truncates the expanded PS4 at 100 characters, so the record
+# format below stays short on purpose and the startup probe refuses to
+# run if a reachable bash mangles records anyway. The pre-commit hook in
+# this repo can invoke this on any platform.
 #
 # Closes the runner half of #856 / Slice 1 of #883.
 # =============================================================================
@@ -135,20 +137,69 @@ rm -rf "$status_dir"
 mkdir -p "$status_dir"
 
 # -----------------------------------------------------------------------------
+# The trace record format.
+#
+# Two properties matter and neither is negotiable:
+#
+#   1. `${BASH_SOURCE[0]:+…}` (not `${BASH_SOURCE}`) keeps PS4 evaluation
+#      from failing under `set -u`: at the top level of a `bash -c`
+#      script BASH_SOURCE[0] is unbound, and an unguarded expansion
+#      aborts the shell, taking out any test that sources a
+#      `set -euo pipefail` library file. The `:+` form neither errors on
+#      an unset variable nor expands its body when unset, so it survives
+#      `set -u` while still allowing the prefix strip below.
+#
+#   2. The path is emitted RELATIVE to the repo root. bash 3.2 — still
+#      /bin/bash on macOS, and reachable from any test whose PATH farm
+#      resolves `bash` there — truncates the expanded PS4 at 100
+#      characters. A checkout path long enough to push the `:@`
+#      terminator past that limit mangles every record from such a
+#      child, and the aggregator drops them: measured coverage would
+#      depend on how deep the checkout happens to sit. A repo-relative
+#      path keeps the prefix around 45 characters whatever the checkout
+#      path. `COV_ROOT` is exported for the strip; if a sandbox scrubs
+#      it the pattern cannot match and the record falls back to the
+#      absolute path (still correct, just long), which the truncation
+#      audit after aggregation then catches.
+# -----------------------------------------------------------------------------
+export COV_ROOT="$REPO_ROOT"
+COV_PS4='+@COV@:${LINENO}:${BASH_SOURCE[0]:+${BASH_SOURCE[0]#${COV_ROOT:-__cov_unset__}/}}:@ '
+
 # BASH_ENV setup file: enables xtrace in every non-interactive bash that
 # inherits it. Child processes spawned via `bash $SCRIPT` get their own
 # tracing turned on automatically.
-# -----------------------------------------------------------------------------
 bash_env="$COVERAGE_DIR/_cov_bashenv.sh"
-cat >"$bash_env" <<'SETUP'
-# coverage runtime — enable xtrace, define PS4 with file+line markers.
-# `${BASH_SOURCE:-}` (not `${BASH_SOURCE}`) prevents PS4 evaluation
-# from failing under `set -u`: at the top level of a `bash -c`
-# script, BASH_SOURCE[0] is unbound; an unguarded expansion under
-# `set -u` aborts the shell, taking out any test that sources a
-# `set -euo pipefail` library file.
+: >"$bash_env"
+printf "PS4='%s'\n" "$COV_PS4" >>"$bash_env"
+cat >>"$bash_env" <<'SETUP'
+# Route xtrace to a descriptor of our own instead of stderr.
+#
+# This is the difference between measuring a child and losing it. A test
+# that captures or discards a child's stderr — `out=$(cmd 2>&1)`,
+# `cmd 2>/dev/null`, `cmd &>/dev/null`, `cmd |& …` — takes that child's
+# xtrace records with it, because they are written to fd 2. The child
+# runs, does its work, and contributes nothing: one such line in one test
+# file was measuring scripts/dot/commands/registry.sh at 58% when it was
+# really at 75%. The runner cannot police what a test redirects, but it
+# can put the records somewhere a redirection cannot reach.
+#
+# BASH_XTRACEFD is bash 4.1+. Older shells (macOS /bin/bash 3.2) fall
+# through and keep writing to stderr, which the worker redirects to the
+# same file — the pre-existing behaviour, no worse. The `exec` sits
+# inside `eval` because bash 3.2 cannot even *parse* `{var}>`, and
+# BASH_ENV files are parsed whole before anything runs.
+if [ -n "${COV_TRACE_FILE:-}" ] && [ -z "${BASH_XTRACEFD:-}" ]; then
+  case "${BASH_VERSION:-}" in
+    1.* | 2.* | 3.* | 4.0*) : ;;
+    *)
+      if eval 'exec {__cov_xfd}>>"$COV_TRACE_FILE"' 2>/dev/null; then
+        BASH_XTRACEFD=$__cov_xfd
+      fi
+      ;;
+  esac
+fi
+# Enabled last so the plumbing above does not trace itself.
 set -x
-PS4='+@COV@:${LINENO}:${BASH_SOURCE:-}:@ '
 SETUP
 
 # Sanity-probe: run one trivial script through the pipeline so a
@@ -163,15 +214,37 @@ echo "probe-sum=$((x + y))"
 PROBE
 chmod +x "$probe_target"
 
-PS4='+@COV@:${LINENO}:${BASH_SOURCE}:@ ' \
-  BASH_ENV="$bash_env" \
-  bash "$probe_target" 2>"$trace_dir/_probe.trace" >/dev/null || true
-probe_lines=$(grep -cE "^\+@COV@:[0-9]+:.*${probe_target}:@" "$trace_dir/_probe.trace" 2>/dev/null || echo 0)
-echo "probe: ${probe_lines} traced lines from ${probe_target}" >&2
-if [[ "$probe_lines" -eq 0 ]]; then
-  echo "::error::xtrace probe captured no lines — coverage mechanism broken" >&2
-  exit 2
+# Probe every bash a test could plausibly reach: the one on PATH, and
+# /bin/bash when it is a different binary (macOS ships 3.2 there). A
+# record is only usable if it survives *intact*, terminator included —
+# hence the `:@` in the pattern.
+probe_bashes=("bash")
+if [[ -x /bin/bash ]] && [[ "$(command -v bash)" != "/bin/bash" ]]; then
+  probe_bashes+=("/bin/bash")
 fi
+for probe_bash in "${probe_bashes[@]}"; do
+  probe_trace="$trace_dir/_probe.trace"
+  : >"$probe_trace"
+  PS4="$COV_PS4" \
+    BASH_ENV="$bash_env" \
+    COV_TRACE_FILE="$probe_trace" \
+    "$probe_bash" "$probe_target" 2>"$probe_trace" >/dev/null </dev/null || true
+  probe_lines=$(grep -cE '^\+@COV@:[0-9]+:[^:]*:@' "$probe_trace" 2>/dev/null) || probe_lines=0
+  probe_all=$(grep -cE '^\++@COV@:[0-9]+:' "$probe_trace" 2>/dev/null) || probe_all=0
+  probe_bad=$((probe_all - probe_lines))
+  probe_version=$("$probe_bash" -c 'echo "${BASH_VERSION%%(*}"' 2>/dev/null || echo "?")
+  echo "probe: ${probe_bash} (bash ${probe_version}) — ${probe_lines} intact record(s), ${probe_bad} mangled" >&2
+  if [[ "$probe_lines" -eq 0 ]]; then
+    echo "::error::xtrace probe captured no usable records via ${probe_bash} — coverage mechanism broken" >&2
+    exit 2
+  fi
+  if [[ "$probe_bad" -gt 0 ]]; then
+    echo "::error::${probe_bash} (bash ${probe_version}) truncates the PS4 expansion, mangling trace records." >&2
+    echo "::error::REPO_ROOT is ${#REPO_ROOT} characters; records emitted through that bash lose their terminator and are dropped." >&2
+    echo "::error::Use a shorter checkout path, or put a bash >= 4.1 ahead of ${probe_bash} on PATH." >&2
+    exit 2
+  fi
+done
 
 # -----------------------------------------------------------------------------
 # Collect test files (mirror tests/framework/test_runner.sh discovery).
@@ -213,18 +286,31 @@ run_one() {
   relative="${f#"$COV_TESTS_DIR"/}"
   slug="${relative//\//__}"
   trace="$COV_TRACE_DIR/${slug}.trace"
+  : >"$trace"
   started=$(date +%s)
+  # `</dev/null` and `>/dev/null` on purpose: a test that backgrounds a
+  # grandchild leaves it holding whatever descriptors it inherited, and
+  # if those are the runner's own stdin/stdout pipes (they are, whenever
+  # a caller wraps this script in a command substitution) the sweep
+  # appears to hang long after every test has finished. Handing each test
+  # /dev/null for both ends makes an orphan unable to hold the pipeline
+  # open. The timeout wrapper — GNU `timeout`, `gtimeout`, or the perl
+  # fallback — signals the whole process group, so orphans are killed
+  # rather than merely detached; `--kill-after=5` finishes off anything
+  # that ignores SIGTERM.
   if [[ -n "${COV_TIMEOUT_CMD:-}" ]]; then
-    PS4='+@COV@:${LINENO}:${BASH_SOURCE}:@ ' \
+    PS4="$COV_PS4" \
       BASH_ENV="$COV_BASH_ENV" \
+      COV_TRACE_FILE="$trace" \
       "$COV_TIMEOUT_CMD" --kill-after=5 "$COV_TEST_TIMEOUT" \
-      bash "$f" 2>"$trace" >/dev/null
+      bash "$f" 2>"$trace" >/dev/null </dev/null
     status=$?
   else
     # No timeout available (stock macOS): run without the hang-guard.
-    PS4='+@COV@:${LINENO}:${BASH_SOURCE}:@ ' \
+    PS4="$COV_PS4" \
       BASH_ENV="$COV_BASH_ENV" \
-      bash "$f" 2>"$trace" >/dev/null
+      COV_TRACE_FILE="$trace" \
+      bash "$f" 2>"$trace" >/dev/null </dev/null
     status=$?
   fi
   ended=$(date +%s)
@@ -237,6 +323,7 @@ run_one() {
 
 export COV_TRACE_DIR="$trace_dir"
 export COV_STATUS_DIR="$status_dir"
+export COV_PS4
 export COV_BASH_ENV="$bash_env"
 export COV_TESTS_DIR="$TESTS_DIR"
 export COV_TEST_TIMEOUT
@@ -302,6 +389,39 @@ else
 fi
 
 # -----------------------------------------------------------------------------
+# Silent-trace audit — the other way a test contributes nothing without
+# saying so. A test that redirects its whole stderr away (`exec 2>…`, or a
+# wrapper that captures the suite itself) hands us an empty trace while
+# exiting cleanly: the tests ran, the coverage vanished. BASH_XTRACEFD
+# above stops that happening for *children* a test captures, but it cannot
+# help a shell too old for BASH_XTRACEFD or a test that redirects the
+# runner's own descriptor, so the result is checked rather than assumed.
+#
+# Warning, not error: a trace can legitimately be thin, and this is a
+# signal to go and look, not a verdict.
+# -----------------------------------------------------------------------------
+silent_tests=()
+for status_file in "$status_dir"/*.status; do
+  [[ -e "$status_file" ]] || continue
+  slug="$(basename "$status_file" .status)"
+  trace_file="$trace_dir/${slug}.trace"
+  rel="$(cut -f3 "$status_file")"
+  if [[ ! -s "$trace_file" ]] ||
+    ! grep -qE '^\++@COV@:[0-9]+:' "$trace_file" 2>/dev/null; then
+    silent_tests+=("${rel:-$slug}")
+  fi
+done
+if [[ "${#silent_tests[@]}" -gt 0 ]]; then
+  echo "::warning::${#silent_tests[@]} test(s) produced no xtrace records at all — their stderr is being redirected away and their coverage is lost" >&2
+  for s in "${silent_tests[@]}"; do
+    echo "::warning::no coverage captured from: $s" >&2
+  done
+  echo "silent-traces: ${#silent_tests[@]} test(s): ${silent_tests[*]}" >&2
+else
+  echo "silent-traces: 0 test(s)" >&2
+fi
+
+# -----------------------------------------------------------------------------
 # Aggregate trace files → lcov.info.
 # -----------------------------------------------------------------------------
 python3 - "$COVERAGE_OUT" "$trace_dir" "$REPO_ROOT" "$COV_INCLUDE_DIRS" <<'PY'
@@ -309,7 +429,7 @@ python3 - "$COVERAGE_OUT" "$trace_dir" "$REPO_ROOT" "$COV_INCLUDE_DIRS" <<'PY'
 import os
 import re
 import sys
-from collections import defaultdict
+from collections import Counter, defaultdict
 from pathlib import Path
 
 out_path, trace_dir, repo_root, include_dirs_spec = sys.argv[1:5]
@@ -405,6 +525,14 @@ def is_skipped(abs_path: Path) -> bool:
 # functions inside command substitutions and subshells.
 hit_re = re.compile(r"^\++@COV@:(\d+):([^:]+):@")
 
+# A record that starts like ours but has lost its `:@ ` terminator was
+# truncated in flight — bash 3.2 cuts the expanded PS4 at 100 characters.
+# Such a record is silently unusable, which is exactly the failure mode
+# this runner must never have, so they are counted and reported.
+record_head_re = re.compile(r"^\++@COV@:(\d+):(.*)$")
+truncated_records = Counter()
+truncated_by_trace = Counter()
+
 # raw_hits[abs_path][line] = total trace records seen for that physical line
 raw_hits = defaultdict(lambda: defaultdict(int))
 source_cache = {}
@@ -444,6 +572,10 @@ for trace_path in sorted(trace_dir.glob("*.trace")):
             for line in f:
                 m = hit_re.match(line)
                 if not m:
+                    head = record_head_re.match(line)
+                    if head:
+                        truncated_records[head.group(2)[:80]] += 1
+                        truncated_by_trace[trace_path.name] += 1
                     continue
                 lineno = int(m.group(1))
                 src = m.group(2).strip()
@@ -951,7 +1083,33 @@ covered = sum(1 for lines in files.values() for h in lines.values() if h > 0)
 pct = (covered * 100.0 / total_lines) if total_lines else 0.0
 print(f"Aggregated: {total_files} files, {covered}/{total_lines} lines = {pct:.2f}%",
       file=sys.stderr)
+
+# Truncation audit. A mangled record is a lost record, so say so. It is a
+# hard error only when the lost record could have been for a measured
+# file — i.e. its surviving prefix overlaps the repo root. Records for
+# paths outside the repo (a $TMPDIR sandbox script, say) never entered
+# the denominator, so they are reported without failing the run.
+if truncated_records:
+    n = sum(truncated_records.values())
+    root = str(repo_root)
+    fatal = any(root.startswith(p) or p.startswith(root)
+                for p in truncated_records)
+    level = "error" if fatal else "warning"
+    print(f"::{level}::{n} trace record(s) were truncated and could not be "
+          f"parsed — bash 3.2 cuts the expanded PS4 at 100 characters",
+          file=sys.stderr)
+    for name, count in truncated_by_trace.most_common(10):
+        print(f"::{level}::truncated records in {name}: {count}", file=sys.stderr)
+    for prefix, count in truncated_records.most_common(5):
+        print(f"  {count} record(s) truncated at: {prefix!r}", file=sys.stderr)
+    print(f"truncated-trace-records: {n} record(s) in "
+          f"{len(truncated_by_trace)} trace file(s)", file=sys.stderr)
+    if fatal:
+        sys.exit(4)
+else:
+    print("truncated-trace-records: 0", file=sys.stderr)
 PY
+aggregate_ec=$?
 
 if [[ ! -s "$COVERAGE_OUT" ]]; then
   echo "::error::failed to produce lcov.info — aggregator wrote empty file." >&2
@@ -987,11 +1145,16 @@ if [[ "$below" == "1" ]]; then
 fi
 
 # Reported last so the coverage number is still visible above it: a killed
-# test invalidates the measurement even when the surviving tests clear the
-# floor.
+# test or a mangled record invalidates the measurement even when the
+# surviving tests clear the floor.
 if [[ "$cov_timeout_failure" -eq 1 ]]; then
   echo "::error::coverage measurement is invalid — ${#killed_tests[@]} test(s) killed by COV_TEST_TIMEOUT" >&2
   exit 3
+fi
+
+if [[ "$aggregate_ec" -ne 0 ]]; then
+  echo "::error::coverage measurement is invalid — trace records for measured files were truncated (aggregator exit ${aggregate_ec})" >&2
+  exit "$aggregate_ec"
 fi
 
 exit 0

--- a/tools/ci/run-coverage.sh
+++ b/tools/ci/run-coverage.sh
@@ -37,7 +37,44 @@ COVERAGE_OUT="${COVERAGE_OUT:-$COVERAGE_DIR/lcov.info}"
 MIN_COVERAGE_PCT="${MIN_COVERAGE_PCT:-0}" # initial floor; tighten per slice
 COV_INCLUDE_DIRS="${COV_INCLUDE_DIRS:-$REPO_ROOT/scripts:$REPO_ROOT/lib:$REPO_ROOT/defaults/dot_local/bin:$REPO_ROOT/defaults/.chezmoitemplates/functions}"
 JOBS="${JOBS:-$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)}"
-COV_TEST_TIMEOUT="${COV_TEST_TIMEOUT:-60}"
+# Per-test wall-clock budget.
+#
+# This used to be 60s, which was *below* the real cost of the heavier
+# suites once they run under xtrace with the sweep's own parallelism
+# competing for CPU (test_auto_doctor.sh, test_auto_verify.sh,
+# test_version_sync_exec.sh and ~25 others). Those tests were SIGTERMed
+# mid-run and contributed nothing to the denominator's numerator, so the
+# reported percentage silently tracked machine load: the same tree
+# measured twice could differ by whole points and individual files could
+# appear to lose coverage between runs that never touched them.
+#
+# 300s is ~2x the slowest test measured over a full sweep at `JOBS=3` on
+# a contended 10-core laptop: regression/test_dot_help_flag_universal.sh
+# at 157s, unit/auto/test_auto_dot_driver.sh at 112s. The one test that
+# came closer, unit/theme/test_themes_toml.sh at 273s, is slow only on a
+# developer machine — it runs `magick identify` over the user's real
+# ~/Pictures/Wallpapers library, which does not exist on a CI runner.
+# It is still a real hang-guard — a genuinely blocked test dies in five
+# minutes rather than stalling the sweep — but it no longer truncates
+# tests that are merely slow.
+#
+# Regardless of the value, a kill is now a HARD ERROR (see the
+# post-sweep audit below): a silent kill that moves the number is the
+# one outcome this runner must never produce again.
+COV_TEST_TIMEOUT="${COV_TEST_TIMEOUT:-300}"
+
+# Tests deliberately not traced, as paths relative to $TESTS_DIR,
+# colon-separated. This is an EXPLICIT list, printed on every run — the
+# opposite of the silent timeout kill it replaces.
+#
+#   regression/test_test_framework_invariants.sh is a meta-suite: it runs
+#   every OTHER regression suite serially, each with its own 180s inner
+#   budget, so its wall-clock cost is the sum of the entire regression
+#   tier and no per-test budget can accommodate it. Every suite it invokes
+#   is already traced directly by this sweep: re-aggregating a full sweep
+#   with and without its trace gives the identical 7700/10977 lines, so
+#   excluding it removes a duplicate, not coverage.
+COV_SKIP_TESTS="${COV_SKIP_TESTS:-regression/test_test_framework_invariants.sh}"
 
 # GNU `timeout` guards against a hung test stalling the sweep, but it does
 # not exist on stock macOS (it's coreutils). Prefer `timeout`, then
@@ -93,6 +130,9 @@ mkdir -p "$COVERAGE_DIR"
 trace_dir="$COVERAGE_DIR/traces"
 rm -rf "$trace_dir"
 mkdir -p "$trace_dir"
+status_dir="$COVERAGE_DIR/status"
+rm -rf "$status_dir"
+mkdir -p "$status_dir"
 
 # -----------------------------------------------------------------------------
 # BASH_ENV setup file: enables xtrace in every non-interactive bash that
@@ -139,13 +179,26 @@ fi
 # Portable read — `mapfile` is bash 4 only and this runner documents
 # macOS support, where /bin/bash is 3.2.
 test_files=()
+skipped_tests=()
 while IFS= read -r _line; do
-  [[ -n "$_line" ]] && test_files+=("$_line")
+  [[ -n "$_line" ]] || continue
+  _rel="${_line#"$TESTS_DIR"/}"
+  case ":$COV_SKIP_TESTS:" in
+    *":$_rel:"*)
+      skipped_tests+=("$_rel")
+      continue
+      ;;
+  esac
+  test_files+=("$_line")
 done < <(find "$TESTS_DIR/unit" "$TESTS_DIR/regression" -name 'test_*.sh' -type f | sort)
 
 if [[ "${#test_files[@]}" -eq 0 ]]; then
   echo "::error::no unit or regression test files discovered under $TESTS_DIR" >&2
   exit 1
+fi
+
+if [[ "${#skipped_tests[@]}" -gt 0 ]]; then
+  echo "skipped-by-policy: ${#skipped_tests[@]} test(s): ${skipped_tests[*]}" >&2
 fi
 
 echo "Tracing ${#test_files[@]} test files (parallel × $JOBS, timeout ${COV_TEST_TIMEOUT}s/test)..." >&2
@@ -156,23 +209,34 @@ echo "Tracing ${#test_files[@]} test files (parallel × $JOBS, timeout ${COV_TES
 # shellcheck disable=SC2317,SC2329  # called indirectly via xargs subshell
 run_one() {
   local f="$1"
-  local relative trace
+  local relative trace slug status started ended
   relative="${f#"$COV_TESTS_DIR"/}"
-  trace="$COV_TRACE_DIR/${relative//\//__}.trace"
+  slug="${relative//\//__}"
+  trace="$COV_TRACE_DIR/${slug}.trace"
+  started=$(date +%s)
   if [[ -n "${COV_TIMEOUT_CMD:-}" ]]; then
     PS4='+@COV@:${LINENO}:${BASH_SOURCE}:@ ' \
       BASH_ENV="$COV_BASH_ENV" \
       "$COV_TIMEOUT_CMD" --kill-after=5 "$COV_TEST_TIMEOUT" \
-      bash "$f" 2>"$trace" >/dev/null || true
+      bash "$f" 2>"$trace" >/dev/null
+    status=$?
   else
     # No timeout available (stock macOS): run without the hang-guard.
     PS4='+@COV@:${LINENO}:${BASH_SOURCE}:@ ' \
       BASH_ENV="$COV_BASH_ENV" \
-      bash "$f" 2>"$trace" >/dev/null || true
+      bash "$f" 2>"$trace" >/dev/null
+    status=$?
   fi
+  ended=$(date +%s)
+  # One record per test: exit status, wall-clock seconds, relative path.
+  # The post-sweep audit turns timeout kills into a hard error and
+  # reports the slowest tests so the budget stays defensible.
+  printf '%s\t%s\t%s\n' "$status" "$((ended - started))" "$relative" \
+    >"$COV_STATUS_DIR/${slug}.status"
 }
 
 export COV_TRACE_DIR="$trace_dir"
+export COV_STATUS_DIR="$status_dir"
 export COV_BASH_ENV="$bash_env"
 export COV_TESTS_DIR="$TESTS_DIR"
 export COV_TEST_TIMEOUT
@@ -190,6 +254,52 @@ printf '%s\n' "${test_files[@]}" |
   true
 elapsed=$(($(date +%s) - start_ts))
 echo "trace phase done in ${elapsed}s" >&2
+
+# -----------------------------------------------------------------------------
+# Timeout audit — a killed test contributes no trace records, so it silently
+# removes its share of the numerator while leaving the denominator intact.
+# That made the reported percentage a function of machine load: two runs over
+# an identical tree could disagree by whole points, and individual files could
+# appear to lose coverage between runs that never touched them.
+#
+# Kills are therefore a HARD ERROR. lcov.info is still written (the artifact
+# and the per-file detail stay useful for debugging) but the runner exits
+# non-zero and names every killed file, so the number is never quietly wrong.
+#
+# `timeout` reports 124 when it had to signal the child, and 137 when the
+# child had to be SIGKILLed after --kill-after; the perl fallback reports
+# 124. Requiring the observed duration to have reached the budget as well
+# keeps a test that genuinely exits 124 from being misreported as a kill.
+# -----------------------------------------------------------------------------
+killed_tests=()
+slowest_report=""
+if [[ -d "$status_dir" ]]; then
+  while IFS=$'\t' read -r st dur rel; do
+    [[ -n "${rel:-}" ]] || continue
+    if [[ "$st" == "124" || "$st" == "137" ]] && [[ "$dur" -ge "$COV_TEST_TIMEOUT" ]]; then
+      killed_tests+=("$rel (${dur}s, exit $st)")
+    fi
+  done < <(cat "$status_dir"/*.status 2>/dev/null)
+  slowest_report=$(sort -t$'\t' -k2,2nr "$status_dir"/*.status 2>/dev/null |
+    head -5 | awk -F'\t' '{printf "  %5ss  %s\n", $2, $3}')
+fi
+
+if [[ -n "$slowest_report" ]]; then
+  echo "slowest tests (budget ${COV_TEST_TIMEOUT}s):" >&2
+  printf '%s\n' "$slowest_report" >&2
+fi
+
+cov_timeout_failure=0
+if [[ "${#killed_tests[@]}" -gt 0 ]]; then
+  cov_timeout_failure=1
+  echo "::error::${#killed_tests[@]} test(s) exceeded COV_TEST_TIMEOUT=${COV_TEST_TIMEOUT}s and were killed; coverage is understated and non-deterministic" >&2
+  for k in "${killed_tests[@]}"; do
+    echo "::error::killed by coverage timeout: $k" >&2
+  done
+  echo "killed-by-timeout: ${#killed_tests[@]} test(s): ${killed_tests[*]}" >&2
+else
+  echo "killed-by-timeout: 0 test(s)" >&2
+fi
 
 # -----------------------------------------------------------------------------
 # Aggregate trace files → lcov.info.
@@ -874,6 +984,14 @@ below=$(awk -v p="$pct" -v t="$MIN_COVERAGE_PCT" 'BEGIN{print (p+0 < t+0) ? "1" 
 if [[ "$below" == "1" ]]; then
   echo "::error::coverage ${pct}% is below the floor ${MIN_COVERAGE_PCT}%" >&2
   exit 1
+fi
+
+# Reported last so the coverage number is still visible above it: a killed
+# test invalidates the measurement even when the surviving tests clear the
+# floor.
+if [[ "$cov_timeout_failure" -eq 1 ]]; then
+  echo "::error::coverage measurement is invalid — ${#killed_tests[@]} test(s) killed by COV_TEST_TIMEOUT" >&2
+  exit 3
 fi
 
 exit 0

--- a/tools/ci/run-coverage.sh
+++ b/tools/ci/run-coverage.sh
@@ -730,6 +730,10 @@ terminator_redir_re = re.compile(
     r"^\s*(done|fi|esac|\}|\))\s+(?P<rest>[0-9]*[<>].*)$"
 )
 cont_op_head_re = re.compile(r"^\s*(\|\||&&|\||;;?|&)")
+# A backslash-continued command whose continuation begins with `&&` or
+# `||` is attributed to the OPERATOR line, not its own, on bash 5.2 —
+# and to its own line on 5.3. See the note in classify().
+cont_andor_re = re.compile(r"^\s*(&&|\|\|)")
 cont_op_tail_re = re.compile(
     r"(\|\||&&|\||;|&|\(|\{|!|\bthen\b|\bdo\b|\belse\b)\s*$"
 )
@@ -1028,6 +1032,51 @@ def analyze(path):
         verdict = classify(line, is_start, cont_reason, prev_code,
                            logical_has_subst, case_depth, excluding,
                            xtrace_disabled)
+
+        # Which bash you run decides where the head of a backslash-joined
+        # `&&`/`||` list is reported, so neither answer can be trusted:
+        #
+        #     true \\
+        #       && echo hi
+        #
+        # bash 5.3 traces `true` at its own line; bash 5.2 — every current
+        # Linux runner — traces it at the `&&` line, which then carries two
+        # records and leaves the head permanently unhittable. Dropping the
+        # head makes the denominator identical on both, at the cost of one
+        # covered line on 5.3. The operator line keeps its own entry, so a
+        # short-circuited right-hand side is still reported as missed.
+        #
+        # Narrow on purpose: only the STATEMENT-START head, and only for
+        # `&&`/`||`. An intermediate `&& cmd \\` in a longer chain is traced
+        # on both (observed), as are `|`, `;` and a trailing-operator join
+        # (`true && \\`), so all of those keep their line.
+        if (
+            verdict == "exec"
+            and is_start
+            and info["ends_with_backslash"]
+            and not st["quote"]
+            and not any(k in WORDISH for k, _ in st["stack"])
+            and lineno < len(text)
+            and cont_andor_re.match(text[lineno])
+        ):
+            verdict = "skip"
+
+        # `done < <(` whose process substitution spans lines is another
+        # version-dependent attribution. bash 5.x runs the substitution's
+        # body at the closing paren, which folds onto this line; bash 3.2
+        # attributes it to the `while`/`for` header instead, leaving the
+        # whole `done < <( … )` region with no record at all. Excluded, so
+        # the denominator agrees across versions.
+        #
+        # The single-line `done < <(cmd)` IS traced on both (observed), so
+        # the classify() rule keeps it — only the spanning form is dropped.
+        if (
+            verdict == "exec"
+            and is_start
+            and (st["quote"] or any(k in WORDISH for k, _ in st["stack"]))
+            and terminator_redir_re.match(strip_comment(line))
+        ):
+            verdict = "skip"
 
         if excl_start_re.search(line):
             excluding = True


### PR DESCRIPTION
The bash coverage runner was reporting a number that was wrong in five separate ways. No test is added or changed here; this only makes the measurement tell the truth.

Measured on the same trace set, so the split is exact:

| Stage | Coverage |
|---|---|
| Before | 59.36% (7526/12679) |
| Timeout fix only | 61.16% (7755/12679) |
| Denominator fix added | 70.15% (7700/10977) |

## The five defects

1. **Untraceable lines counted as uncovered.** bash emits no xtrace record for a function-definition header, for a `case` label with nothing after the `)`, for the interior of a multi-line word (`$( )`, embedded jq/awk programs, multi-line printf), for plain backslash continuations, or for a compound terminator carrying only a redirection. Those lines sat in the denominator and could never be hit. 2154 lines were excluded, verified construct by construct against what bash actually emits rather than assumed.

2. **Tests killed by the 60s timeout were dropped silently**, taking their coverage with them and making the result depend on machine load. The budget is now 300s, kills are a hard error naming each file, and the one suite no budget can fit is explicitly skipped rather than silently killed.

3. **Trace records were lost to stderr redirection.** 540 of 706 test files redirect a child's stderr on a script-invocation line, discarding that child's coverage. Fixed at the runner via a dedicated trace descriptor, with no test files edited.

4. **PS4 truncation under bash 3.2** cut records at 100 characters, so measured coverage depended on the length of the checkout path. Records now carry a short repo-relative path, and the runner refuses to start if a probe record comes back mangled.

5. **A sweep that stopped early still printed a percentage and exited 0.** One run reported 47.28% after completing 230 of 670 tests. The runner now reports completion counts and exits non-zero.

## Verification

`tests/unit/ci/test_run_coverage_aggregator.sh` drives seven fixtures through the real runner, one per construct, each written so that every statement executes. It asserts both the exact executable-line set and that every fixture reaches 100%. 13 of its first 17 assertions fail against the previous aggregator.

Three real constructs were re-run by hand under the runner's own PS4 to confirm the exclusions describe reality. Of the 2154 newly excluded lines, 53% are multi-line statement interiors, 32% function headers, 13% case labels.

The CI floor rises from 58% to 68%. 70.15% is a lower bound: the record-loss fixes landed after that measurement and can only recover more.

**Not claimed:** this does not reach the 98% target. 167 of 185 files remain below it, which is a genuine test gap and separate work.

Signed-off-by: Sebastien Rousseau <sebastian.rousseau@gmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GkTMSRzg9EVUd11XZ9bbHC

---

THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co
