### PR TITLE
test: raise bash coverage on agent, mcp-doctor, perf and shell functions

### DIFF
--- a/defaults/dot_local/bin/executable_lorem
+++ b/defaults/dot_local/bin/executable_lorem
@@ -45,6 +45,10 @@ random_word() {
 generate_sentence() {
   local word_count=$((RANDOM % 10 + 5))
   local sentence=""
+  # `i` and `word` must be local: the callers loop on `i` too, and leaking it
+  # here ended their loop after a single iteration (`lorem s 5` printed one
+  # sentence, `lorem p 3` one paragraph).
+  local i word
   for ((i = 0; i < word_count; i++)); do
     if [[ $i -eq 0 ]]; then
       word=$(random_word)
@@ -59,6 +63,7 @@ generate_sentence() {
 generate_paragraph() {
   local sentence_count=$((RANDOM % 4 + 3))
   local paragraph=""
+  local i
   for ((i = 0; i < sentence_count; i++)); do
     if [[ $i -eq 0 ]]; then
       paragraph=$(generate_sentence)
@@ -93,7 +98,9 @@ case "$TYPE" in
   p | paragraph | paragraphs)
     for ((i = 0; i < COUNT; i++)); do
       generate_paragraph
-      [[ $i -lt $((COUNT - 1)) ]] && echo
+      # `|| true`: on the last iteration the test is false, and as the final
+      # command of the script that made `lorem` (and `lorem p N`) exit 1.
+      [[ $i -lt $((COUNT - 1)) ]] && echo || true
     done
     ;;
   -h | --help)

--- a/scripts/diagnostics/mcp-doctor.sh
+++ b/scripts/diagnostics/mcp-doctor.sh
@@ -398,7 +398,7 @@ if command -v jq >/dev/null 2>&1; then
       {
         jq -r '.mcpServers | to_entries[]? | (.value.env // {}) | to_entries[]?.value' "$MCP_CONFIG"
         jq -r '.mcpServers | to_entries[]? | (.value.args // [])[]?' "$MCP_CONFIG"
-      } | sed -n 's/^\${\([A-Z0-9_]\+\)}$/\1/p' | sort -u
+      } | sed -n 's/^\${\([A-Z0-9_][A-Z0-9_]*\)}$/\1/p' | sort -u
     )"
     if [[ -z "$env_vars" ]]; then
       log_success "Server env placeholders" "none declared"

--- a/scripts/dot/commands/agent.sh
+++ b/scripts/dot/commands/agent.sh
@@ -228,15 +228,16 @@ EOF
       checkpoint_id="$(basename "$checkpoint_file" .json)"
       ui_info "Agent mode" "$name"
       dot_agent_session_log "run_start" "$name" "running" "argv=$*" "checkpoint_id=$checkpoint_id"
-      # `if !` instead of `set +e / "$@" / set -e` — bash's errexit
-      # is automatically suspended inside a conditional, so we capture
-      # the exit code cleanly without toggling shell options.
+      # Run inside the `if` condition (errexit is suspended there) and
+      # read `$?` in the else-branch: it holds the command's own status.
+      # `if ! cmd; then exit_code=$?` reads the negation's status (0) and
+      # silently reported every failure as exit 0.
       local exit_code=0
-      if ! "$@"; then
+      if "$@"; then
+        dot_agent_session_log "run_finish" "$name" "ok" "exit_code=$exit_code" "checkpoint_id=$checkpoint_id"
+      else
         exit_code=$?
         dot_agent_session_log "run_finish" "$name" "failed" "exit_code=$exit_code" "checkpoint_id=$checkpoint_id"
-      else
-        dot_agent_session_log "run_finish" "$name" "ok" "exit_code=$exit_code" "checkpoint_id=$checkpoint_id"
       fi
       return "$exit_code"
       ;;
@@ -347,11 +348,11 @@ EOF
           _agent_apply_profile_env "$replay_profile"
           dot_agent_session_log "checkpoint_replay" "$replay_profile" "running" "checkpoint_id=$checkpoint_id"
           local exit_code=0
-          if ! "${replay_argv[@]}"; then
+          if "${replay_argv[@]}"; then
+            dot_agent_session_log "checkpoint_replay_finish" "$replay_profile" "ok" "checkpoint_id=$checkpoint_id" "exit_code=$exit_code"
+          else
             exit_code=$?
             dot_agent_session_log "checkpoint_replay_finish" "$replay_profile" "failed" "checkpoint_id=$checkpoint_id" "exit_code=$exit_code"
-          else
-            dot_agent_session_log "checkpoint_replay_finish" "$replay_profile" "ok" "checkpoint_id=$checkpoint_id" "exit_code=$exit_code"
           fi
           return "$exit_code"
           ;;
@@ -392,13 +393,13 @@ EOF
       dot_agent_session_log "delegate_start" "$delegate_profile" "running" "delegate=$delegate_name" "parent=$current_profile" "timeout=$delegate_timeout"
       ui_info "Delegating" "$delegate_name (profile: $delegate_profile, timeout: ${delegate_timeout}s)"
       local exit_code=0
-      if ! timeout "$delegate_timeout" "$@"; then
+      if timeout "$delegate_timeout" "$@"; then
+        dot_agent_session_log "delegate_finish" "$delegate_profile" "ok" "delegate=$delegate_name" "exit_code=$exit_code"
+        ui_ok "Delegate" "$delegate_name completed"
+      else
         exit_code=$?
         dot_agent_session_log "delegate_finish" "$delegate_profile" "failed" "delegate=$delegate_name" "exit_code=$exit_code"
         ui_err "Delegate" "$delegate_name failed (exit $exit_code)"
-      else
-        dot_agent_session_log "delegate_finish" "$delegate_profile" "ok" "delegate=$delegate_name" "exit_code=$exit_code"
-        ui_ok "Delegate" "$delegate_name completed"
       fi
       return "$exit_code"
       ;;

--- a/scripts/ops/chezmoi-update.sh
+++ b/scripts/ops/chezmoi-update.sh
@@ -45,7 +45,11 @@ NOTICE_FILE="$STATE_DIR/notice"
 
 run_update() {
   echo "Updating dotfiles..."
-  chezmoi update "${args[@]}"
+  # `${args[@]+...}`: with DOTFILES_INTERACTIVE_APPLY=1 no flags are added,
+  # and bash 3.2 (the system bash on macOS) treats an unguarded empty array
+  # expansion under `set -u` as an unbound variable — `dot update` then died
+  # instead of running chezmoi.
+  chezmoi update ${args[@]+"${args[@]}"}
 }
 
 if $ASYNC; then

--- a/tests/unit/diagnostics/test_drift_dashboard_report.sh
+++ b/tests/unit/diagnostics/test_drift_dashboard_report.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2015-2026 Sebastien Rousseau
+# shellcheck disable=SC1090,SC1091,SC2034
+# Behavioural coverage for scripts/diagnostics/drift-dashboard.sh — all four
+# drift classes (managed, untracked source, orphan deployed, stale source),
+# both output modes and the exit contract.
+#
+# `chezmoi` and `git` are replaced by PATH-shadowing stubs written into the
+# sandbox, so every class can be produced on demand without touching the
+# host's chezmoi state.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+source "$SCRIPT_DIR/../../framework/assertions.sh"
+source "$SCRIPT_DIR/../../framework/coverage_helpers.sh"
+
+DRIFT="$REPO_ROOT/scripts/diagnostics/drift-dashboard.sh"
+
+trap cov_teardown_sandbox EXIT
+cov_setup_sandbox
+
+BIN="$DOTFILES_COV_TMPDIR/bin"
+OUTF="$DOTFILES_COV_TMPDIR/drift-out.txt"
+SRC="$DOTFILES_COV_TMPDIR/src"
+mkdir -p "$SRC/.git"
+
+# Stub chezmoi: each subcommand's answer comes from a file we rewrite per
+# test, so one stub covers every drift shape.
+cat >"$BIN/chezmoi" <<'STUB'
+#!/usr/bin/env bash
+case "${1:-}" in
+  status)      cat "$DRIFT_FIX/status" 2>/dev/null ;;
+  source-path)
+    if [[ -n "${2:-}" ]]; then
+      cat "$DRIFT_FIX/source-path" 2>/dev/null
+    else
+      cat "$DRIFT_FIX/src-dir" 2>/dev/null
+    fi
+    ;;
+  managed)     cat "$DRIFT_FIX/managed" 2>/dev/null ;;
+  diff)        echo "stub chezmoi diff $*" ;;
+  *)           : ;;
+esac
+exit 0
+STUB
+chmod +x "$BIN/chezmoi"
+
+export DRIFT_FIX="$DOTFILES_COV_TMPDIR/fix"
+mkdir -p "$DRIFT_FIX"
+: >"$DRIFT_FIX/status"
+: >"$DRIFT_FIX/managed"
+: >"$DRIFT_FIX/source-path"
+printf '%s\n' "$SRC" >"$DRIFT_FIX/src-dir"
+
+# Stub git so `git -C <src> ls-files --others` reports what we choose.
+cat >"$BIN/git" <<'STUB'
+#!/usr/bin/env bash
+for a in "$@"; do
+  if [[ "$a" == "ls-files" ]]; then
+    cat "$DRIFT_FIX/untracked" 2>/dev/null
+    exit 0
+  fi
+done
+exit 0
+STUB
+chmod +x "$BIN/git"
+: >"$DRIFT_FIX/untracked"
+
+ORPHANS="$XDG_STATE_HOME/dotfiles/orphans"
+mkdir -p "$(dirname "$ORPHANS")"
+
+drift() {
+  bash "$DRIFT" "$@" >"$OUTF" </dev/null
+  RC=$?
+  return 0
+}
+out_has() { assert_file_contains "$OUTF" "$1" "${2:-output contains $1}"; }
+
+test_start "script_exists_and_parses"
+assert_file_exists "$DRIFT" "drift-dashboard.sh must exist"
+assert_true "bash -n '$DRIFT'" "valid bash syntax"
+
+test_start "help_exits_before_any_probing"
+drift --help
+assert_equals 0 "$RC" "rc"
+out_has "Usage: drift-dashboard.sh" "usage"
+out_has "--json" "documents json mode"
+
+test_start "clean_tree_reports_no_drift_and_exits_0"
+drift
+assert_equals 0 "$RC" "rc"
+out_has "Dotfiles Drift Dashboard" "header"
+out_has "Managed drift" "class 1"
+out_has "Untracked source" "class 2"
+out_has "Orphan deployed" "class 3"
+out_has "Stale source" "class 4"
+out_has "no drift detected" "verdict"
+
+test_start "clean_tree_json_is_all_zeroes"
+drift --json
+assert_equals 0 "$RC" "rc"
+assert_equals "0" "$(jq -r .total <"$OUTF")" "total"
+assert_equals "0" "$(jq -r .managed_drift <"$OUTF")" "managed"
+assert_equals "0" "$(jq -r .stale_source <"$OUTF")" "stale"
+
+test_start "managed_drift_is_counted_and_listed"
+printf 'MM .zshrc\nMM .gitconfig\n' >"$DRIFT_FIX/status"
+drift
+assert_equals 1 "$RC" "any drift exits 1"
+out_has "2 file(s)" "count"
+out_has ".zshrc" "status echoed"
+out_has "Total drift signals" "summary"
+
+test_start "managed_drift_is_counted_in_json"
+drift -j
+assert_equals 1 "$RC" "rc"
+assert_equals "2" "$(jq -r .managed_drift <"$OUTF")" "managed count"
+assert_equals "2" "$(jq -r .total <"$OUTF")" "total"
+
+test_start "diff_flag_appends_the_chezmoi_diff"
+drift --diff
+assert_equals 1 "$RC" "rc"
+out_has "chezmoi diff (excluding" "section"
+out_has "stub chezmoi diff" "diff output included"
+
+test_start "diff_can_be_requested_by_environment"
+DOTFILES_DRIFT_SHOW_DIFF=1 drift
+assert_equals 1 "$RC" "rc"
+out_has "stub chezmoi diff" "env var honoured"
+
+test_start "untracked_source_files_are_counted"
+: >"$DRIFT_FIX/status"
+printf 'notes.md\nwip.sh\n' >"$DRIFT_FIX/untracked"
+drift
+assert_equals 1 "$RC" "rc"
+out_has "2 file(s) in chezmoi source not tracked by git" "warning"
+out_has "wip.sh" "file listed"
+
+test_start "orphan_file_is_counted"
+: >"$DRIFT_FIX/untracked"
+printf '%s\n' ".config/gone.conf" >"$ORPHANS"
+drift
+assert_equals 1 "$RC" "rc"
+out_has "1 file(s) — review" "orphan warning"
+
+test_start "stale_source_is_detected_by_mtime"
+rm -f "$ORPHANS"
+printf 'deployed.conf\n' >"$DRIFT_FIX/managed"
+SRC_FILE="$SRC/deployed.conf"
+printf 'source\n' >"$SRC_FILE"
+printf '%s\n' "$SRC_FILE" >"$DRIFT_FIX/source-path"
+printf 'deployed\n' >"$HOME/deployed.conf"
+touch -t 202001010000 "$SRC_FILE"
+drift
+assert_equals 1 "$RC" "rc"
+out_has "1 target(s) newer than source" "stale warning"
+out_has "deployed.conf" "path listed"
+
+test_start "stale_source_is_counted_in_json"
+drift --json
+assert_equals 1 "$RC" "rc"
+assert_equals "1" "$(jq -r .stale_source <"$OUTF")" "stale count"
+
+test_start "an_up_to_date_source_is_not_stale"
+touch "$SRC_FILE"
+drift
+assert_equals 0 "$RC" "rc"
+out_has "Stale source" "row"
+out_has "no drift detected" "clean"
+
+test_start "missing_chezmoi_is_a_prerequisite_failure"
+NOCM="$DOTFILES_COV_TMPDIR/nocm"
+mkdir -p "$NOCM"
+ln -sf "$(command -v bash)" "$NOCM/bash"
+for c in jq python3 wc tr git sed grep cat head date printf uname dirname basename tty locale; do
+  p="$(command -v "$c" 2>/dev/null)" && ln -sf "$p" "$NOCM/$c"
+done
+PATH="$NOCM" drift
+assert_equals 2 "$RC" "rc"
+out_has "chezmoi" "error names the missing tool"
+
+test_start "missing_chezmoi_reports_json_when_asked"
+PATH="$NOCM" drift --json
+assert_equals 2 "$RC" "rc"
+assert_equals "chezmoi not found" "$(jq -r .error <"$OUTF")" "json error"
+
+echo "RESULTS:$TESTS_RUN:$TESTS_PASSED:$TESTS_FAILED"

--- a/tests/unit/diagnostics/test_mcp_doctor_policy.sh
+++ b/tests/unit/diagnostics/test_mcp_doctor_policy.sh
@@ -1,0 +1,312 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2015-2026 Sebastien Rousseau
+# shellcheck disable=SC1090,SC1091,SC2034
+# Behavioural coverage for the *policy* half of
+# scripts/diagnostics/mcp-doctor.sh: config/policy/lock/registry discovery,
+# the SEP-1649 server card checks, the JSON summary and the strict-mode exit
+# contract. Every fixture is written inside the coverage sandbox and fed in
+# through the script's own env overrides (MCP_CONFIG, MCP_POLICY_CONFIG,
+# MCP_LOCK_CONFIG, MCP_REGISTRY_CONFIG, MCP_SERVER_CARD, REPO_ROOT), so no
+# host state is read or written.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+source "$SCRIPT_DIR/../../framework/assertions.sh"
+source "$SCRIPT_DIR/../../framework/coverage_helpers.sh"
+
+DOCTOR="$REPO_ROOT/scripts/diagnostics/mcp-doctor.sh"
+
+trap cov_teardown_sandbox EXIT
+cov_setup_sandbox
+
+FIX="$DOTFILES_COV_TMPDIR/fixtures"
+mkdir -p "$FIX"
+OUTF="$DOTFILES_COV_TMPDIR/doctor-out.txt"
+
+# doctor <env-assignments…> [-- <script-args…>] — run mcp-doctor under the
+# given environment, writing its report to $OUTF and its status to RC.
+doctor() {
+  local -a envs=() args=()
+  while (($#)); do
+    if [[ "$1" == "--" ]]; then
+      shift
+      args=("$@")
+      break
+    fi
+    envs+=("$1")
+    shift
+  done
+  # The report is kept in a FILE, never in a shell variable: a captured
+  # multi-line report becomes a kilobyte-long xtrace record, and long
+  # records get truncated in the coverage trace, silently dropping the
+  # coverage of the lines that produced them. stderr is deliberately left
+  # attached to ours so the child's xtrace still reaches the trace file.
+  env "${envs[@]}" bash "$DOCTOR" ${args[@]+"${args[@]}"} >"$OUTF" </dev/null
+  RC=$?
+  return 0
+}
+
+# out_has <needle> [msg] / out_lacks <needle> [msg] — assert on the report.
+out_has() { assert_file_contains "$OUTF" "$1" "${2:-output contains $1}"; }
+out_lacks() {
+  if grep -qF -- "$1" "$OUTF"; then
+    ((TESTS_FAILED++)) || true
+    printf '%b\n' "  ${RED}✗${NC} $CURRENT_TEST: ${2:-output should not contain $1}"
+  else
+    ((TESTS_PASSED++)) || true
+    printf '%b\n' "  ${GREEN}✓${NC} $CURRENT_TEST: ${2:-output lacks $1}"
+  fi
+}
+# out_json <jq-filter> — read one field out of a --json run.
+out_json() { jq -r "$1" <"$OUTF"; }
+
+MINIMAL_CFG="$FIX/minimal.json"
+cat >"$MINIMAL_CFG" <<'JSON'
+{"mcpServers":{"filesystem":{"command":"npx","args":["-y","@modelcontextprotocol/server-filesystem@1.0.0","/tmp/project"]}}}
+JSON
+
+LAX_POLICY="$FIX/lax-policy.json"
+cat >"$LAX_POLICY" <<'JSON'
+{
+  "defaultProfile": "lax",
+  "profiles": {
+    "lax": {
+      "allowedLaunchers": ["npx", "node", "uvx"],
+      "blockedFilesystemRoots": ["/", "/home", "/Users"],
+      "blockedArgPatterns": ["^--allow-.*", "^--unsafe$"],
+      "forbidNetworkServersByDefault": [],
+      "requiredEnvByServer": {},
+      "trustedTransports": ["stdio"],
+      "warnOnUnpinnedNpx": false,
+      "requireApprovedPackageLock": false,
+      "requireRegistryEntry": false,
+      "requireHttpsForHttpTransports": false,
+      "requireOauthForHttpTransports": false
+    }
+  }
+}
+JSON
+
+test_start "script_exists_and_parses"
+assert_file_exists "$DOCTOR" "mcp-doctor.sh must exist"
+assert_true "bash -n '$DOCTOR'" "valid bash syntax"
+
+# ── config discovery ────────────────────────────────────────────────────
+test_start "healthy_config_passes_with_rc0"
+doctor "MCP_CONFIG=$MINIMAL_CFG" "MCP_POLICY_CONFIG=$LAX_POLICY" \
+  "MCP_LOCK_CONFIG=$FIX/none.json" "MCP_REGISTRY_CONFIG=$FIX/none.json" \
+  "MCP_SERVER_CARD=$FIX/none.json"
+assert_equals 0 "$RC" "rc"
+out_has "MCP Doctor" "header"
+out_has "JSON syntax" "validation section"
+out_has "1 configured" "server count"
+
+test_start "missing_config_is_an_error_and_exits_1"
+# HOME without a .dotfiles tree, so the fallback candidate loop finds nothing.
+mkdir -p "$FIX/emptyhome"
+doctor "HOME=$FIX/emptyhome" "MCP_CONFIG=$FIX/absent.json" "MCP_POLICY_CONFIG=$LAX_POLICY" \
+  "MCP_LOCK_CONFIG=$FIX/none.json" "MCP_REGISTRY_CONFIG=$FIX/none.json" \
+  "MCP_SERVER_CARD=$FIX/none.json"
+assert_equals 1 "$RC" "rc"
+out_has "not found (expected" "config error"
+out_has "MCP issues found" "summary"
+
+test_start "invalid_config_json_is_an_error"
+printf '{oops' >"$FIX/bad.json"
+doctor "MCP_CONFIG=$FIX/bad.json" "MCP_POLICY_CONFIG=$LAX_POLICY" \
+  "MCP_LOCK_CONFIG=$FIX/none.json" "MCP_REGISTRY_CONFIG=$FIX/none.json" \
+  "MCP_SERVER_CARD=$FIX/none.json"
+assert_equals 1 "$RC" "rc"
+out_has "JSON syntax" "syntax row"
+out_has "invalid" "invalid"
+
+test_start "empty_server_map_is_an_error"
+printf '{"mcpServers":{}}' >"$FIX/empty.json"
+doctor "MCP_CONFIG=$FIX/empty.json" "MCP_POLICY_CONFIG=$LAX_POLICY" \
+  "MCP_LOCK_CONFIG=$FIX/none.json" "MCP_REGISTRY_CONFIG=$FIX/none.json" \
+  "MCP_SERVER_CARD=$FIX/none.json"
+assert_equals 1 "$RC" "rc"
+out_has "none configured" "server count error"
+
+test_start "config_falls_back_to_the_dotfiles_copy"
+# With no MCP_CONFIG and no ~/.config/claude copy, the loop over the
+# ~/.dotfiles candidates picks the repo's tracked config.
+rm -f "$HOME/.config/claude/mcp_servers.json"
+doctor "MCP_POLICY_CONFIG=$LAX_POLICY" "MCP_LOCK_CONFIG=$FIX/none.json" \
+  "MCP_REGISTRY_CONFIG=$FIX/none.json" "MCP_SERVER_CARD=$FIX/none.json" \
+  "HOME=$HOME"
+out_has "MCP config" "config row rendered"
+
+# ── policy / supply-chain presence ──────────────────────────────────────
+test_start "missing_policy_config_warns"
+doctor "MCP_CONFIG=$MINIMAL_CFG" "MCP_POLICY_CONFIG=$FIX/absent.json" \
+  "MCP_LOCK_CONFIG=$FIX/none.json" "MCP_REGISTRY_CONFIG=$FIX/none.json" \
+  "MCP_SERVER_CARD=$FIX/none.json"
+assert_equals 0 "$RC" "warnings alone do not fail"
+out_has "using built-in defaults" "warning"
+
+test_start "strict_mode_turns_warnings_into_failure"
+# Under --strict every log_warn also increments Errors, so the same run that
+# exits 0 with warnings exits 1 and reports them as errors.
+doctor "MCP_CONFIG=$MINIMAL_CFG" "MCP_POLICY_CONFIG=$FIX/absent.json" \
+  "MCP_LOCK_CONFIG=$FIX/none.json" "MCP_REGISTRY_CONFIG=$FIX/none.json" \
+  "MCP_SERVER_CARD=$FIX/none.json" -- --strict
+assert_equals 1 "$RC" "rc"
+out_has "MCP issues found" "strict summary"
+out_has "errors" "warnings promoted to errors"
+
+test_start "lock_and_registry_optional_when_policy_does_not_require_them"
+doctor "MCP_CONFIG=$MINIMAL_CFG" "MCP_POLICY_CONFIG=$LAX_POLICY" \
+  "MCP_LOCK_CONFIG=$FIX/absent.json" "MCP_REGISTRY_CONFIG=$FIX/absent.json" \
+  "MCP_SERVER_CARD=$FIX/none.json"
+out_has "Package lock" "lock row"
+out_has "not required" "optional"
+
+test_start "lock_and_registry_missing_warn_under_strict_local_policy"
+STRICT_POLICY="$FIX/strict-policy.json"
+jq '.profiles.lax.requireApprovedPackageLock = true
+    | .profiles.lax.requireRegistryEntry = true' "$LAX_POLICY" >"$STRICT_POLICY"
+doctor "MCP_CONFIG=$MINIMAL_CFG" "MCP_POLICY_CONFIG=$STRICT_POLICY" \
+  "MCP_LOCK_CONFIG=$FIX/absent.json" "MCP_REGISTRY_CONFIG=$FIX/absent.json" \
+  "MCP_SERVER_CARD=$FIX/none.json"
+out_has "strict-local expects a tracked lock file" "lock warning"
+out_has "strict-local expects a tracked registry file" "registry warning"
+
+test_start "present_lock_and_registry_are_reported"
+printf '{"packages":{}}' >"$FIX/lock.json"
+printf '{"servers":{}}' >"$FIX/registry.json"
+doctor "MCP_CONFIG=$MINIMAL_CFG" "MCP_POLICY_CONFIG=$LAX_POLICY" \
+  "MCP_LOCK_CONFIG=$FIX/lock.json" "MCP_REGISTRY_CONFIG=$FIX/registry.json" \
+  "MCP_SERVER_CARD=$FIX/none.json"
+out_has "lock.json" "lock path"
+out_has "registry.json" "registry path"
+
+# ── SEP-1649 server card ────────────────────────────────────────────────
+test_start "missing_server_card_warns"
+doctor "MCP_CONFIG=$MINIMAL_CFG" "MCP_POLICY_CONFIG=$LAX_POLICY" \
+  "MCP_LOCK_CONFIG=$FIX/none.json" "MCP_REGISTRY_CONFIG=$FIX/none.json" \
+  "MCP_SERVER_CARD=$FIX/absent.json"
+out_has "Server card" "card row"
+out_has "not found (expected" "warning"
+
+test_start "invalid_server_card_json_is_an_error"
+printf 'not json' >"$FIX/card-bad.json"
+doctor "MCP_CONFIG=$MINIMAL_CFG" "MCP_POLICY_CONFIG=$LAX_POLICY" \
+  "MCP_LOCK_CONFIG=$FIX/none.json" "MCP_REGISTRY_CONFIG=$FIX/none.json" \
+  "MCP_SERVER_CARD=$FIX/card-bad.json"
+assert_equals 1 "$RC" "rc"
+out_has "invalid JSON" "card error"
+
+test_start "complete_server_card_passes_every_field_check"
+cat >"$FIX/card-ok.json" <<'JSON'
+{"cardVersion":"1.0","name":"dotfiles","capabilities":{"tools":true},"transport":{"type":"stdio"}}
+JSON
+doctor "MCP_CONFIG=$MINIMAL_CFG" "MCP_POLICY_CONFIG=$LAX_POLICY" \
+  "MCP_LOCK_CONFIG=$FIX/none.json" "MCP_REGISTRY_CONFIG=$FIX/none.json" \
+  "MCP_SERVER_CARD=$FIX/card-ok.json"
+assert_equals 0 "$RC" "rc"
+out_has "Card version" "version row"
+out_has "Card capabilities" "capabilities row"
+out_has "Card transport" "transport row"
+
+test_start "empty_server_card_warns_on_every_field"
+printf '{}' >"$FIX/card-empty.json"
+doctor "MCP_CONFIG=$MINIMAL_CFG" "MCP_POLICY_CONFIG=$LAX_POLICY" \
+  "MCP_LOCK_CONFIG=$FIX/none.json" "MCP_REGISTRY_CONFIG=$FIX/none.json" \
+  "MCP_SERVER_CARD=$FIX/card-empty.json"
+out_has "missing cardVersion field" "version warning"
+out_has "missing name field" "name warning"
+out_has "missing capabilities block" "capabilities warning"
+out_has "missing transport block" "transport warning"
+
+# ── JSON summary ────────────────────────────────────────────────────────
+test_start "json_mode_emits_a_machine_readable_summary"
+doctor "MCP_CONFIG=$MINIMAL_CFG" "MCP_POLICY_CONFIG=$LAX_POLICY" \
+  "MCP_LOCK_CONFIG=$FIX/none.json" "MCP_REGISTRY_CONFIG=$FIX/none.json" \
+  "MCP_SERVER_CARD=$FIX/card-ok.json" -- --json
+assert_equals 0 "$RC" "rc"
+assert_equals "healthy" "$(out_json .status)" "status"
+assert_equals "1" "$(out_json .server_count)" "server_count"
+assert_equals "true" "$(out_json .checks.config_present)" "config_present"
+assert_equals "false" "$(out_json .strict)" "strict flag"
+assert_output_not_contains "MCP Doctor" "printf '%s' \"\$OUT\""
+
+test_start "json_mode_reports_warning_status"
+doctor "MCP_CONFIG=$MINIMAL_CFG" "MCP_POLICY_CONFIG=$FIX/absent.json" \
+  "MCP_LOCK_CONFIG=$FIX/none.json" "MCP_REGISTRY_CONFIG=$FIX/none.json" \
+  "MCP_SERVER_CARD=$FIX/none.json" -- -j
+assert_equals "warning" "$(out_json .status)" "status"
+assert_true "[[ \$(out_json .summary.warnings) -gt 0 ]]" "warnings counted"
+
+test_start "json_strict_mode_reports_failed_status_and_exit_1"
+doctor "MCP_CONFIG=$MINIMAL_CFG" "MCP_POLICY_CONFIG=$FIX/absent.json" \
+  "MCP_LOCK_CONFIG=$FIX/none.json" "MCP_REGISTRY_CONFIG=$FIX/none.json" \
+  "MCP_SERVER_CARD=$FIX/none.json" -- --json -s
+assert_equals 1 "$RC" "rc"
+assert_equals "failed" "$(out_json .status)" "status"
+assert_equals "true" "$(out_json .strict)" "strict flag"
+
+test_start "unknown_flags_are_ignored"
+doctor "MCP_CONFIG=$MINIMAL_CFG" "MCP_POLICY_CONFIG=$LAX_POLICY" \
+  "MCP_LOCK_CONFIG=$FIX/none.json" "MCP_REGISTRY_CONFIG=$FIX/none.json" \
+  "MCP_SERVER_CARD=$FIX/card-ok.json" -- --definitely-not-a-flag
+assert_equals 0 "$RC" "rc"
+out_has "MCP Doctor" "still ran"
+
+test_start "invalid_policy_json_falls_back_to_builtin_defaults"
+printf 'nope' >"$FIX/policy-bad.json"
+doctor "MCP_CONFIG=$MINIMAL_CFG" "MCP_POLICY_CONFIG=$FIX/policy-bad.json" \
+  "MCP_LOCK_CONFIG=$FIX/none.json" "MCP_REGISTRY_CONFIG=$FIX/none.json" \
+  "MCP_SERVER_CARD=$FIX/none.json"
+out_has "Launcher policy" "default allowlist still applied"
+
+# ── no jq ───────────────────────────────────────────────────────────────
+test_start "without_jq_only_the_grep_fallback_runs"
+NOJQ="$DOTFILES_COV_TMPDIR/nojq"
+mkdir -p "$NOJQ"
+IFS=: read -ra _dirs <<<"$PATH"
+_link_dirs() {
+  local _d
+  for _d in "$@"; do
+    [[ -d "$_d" ]] && ln -s "$_d"/* "$NOJQ"/ 2>/dev/null
+  done
+  return 0
+}
+# System dirs first: a PATH entry may hold a *directory* whose name shadows
+# a real command (PowerShell ships a `tr` locale dir). The prune pass then
+# drops any link that did not resolve to a file.
+# Building the farm expands to `ln -s` calls with ~900 arguments each. Under
+# the coverage runner every one of those is an xtrace record tens of KB long,
+# and records that big come back truncated — corrupting the trace around
+# them. Turn tracing off for the farm only, then back on.
+_xtrace_was_on=0
+case "$-" in *x*) _xtrace_was_on=1 ;; esac
+set +x
+_link_dirs /usr/bin /bin /usr/sbin /sbin
+_link_dirs "${_dirs[@]}"
+for _l in "$NOJQ"/*; do [[ -f "$_l" ]] || rm -f "$_l"; done
+_link_dirs /usr/bin /bin /usr/sbin /sbin
+rm -f "$NOJQ/jq"
+# Keep the *current* bash: on macOS the farm would otherwise resolve `bash`
+# to /bin/bash 3.2, whose xtrace truncates the PS4 expansion at 100 chars —
+# every coverage record from the child would be malformed and dropped.
+ln -sf "$(command -v bash)" "$NOJQ/bash"
+[[ "$_xtrace_was_on" == "1" ]] && set -x
+doctor "PATH=$NOJQ" "MCP_CONFIG=$MINIMAL_CFG" "MCP_POLICY_CONFIG=$LAX_POLICY" \
+  "MCP_LOCK_CONFIG=$FIX/none.json" "MCP_REGISTRY_CONFIG=$FIX/none.json" \
+  "MCP_SERVER_CARD=$FIX/none.json"
+out_has "not installed, running limited checks" "jq warning"
+out_has "mcpServers key" "grep fallback ran"
+
+test_start "without_jq_a_config_lacking_the_key_fails"
+printf '{"other":{}}' >"$FIX/nokey.json"
+doctor "PATH=$NOJQ" "MCP_CONFIG=$FIX/nokey.json" "MCP_POLICY_CONFIG=$LAX_POLICY" \
+  "MCP_LOCK_CONFIG=$FIX/none.json" "MCP_REGISTRY_CONFIG=$FIX/none.json" \
+  "MCP_SERVER_CARD=$FIX/none.json"
+assert_equals 1 "$RC" "rc"
+out_has "mcpServers key" "row"
+out_has "missing" "failure"
+
+echo "RESULTS:$TESTS_RUN:$TESTS_PASSED:$TESTS_FAILED"

--- a/tests/unit/diagnostics/test_mcp_doctor_policy.sh
+++ b/tests/unit/diagnostics/test_mcp_doctor_policy.sh
@@ -231,7 +231,7 @@ assert_equals "healthy" "$(out_json .status)" "status"
 assert_equals "1" "$(out_json .server_count)" "server_count"
 assert_equals "true" "$(out_json .checks.config_present)" "config_present"
 assert_equals "false" "$(out_json .strict)" "strict flag"
-assert_output_not_contains "MCP Doctor" "printf '%s' \"\$OUT\""
+out_lacks "MCP Doctor" "no human-readable chrome in --json mode"
 
 test_start "json_mode_reports_warning_status"
 doctor "MCP_CONFIG=$MINIMAL_CFG" "MCP_POLICY_CONFIG=$FIX/absent.json" \

--- a/tests/unit/diagnostics/test_mcp_doctor_servers.sh
+++ b/tests/unit/diagnostics/test_mcp_doctor_servers.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2015-2026 Sebastien Rousseau
+# shellcheck disable=SC1090,SC1091,SC2034
+# Behavioural coverage for the *per-server* policy checks in
+# scripts/diagnostics/mcp-doctor.sh: launcher allowlist, filesystem scope,
+# risky args, forbidden default servers, transport trust, HTTPS/OAuth
+# requirements, auth-profile compatibility, env placeholders, required
+# tokens, npx pinning, package-lock and registry conformance.
+#
+# Each check gets both verdicts (clean + flagged). Fixtures live in the
+# coverage sandbox and reach the script through its own env overrides, so
+# nothing on the host is read or written.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+source "$SCRIPT_DIR/../../framework/assertions.sh"
+source "$SCRIPT_DIR/../../framework/coverage_helpers.sh"
+
+DOCTOR="$REPO_ROOT/scripts/diagnostics/mcp-doctor.sh"
+
+trap cov_teardown_sandbox EXIT
+cov_setup_sandbox
+
+FIX="$DOTFILES_COV_TMPDIR/fixtures"
+mkdir -p "$FIX"
+OUTF="$DOTFILES_COV_TMPDIR/doctor-out.txt"
+NONE="$FIX/none.json"
+
+# doctor <env-assignments…> [-- <script-args…>] — run mcp-doctor under the
+# given environment, writing its report to $OUTF and its status to RC.
+doctor() {
+  local -a envs=() args=()
+  while (($#)); do
+    if [[ "$1" == "--" ]]; then
+      shift
+      args=("$@")
+      break
+    fi
+    envs+=("$1")
+    shift
+  done
+  # The report is kept in a FILE, never in a shell variable: a captured
+  # multi-line report becomes a kilobyte-long xtrace record, and long
+  # records get truncated in the coverage trace, silently dropping the
+  # coverage of the lines that produced them. stderr is deliberately left
+  # attached to ours so the child's xtrace still reaches the trace file.
+  env "${envs[@]}" bash "$DOCTOR" ${args[@]+"${args[@]}"} >"$OUTF" </dev/null
+  RC=$?
+  return 0
+}
+
+# out_has <needle> [msg] / out_lacks <needle> [msg] — assert on the report.
+out_has() { assert_file_contains "$OUTF" "$1" "${2:-output contains $1}"; }
+out_lacks() {
+  if grep -qF -- "$1" "$OUTF"; then
+    ((TESTS_FAILED++)) || true
+    printf '%b\n' "  ${RED}✗${NC} $CURRENT_TEST: ${2:-output should not contain $1}"
+  else
+    ((TESTS_PASSED++)) || true
+    printf '%b\n' "  ${GREEN}✓${NC} $CURRENT_TEST: ${2:-output lacks $1}"
+  fi
+}
+# out_json <jq-filter> — read one field out of a --json run.
+out_json() { jq -r "$1" <"$OUTF"; }
+
+# check <config-file> <policy-file> [extra-env…] — the common invocation.
+check() {
+  local cfg="$1" pol="$2"
+  shift 2
+  doctor "MCP_CONFIG=$cfg" "MCP_POLICY_CONFIG=$pol" \
+    "MCP_LOCK_CONFIG=$FIX/lock.json" "MCP_REGISTRY_CONFIG=$FIX/registry.json" \
+    "MCP_SERVER_CARD=$NONE" "$@"
+}
+
+printf '{"packages":{"filesystem":{"package":"@modelcontextprotocol/server-filesystem@1.0.0"}}}' \
+  >"$FIX/lock.json"
+cat >"$FIX/registry.json" <<'JSON'
+{"servers":{
+  "filesystem":{"transport":"stdio","launcher":"npx","package":"@modelcontextprotocol/server-filesystem@1.0.0","authProfile":"none"},
+  "remote":{"transport":"http","launcher":"npx","package":"","url":"https://mcp.example.com","auth":"oauth2","authProfile":"env-token"},
+  "other":{"transport":"http","launcher":"npx","package":"","url":"https://x.example","auth":"oauth2","authProfile":"bearer-static"}
+}}
+JSON
+
+# Policy with every gate ON — the "strict-local" shape the repo ships.
+FULL_POLICY="$FIX/full-policy.json"
+cat >"$FULL_POLICY" <<'JSON'
+{
+  "defaultProfile": "strict-local",
+  "profiles": {
+    "strict-local": {
+      "allowedLaunchers": ["npx", "node", "uvx"],
+      "blockedFilesystemRoots": ["/", "/home", "/Users"],
+      "blockedArgPatterns": ["^--allow-.*", "^--unsafe$"],
+      "forbidNetworkServersByDefault": ["brave-search"],
+      "requiredEnvByServer": {"github": ["GITHUB_TOKEN"]},
+      "trustedTransports": ["stdio", "http"],
+      "authProfiles": ["none", "env-token"],
+      "warnOnUnpinnedNpx": true,
+      "requireApprovedPackageLock": true,
+      "requireRegistryEntry": true,
+      "requireHttpsForHttpTransports": true,
+      "requireOauthForHttpTransports": true
+    }
+  }
+}
+JSON
+
+# A config that satisfies every gate above.
+CLEAN="$FIX/clean.json"
+cat >"$CLEAN" <<'JSON'
+{"mcpServers":{
+  "filesystem":{"command":"npx","args":["@modelcontextprotocol/server-filesystem@1.0.0"]},
+  "remote":{"command":"npx","transport":"http","url":"https://mcp.example.com","args":[]}
+}}
+JSON
+
+test_start "clean_config_passes_every_policy_gate"
+check "$CLEAN" "$FULL_POLICY"
+assert_equals 0 "$RC" "rc"
+out_has "all server launchers are allowlisted" "launcher policy"
+out_has "no high-risk wildcard/unsafe args" "arg policy"
+out_has "local-only default set" "default server policy"
+out_has "all servers use trusted transports" "transport policy"
+out_has "HTTP transports are HTTPS" "transport security"
+out_has "all server auth profiles match policy" "auth compatibility"
+out_has "HTTP transports are registry-approved for OAuth2" "auth policy"
+out_has "no unpinned npx packages found" "package pinning"
+out_has "all active servers match approved package refs" "package lock"
+out_has "all active servers match the tracked MCP registry" "registry policy"
+out_has "not globally broad" "filesystem scope"
+out_has "none declared" "env placeholders"
+
+test_start "broad_filesystem_scope_is_flagged"
+printf '{"mcpServers":{"filesystem":{"command":"npx","args":["/"]}}}' >"$FIX/broad.json"
+check "$FIX/broad.json" "$FULL_POLICY"
+out_has "too broad (use a project-scoped directory)" "warning"
+
+test_start "non_allowlisted_launcher_is_flagged"
+printf '{"mcpServers":{"weird":{"command":"bash","args":["-c","true"]}}}' >"$FIX/launcher.json"
+check "$FIX/launcher.json" "$FULL_POLICY"
+out_has "review non-standard command weird:bash" "warning names the server"
+
+test_start "risky_args_are_flagged"
+printf '{"mcpServers":{"fs":{"command":"npx","args":["--unsafe","--allow-everything"]}}}' >"$FIX/risky.json"
+check "$FIX/risky.json" "$FULL_POLICY"
+out_has "review risky argument fs:--unsafe" "unsafe flag"
+out_has "review risky argument fs:--allow-everything" "allow- flag"
+
+test_start "forbidden_default_server_is_flagged"
+printf '{"mcpServers":{"brave-search":{"command":"npx","args":["pkg@1.0.0"]}}}' >"$FIX/forbidden.json"
+check "$FIX/forbidden.json" "$FULL_POLICY"
+out_has "brave-search enabled in strict-local profile" "warning"
+
+test_start "untrusted_transport_is_flagged"
+printf '{"mcpServers":{"ws":{"command":"npx","transport":"websocket","args":["pkg@1.0.0"]}}}' >"$FIX/transport.json"
+check "$FIX/transport.json" "$FULL_POLICY"
+out_has "review untrusted transport ws:websocket" "warning"
+
+test_start "plain_http_transport_url_is_flagged"
+printf '{"mcpServers":{"remote":{"command":"npx","transport":"http","url":"http://mcp.example.com","args":[]}}}' \
+  >"$FIX/insecure.json"
+check "$FIX/insecure.json" "$FULL_POLICY"
+out_has "remote uses non-HTTPS HTTP transport" "warning"
+
+test_start "streamable_http_must_use_https"
+printf '{"mcpServers":{"stream":{"command":"npx","transport":"streamable-http","url":"http://x.example","args":[]}}}' \
+  >"$FIX/stream.json"
+check "$FIX/stream.json" "$FULL_POLICY"
+out_has "stream streamable-http transport must use HTTPS" "warning"
+
+test_start "auth_profile_outside_policy_is_flagged"
+# The registry gives "other" the authProfile "bearer-static", which the
+# policy's authProfiles list does not allow.
+printf '{"mcpServers":{"other":{"command":"npx","transport":"http","url":"https://x.example","args":[]}}}' \
+  >"$FIX/auth.json"
+check "$FIX/auth.json" "$FULL_POLICY"
+out_has "uses auth profile not in policy" "auth compatibility warning"
+
+test_start "http_transport_without_registered_oauth_is_flagged"
+NO_OAUTH_REG="$FIX/registry-no-oauth.json"
+jq '.servers.remote.auth = "none"' "$FIX/registry.json" >"$NO_OAUTH_REG"
+doctor "MCP_CONFIG=$CLEAN" "MCP_POLICY_CONFIG=$FULL_POLICY" \
+  "MCP_LOCK_CONFIG=$FIX/lock.json" "MCP_REGISTRY_CONFIG=$NO_OAUTH_REG" \
+  "MCP_SERVER_CARD=$NONE"
+out_has "remote HTTP transport is not registered for OAuth2" "warning"
+
+test_start "unset_env_placeholder_is_flagged"
+printf '{"mcpServers":{"gh":{"command":"npx","args":["pkg@1.0.0"],"env":{"TOKEN":"${DOTFILES_MCP_TEST_TOKEN}"}}}}' \
+  >"$FIX/env.json"
+check "$FIX/env.json" "$FULL_POLICY"
+out_has "DOTFILES_MCP_TEST_TOKEN is not set" "warning"
+
+test_start "set_env_placeholder_passes"
+check "$FIX/env.json" "$FULL_POLICY" "DOTFILES_MCP_TEST_TOKEN=xyz"
+out_has "all referenced placeholders are set" "ok"
+
+test_start "required_token_missing_for_a_configured_server"
+printf '{"mcpServers":{"github":{"command":"npx","args":["pkg@1.0.0"]}}}' >"$FIX/github.json"
+check "$FIX/github.json" "$FULL_POLICY" "GITHUB_TOKEN="
+out_has "GITHUB_TOKEN missing for github MCP server" "warning"
+
+test_start "required_token_present_for_a_configured_server"
+check "$FIX/github.json" "$FULL_POLICY" "GITHUB_TOKEN=ghp_test"
+out_has "GITHUB_TOKEN is set for github MCP server" "ok"
+
+test_start "required_token_rule_skipped_when_the_server_is_absent"
+check "$CLEAN" "$FULL_POLICY" "GITHUB_TOKEN="
+out_lacks "for github MCP server" "no token row for an absent server"
+
+test_start "unpinned_npx_package_is_flagged"
+printf '{"mcpServers":{"fs":{"command":"npx","args":["@modelcontextprotocol/server-filesystem"]}}}' \
+  >"$FIX/unpinned.json"
+check "$FIX/unpinned.json" "$FULL_POLICY"
+out_has "fs uses unpinned npx package" "warning"
+
+test_start "package_not_matching_the_lock_is_flagged"
+printf '{"mcpServers":{"filesystem":{"command":"npx","args":["@modelcontextprotocol/server-filesystem@9.9.9"]}}}' \
+  >"$FIX/drifted.json"
+check "$FIX/drifted.json" "$FULL_POLICY"
+out_has "filesystem uses @modelcontextprotocol/server-filesystem@9.9.9" "actual"
+out_has "approved: @modelcontextprotocol/server-filesystem@1.0.0" "expected"
+
+test_start "server_missing_from_the_registry_is_flagged"
+printf '{"mcpServers":{"ghost":{"command":"npx","args":["ghost@1.0.0"]}}}' >"$FIX/ghost.json"
+check "$FIX/ghost.json" "$FULL_POLICY"
+out_has "ghost is missing or diverges from the tracked MCP registry" "warning"
+
+test_start "invalid_lock_and_registry_json_fall_back_to_empty_sets"
+printf 'nope' >"$FIX/lock-bad.json"
+printf 'nope' >"$FIX/registry-bad.json"
+doctor "MCP_CONFIG=$CLEAN" "MCP_POLICY_CONFIG=$FULL_POLICY" \
+  "MCP_LOCK_CONFIG=$FIX/lock-bad.json" "MCP_REGISTRY_CONFIG=$FIX/registry-bad.json" \
+  "MCP_SERVER_CARD=$NONE"
+out_has "approved:" "every server counts as untracked"
+out_has "diverges from the tracked MCP registry" "registry mismatch"
+
+echo "RESULTS:$TESTS_RUN:$TESTS_PASSED:$TESTS_FAILED"

--- a/tests/unit/diagnostics/test_perf_reporting.sh
+++ b/tests/unit/diagnostics/test_perf_reporting.sh
@@ -120,19 +120,36 @@ out_has "Needs attention" "verdict for a zero score"
 unset DOTFILES_PERF_MAX_MS
 export DOTFILES_PERF_TARGET_BASH_MS=100000
 
-test_start "a_mid_range_score_lands_between_the_two_floors"
-# target < mean < max is the interpolated band: score is neither 100 nor 0.
-export DOTFILES_PERF_MAX_MS=5000 DOTFILES_PERF_TARGET_BASH_MS=100000
+test_start "a_score_between_the_floors_follows_the_documented_formula"
+# Between the two floors the score is interpolated. The measured mean is
+# whatever the machine gives us, so the oracle recomputes the documented
+# formula from the report's own numbers instead of guessing a band.
+export DOTFILES_PERF_MAX_MS=100000 DOTFILES_PERF_TARGET_BASH_MS=100000
 perf --json --shell bash --runs 1 --target 1
 assert_equals 0 "$RC" "rc"
-assert_true "[[ \$(jq -r .score <'$OUTF') -gt 0 && \$(jq -r .score <'$OUTF') -lt 100 ]]" "interpolated score"
+mean="$(jq -r .mean_ms <"$OUTF")"
+target="$(jq -r .target_ms <"$OUTF")"
+max="$(jq -r .max_ms_target <"$OUTF")"
+score="$(jq -r .score <"$OUTF")"
+if [[ "$mean" -le "$target" ]]; then
+  expected=100
+elif [[ "$mean" -ge "$max" ]]; then
+  expected=0
+else
+  expected=$((100 - (mean - target) * 100 / (max - target)))
+fi
+assert_equals "$expected" "$score" "score interpolates between target and max"
+assert_true "[[ $mean -gt $target && $mean -lt $max ]]" "the measurement sits in the interpolated band"
 
-test_start "a_good_but_not_perfect_score_is_reported_as_good"
+test_start "a_score_below_100_is_reported_as_good_or_needs_attention"
+# A 200ms ceiling puts any real shell startup below a perfect score.
+export DOTFILES_PERF_MAX_MS=200
 perf --shell bash --runs 1 --target 1 --no-baseline-check
 assert_equals 0 "$RC" "rc"
-# A score below 100 is either "Good" (>=80) or "Needs attention"; which one
-# depends on how loaded the machine is, so accept the non-perfect pair.
+# Which of the two non-perfect verdicts applies depends on how loaded the
+# machine is, so accept the pair and reject the perfect one.
 assert_true "grep -qE 'Good \(tune to reach 100\)|Needs attention' '$OUTF'" "non-perfect verdict"
+assert_true "! grep -q 'Excellent' '$OUTF'" "not reported as excellent"
 unset DOTFILES_PERF_MAX_MS
 export DOTFILES_PERF_TARGET_BASH_MS=100000
 

--- a/tests/unit/diagnostics/test_perf_reporting.sh
+++ b/tests/unit/diagnostics/test_perf_reporting.sh
@@ -1,0 +1,234 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2015-2026 Sebastien Rousseau
+# shellcheck disable=SC1090,SC1091,SC2034
+# Behavioural coverage for scripts/diagnostics/perf.sh: the per-tool timing
+# reader (--by-tool / --reset), the measurement + scoring path (kept to a
+# single shell and a single run so the suite stays fast), the JSON report,
+# and baseline write / compare / regression reporting.
+#
+# Everything runs against the sandbox HOME, so the baseline and timing files
+# written here live in the sandbox and never touch the real cache.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+source "$SCRIPT_DIR/../../framework/assertions.sh"
+source "$SCRIPT_DIR/../../framework/coverage_helpers.sh"
+
+PERF="$REPO_ROOT/scripts/diagnostics/perf.sh"
+
+trap cov_teardown_sandbox EXIT
+cov_setup_sandbox
+
+OUTF="$DOTFILES_COV_TMPDIR/perf-out.txt"
+TIMINGS="$XDG_STATE_HOME/dotfiles/eval-timings.jsonl"
+BASELINE="$XDG_CACHE_HOME/dotfiles/perf-baseline.json"
+mkdir -p "$(dirname "$TIMINGS")" "$(dirname "$BASELINE")"
+
+# perf <args…> — run perf.sh, report to $OUTF, status in RC. stderr stays
+# attached so the child's xtrace still reaches the coverage trace.
+perf() {
+  bash "$PERF" "$@" >"$OUTF" </dev/null
+  RC=$?
+  return 0
+}
+out_has() { assert_file_contains "$OUTF" "$1" "${2:-output contains $1}"; }
+
+test_start "script_exists_and_parses"
+assert_file_exists "$PERF" "perf.sh must exist"
+assert_true "bash -n '$PERF'" "valid bash syntax"
+
+# ── --by-tool / --reset ─────────────────────────────────────────────────
+test_start "by_tool_without_data_warns_and_exits_0"
+: >"$TIMINGS"
+perf --by-tool
+assert_equals 0 "$RC" "rc"
+out_has "no data at" "warning names the file"
+
+test_start "by_tool_aggregates_recorded_timings"
+cat >"$TIMINGS" <<'JSONL'
+{"label":"mise","ms":120,"shell":"zsh"}
+{"label":"mise","ms":80,"shell":"bash"}
+{"label":"starship","ms":40,"shell":"zsh"}
+{"label":"starship","ms":10,"shell":"zsh"}
+{"label":"broken","ms":"not-a-number","shell":"zsh"}
+not json at all
+
+JSONL
+perf --by-tool
+assert_equals 0 "$RC" "rc"
+out_has "Per-tool timing breakdown" "header"
+out_has "mise" "slowest tool listed first"
+out_has "starship" "second tool listed"
+assert_true "grep -qE 'mise +2 +200ms' '$OUTF'" "count and total aggregated"
+
+test_start "reset_clears_the_timing_log"
+perf --reset
+assert_equals 0 "$RC" "rc"
+out_has "cleared" "confirmation"
+assert_equals "0" "$(wc -c <"$TIMINGS" | tr -d ' ')" "log truncated"
+
+test_start "reset_then_by_tool_reports_the_now_empty_log"
+printf '{"label":"x","ms":1,"shell":"zsh"}\n' >"$TIMINGS"
+perf --reset --by-tool
+assert_equals 0 "$RC" "rc"
+out_has "cleared" "reset ran"
+out_has "no data at" "and then found nothing to report"
+
+# ── measurement + report ────────────────────────────────────────────────
+test_start "unknown_shell_filter_has_nothing_to_measure"
+perf --shell definitely-not-a-shell
+assert_equals 1 "$RC" "rc"
+out_has "no measurable shells found" "error"
+out_has "filter: definitely-not-a-shell" "filter echoed"
+
+test_start "json_report_has_the_documented_shape"
+# Per-shell targets come from DOTFILES_PERF_TARGET_<SHELL>_MS (bash defaults
+# to 60ms); pin it high so a loaded machine cannot make the verdict flaky.
+export DOTFILES_PERF_TARGET_BASH_MS=100000
+perf --json --shell bash --runs 1 --target 100000
+assert_equals 0 "$RC" "rc"
+assert_equals "1" "$(jq -r .runs <"$OUTF")" "runs"
+assert_equals "100" "$(jq -r .score <"$OUTF")" "score is 100 under a huge target"
+assert_equals "true" "$(jq -r '.shells.bash.pass' <"$OUTF")" "bash passes"
+assert_equals "0" "$(jq -r .regression_count <"$OUTF")" "no regressions yet"
+assert_true "[[ \$(jq -r '.shells.bash.mean_ms' <'$OUTF') -ge 0 ]]" "mean recorded"
+
+test_start "an_impossible_target_scores_zero"
+# TARGET 0 with MAX 1ms puts any real measurement past the zero-score floor,
+# and a per-shell bash target of 0 makes the pass/fail column fail too.
+export DOTFILES_PERF_MAX_MS=1 DOTFILES_PERF_TARGET_BASH_MS=0
+perf --json --shell bash --runs 1 --target 0
+assert_equals 0 "$RC" "rc"
+assert_equals "0" "$(jq -r .score <"$OUTF")" "score floors at 0"
+assert_equals "false" "$(jq -r '.shells.bash.pass' <"$OUTF")" "bash fails its target"
+
+test_start "human_report_renders_the_per_shell_table"
+perf --shell bash --runs 1 --target 100000 --no-baseline-check
+assert_equals 0 "$RC" "rc"
+out_has "Shell Performance" "header"
+out_has "Per-shell startup" "section"
+out_has "bash" "shell row"
+out_has "Excellent" "verdict for a passing score"
+
+test_start "a_missed_target_is_reported_with_the_overshoot"
+perf --shell bash --runs 1 --target 0 --no-baseline-check
+assert_equals 0 "$RC" "rc"
+out_has "over by" "overshoot detail"
+out_has "Needs attention" "verdict for a zero score"
+unset DOTFILES_PERF_MAX_MS
+export DOTFILES_PERF_TARGET_BASH_MS=100000
+
+test_start "a_mid_range_score_lands_between_the_two_floors"
+# target < mean < max is the interpolated band: score is neither 100 nor 0.
+export DOTFILES_PERF_MAX_MS=5000 DOTFILES_PERF_TARGET_BASH_MS=100000
+perf --json --shell bash --runs 1 --target 1
+assert_equals 0 "$RC" "rc"
+assert_true "[[ \$(jq -r .score <'$OUTF') -gt 0 && \$(jq -r .score <'$OUTF') -lt 100 ]]" "interpolated score"
+
+test_start "a_good_but_not_perfect_score_is_reported_as_good"
+perf --shell bash --runs 1 --target 1 --no-baseline-check
+assert_equals 0 "$RC" "rc"
+# A score below 100 is either "Good" (>=80) or "Needs attention"; which one
+# depends on how loaded the machine is, so accept the non-perfect pair.
+assert_true "grep -qE 'Good \(tune to reach 100\)|Needs attention' '$OUTF'" "non-perfect verdict"
+unset DOTFILES_PERF_MAX_MS
+export DOTFILES_PERF_TARGET_BASH_MS=100000
+
+test_start "zsh_is_measured_with_its_own_target"
+# zsh is the reference shell for the headline score, and has its own
+# per-shell target arm in shell_target_for.
+perf --json --shell zsh --runs 1 --target 100000
+assert_equals 0 "$RC" "rc"
+assert_true "[[ \$(jq -r '.shells.zsh.mean_ms' <'$OUTF') -ge 0 ]]" "zsh measured"
+assert_equals "$(jq -r .mean_ms <"$OUTF")" "$(jq -r '.shells.zsh.mean_ms' <"$OUTF")" "headline mean comes from zsh"
+
+test_start "profile_flag_adds_the_zprof_section"
+perf --shell bash --runs 1 --target 100000 --no-baseline-check --profile
+assert_equals 0 "$RC" "rc"
+out_has "Top contributors (zprof)" "section"
+
+# ── baseline ────────────────────────────────────────────────────────────
+test_start "baseline_flag_writes_the_measured_means"
+rm -f "$BASELINE"
+perf --shell bash --runs 1 --target 100000 --baseline --no-baseline-check
+assert_equals 0 "$RC" "rc"
+assert_file_exists "$BASELINE" "baseline written"
+assert_true "[[ \$(jq -r '.shells.bash' <'$BASELINE') -ge 0 ]]" "bash mean recorded"
+assert_equals "10" "$(jq -r .regression_pct <"$BASELINE")" "default threshold recorded"
+out_has "wrote baseline to" "confirmation"
+
+test_start "a_matching_baseline_reports_no_regression"
+printf '{"recorded_at":"2026-01-01T00:00:00Z","regression_pct":10,"shells":{"bash":100000}}\n' >"$BASELINE"
+perf --shell bash --runs 1 --target 100000
+assert_equals 0 "$RC" "rc"
+out_has "within" "all shells within the threshold"
+
+test_start "a_regressed_baseline_is_reported_with_the_delta"
+printf '{"recorded_at":"2026-01-01T00:00:00Z","regression_pct":10,"shells":{"bash":1}}\n' >"$BASELINE"
+perf --shell bash --runs 1 --target 100000
+assert_equals 0 "$RC" "rc"
+out_has "Baseline regressions" "section"
+out_has "vs baseline 1 ms" "delta line"
+out_has "threshold: >10%" "threshold echoed"
+
+test_start "regressions_are_listed_in_the_json_report"
+perf --json --shell bash --runs 1 --target 100000
+assert_equals 0 "$RC" "rc"
+assert_equals "1" "$(jq -r .regression_count <"$OUTF")" "regression counted"
+assert_true "jq -e '.regressions[0] | test(\"^bash: \")' <'$OUTF' >/dev/null" "regression text"
+
+test_start "no_baseline_check_skips_the_comparison"
+perf --shell bash --runs 1 --target 100000 --no-baseline-check
+assert_equals 0 "$RC" "rc"
+assert_true "! grep -q 'Baseline regressions' '$OUTF'" "comparison skipped"
+
+test_start "an_unreadable_baseline_is_ignored"
+printf 'not json\n' >"$BASELINE"
+perf --shell bash --runs 1 --target 100000
+assert_equals 0 "$RC" "rc"
+assert_true "! grep -q 'Baseline regressions' '$OUTF'" "no regressions from a broken file"
+
+test_start "unknown_flags_are_ignored"
+rm -f "$BASELINE"
+perf --definitely-not-a-flag --shell bash --runs 1 --target 100000
+assert_equals 0 "$RC" "rc"
+out_has "Shell Performance" "still ran"
+
+test_start "perf_requires_python3"
+NOPY="$DOTFILES_COV_TMPDIR/nopy"
+mkdir -p "$NOPY"
+IFS=: read -ra _dirs <<<"$PATH"
+_link_dirs() {
+  local _d
+  for _d in "$@"; do
+    [[ -d "$_d" ]] && ln -s "$_d"/* "$NOPY"/ 2>/dev/null
+  done
+  return 0
+}
+# Building the farm expands to `ln -s` calls with ~900 arguments each; under
+# the coverage runner each is an xtrace record tens of KB long, and records
+# that big come back truncated, corrupting the trace around them. Trace-off
+# for the farm only.
+_xtrace_was_on=0
+case "$-" in *x*) _xtrace_was_on=1 ;; esac
+set +x
+# System dirs first: a PATH entry may hold a *directory* whose name shadows a
+# real command (PowerShell ships a `tr` locale dir); the prune pass then drops
+# any link that did not resolve to a file.
+_link_dirs /usr/bin /bin /usr/sbin /sbin
+_link_dirs "${_dirs[@]}"
+for _l in "$NOPY"/*; do [[ -f "$_l" ]] || rm -f "$_l"; done
+_link_dirs /usr/bin /bin /usr/sbin /sbin
+rm -f "$NOPY/python3"
+# Keep the *current* bash: on macOS the farm would otherwise resolve `bash`
+# to /bin/bash 3.2, whose xtrace truncates the PS4 expansion at 100 chars —
+# every coverage record from the child would be malformed and dropped.
+ln -sf "$(command -v bash)" "$NOPY/bash"
+[[ "$_xtrace_was_on" == "1" ]] && set -x
+PATH="$NOPY" perf --json
+assert_equals 1 "$RC" "rc"
+assert_true "! grep -q runs '$OUTF'" "no report produced"
+
+echo "RESULTS:$TESTS_RUN:$TESTS_PASSED:$TESTS_FAILED"

--- a/tests/unit/diagnostics/test_perf_reporting.sh
+++ b/tests/unit/diagnostics/test_perf_reporting.sh
@@ -154,17 +154,30 @@ unset DOTFILES_PERF_MAX_MS
 export DOTFILES_PERF_TARGET_BASH_MS=100000
 
 test_start "zsh_is_measured_with_its_own_target"
-# zsh is the reference shell for the headline score, and has its own
-# per-shell target arm in shell_target_for.
+# zsh is the reference shell for the headline score and has its own arm in
+# shell_target_for — but it is not installed everywhere (the Linux CI runner
+# has no zsh), and then the filter matches nothing at all.
 perf --json --shell zsh --runs 1 --target 100000
-assert_equals 0 "$RC" "rc"
-assert_true "[[ \$(jq -r '.shells.zsh.mean_ms' <'$OUTF') -ge 0 ]]" "zsh measured"
-assert_equals "$(jq -r .mean_ms <"$OUTF")" "$(jq -r '.shells.zsh.mean_ms' <"$OUTF")" "headline mean comes from zsh"
+if command -v zsh >/dev/null 2>&1; then
+  assert_equals 0 "$RC" "rc"
+  assert_true "[[ \$(jq -r '.shells.zsh.mean_ms' <'$OUTF') -ge 0 ]]" "zsh measured"
+  assert_equals "$(jq -r .mean_ms <"$OUTF")" "$(jq -r '.shells.zsh.mean_ms' <"$OUTF")" "headline mean comes from zsh"
+else
+  assert_equals 1 "$RC" "no measurable shell without zsh"
+  out_has "no measurable shells found" "error names the empty filter"
+fi
 
 test_start "profile_flag_adds_the_zprof_section"
-perf --shell bash --runs 1 --target 100000 --no-baseline-check --profile
-assert_equals 0 "$RC" "rc"
-out_has "Top contributors (zprof)" "section"
+# zprof is a zsh module, so --profile only completes where zsh exists (it is
+# absent on the Linux CI runner).
+if command -v zsh >/dev/null 2>&1; then
+  perf --shell bash --runs 1 --target 100000 --no-baseline-check --profile
+  assert_equals 0 "$RC" "rc"
+  out_has "Top contributors (zprof)" "section"
+else
+  perf --shell bash --runs 1 --target 100000 --no-baseline-check --profile
+  out_has "Top contributors (zprof)" "section header still rendered"
+fi
 
 # ── baseline ────────────────────────────────────────────────────────────
 test_start "baseline_flag_writes_the_measured_means"

--- a/tests/unit/dot-cli/test_dot_agent_a2a.sh
+++ b/tests/unit/dot-cli/test_dot_agent_a2a.sh
@@ -71,7 +71,14 @@ assert_contains "specVersion" "$OUT" "validation rows"
 # resolve_source_dir() derives the repo root from lib/dot's own location, so
 # a fake root that symlinks lib/ + scripts/dot/ back to the repo lets us
 # swap in a deliberately broken .well-known/agent-card.json.
-FAKE="$DOTFILES_COV_TMPDIR/fake-root"
+#
+# The fake root deliberately lives OUTSIDE the sandbox tmpdir: the coverage
+# aggregator resolves each traced BASH_SOURCE path after the test exits, and
+# a fake root torn down with the sandbox would leave those records pointing
+# at a dangling path, so the lines executed through it would not be counted.
+# The fixed name is wiped on entry, so at most one such tree ever exists.
+FAKE="${TMPDIR:-/tmp}/dotfiles-cov-agent-fakeroot"
+rm -rf "$FAKE"
 mkdir -p "$FAKE/scripts/diagnostics" "$FAKE/.well-known"
 ln -s "$REPO_ROOT/lib" "$FAKE/lib"
 ln -s "$REPO_ROOT/scripts/dot" "$FAKE/scripts/dot"

--- a/tests/unit/dot-cli/test_dot_agent_a2a.sh
+++ b/tests/unit/dot-cli/test_dot_agent_a2a.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2015-2026 Sebastien Rousseau
+# shellcheck disable=SC1090,SC1091,SC2034
+# Behavioural coverage for the `a2a-card`, `conformance` and unknown-command
+# arms of scripts/dot/commands/agent.sh (`cmd_mode`), driven through the real
+# dispatcher (`meta.sh agent …`) inside the coverage sandbox. Split from
+# test_dot_agent_dispatch.sh to stay inside the coverage runner's 60s
+# per-file budget.
+#
+# Child stderr is captured to a file and replayed to our own stderr so the
+# xtrace records the coverage runner relies on are not swallowed.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+source "$SCRIPT_DIR/../../framework/assertions.sh"
+source "$SCRIPT_DIR/../../framework/coverage_helpers.sh"
+
+META="$REPO_ROOT/scripts/dot/commands/meta.sh"
+AGENT_MODULE="$REPO_ROOT/scripts/dot/commands/agent.sh"
+REAL_PROFILES="$REPO_ROOT/defaults/dot_config/dotfiles/agent-profiles.json"
+
+trap cov_teardown_sandbox EXIT
+cov_setup_sandbox
+
+STATE_DIR="$XDG_STATE_HOME/dotfiles"
+CHECKPOINT_DIR="$STATE_DIR/checkpoints"
+SESSIONS="$STATE_DIR/agent-sessions.jsonl"
+
+# `timeout` (used by `agent delegate`) is coreutils-only on macOS; shim it so
+# the delegate arm is deterministic on every platform.
+cat >"$DOTFILES_COV_TMPDIR/bin/timeout" <<'EOF'
+#!/usr/bin/env bash
+shift
+exec "$@"
+EOF
+chmod +x "$DOTFILES_COV_TMPDIR/bin/timeout"
+
+# run_cmd <cmd…> — sets OUT / ERR / RC. stderr is replayed (xtrace-safe).
+run_cmd() {
+  local errf="$DOTFILES_COV_TMPDIR/stderr.$$"
+  OUT="$("$@" 2>"$errf" </dev/null)"
+  RC=$?
+  ERR="$(grep -v '^+*@COV@' "$errf" 2>/dev/null || true)"
+  [[ "${DOTFILES_COV_ECHO_STDERR:-0}" == "1" ]] && cat "$errf" >&2
+  rm -f "$errf"
+  return 0
+}
+
+meta() { run_cmd bash "$META" "$@"; }
+
+# ── a2a-card (real card) ────────────────────────────────────────────────
+test_start "a2a_card_renders_summary"
+meta agent a2a-card
+assert_equals 0 "$RC" "rc"
+assert_contains "A2A v0.3 Agent Card" "$OUT" "header"
+assert_contains "Skills" "$OUT" "skills row"
+
+test_start "a2a_card_json"
+meta agent a2a-card --json
+assert_equals 0 "$RC" "rc"
+assert_equals "0.3" "$(printf '%s' "$OUT" | jq -r .specVersion)" "raw card"
+
+test_start "a2a_card_validate_shipped_card_passes"
+meta agent a2a-card --validate ignored-positional
+assert_equals 0 "$RC" "rc"
+assert_contains "specVersion" "$OUT" "validation rows"
+
+# ── a2a-card (broken card via a fake repo root) ─────────────────────────
+# resolve_source_dir() derives the repo root from lib/dot's own location, so
+# a fake root that symlinks lib/ + scripts/dot/ back to the repo lets us
+# swap in a deliberately broken .well-known/agent-card.json.
+FAKE="$DOTFILES_COV_TMPDIR/fake-root"
+mkdir -p "$FAKE/scripts/diagnostics" "$FAKE/.well-known"
+ln -s "$REPO_ROOT/lib" "$FAKE/lib"
+ln -s "$REPO_ROOT/scripts/dot" "$FAKE/scripts/dot"
+cat >"$FAKE/scripts/diagnostics/a2a-conformance.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "stub-conformance $*"
+EOF
+chmod +x "$FAKE/scripts/diagnostics/a2a-conformance.sh"
+FAKE_META="$FAKE/scripts/dot/commands/meta.sh"
+fmeta() { AGENT_PROFILE_CONFIG="$REAL_PROFILES" run_cmd bash "$FAKE_META" "$@"; }
+
+test_start "a2a_card_validate_invalid_json_exits_1"
+printf '{oops' >"$FAKE/.well-known/agent-card.json"
+fmeta agent a2a-card --strict
+assert_equals 1 "$RC" "rc"
+assert_contains "invalid" "$OUT" "JSON invalid row"
+
+test_start "a2a_card_validate_reports_every_missing_field"
+printf '{"specVersion":"0.2","skills":[]}' >"$FAKE/.well-known/agent-card.json"
+fmeta agent a2a-card -s
+assert_equals 1 "$RC" "strict exit"
+assert_contains "expected 0.3, got 0.2" "$OUT" "specVersion"
+assert_contains "missing or empty" "$OUT" "skills"
+assert_contains "authentication" "$OUT" "authentication row"
+assert_contains "missing method" "$OUT" "signing"
+
+test_start "a2a_card_missing_file"
+rm -f "$FAKE/.well-known/agent-card.json"
+fmeta agent a2a-card
+assert_equals 1 "$RC" "rc"
+assert_contains "A2A v0.3 card not found" "$ERR" "error"
+
+test_start "conformance_execs_script_with_args"
+fmeta agent conformance --json
+assert_equals 0 "$RC" "rc"
+assert_contains "stub-conformance --json" "$OUT" "args forwarded"
+
+# ── unknown ─────────────────────────────────────────────────────────────
+test_start "mode_unknown_subcommand"
+meta mode bogus
+assert_equals 1 "$RC" "rc"
+assert_contains "Usage: dot mode [list|current" "$ERR" "usage"
+
+echo "RESULTS:$TESTS_RUN:$TESTS_PASSED:$TESTS_FAILED"

--- a/tests/unit/dot-cli/test_dot_agent_checkpoint.sh
+++ b/tests/unit/dot-cli/test_dot_agent_checkpoint.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2015-2026 Sebastien Rousseau
+# shellcheck disable=SC1090,SC1091,SC2034
+# Behavioural coverage for the `checkpoint` and `delegate` arms of
+# scripts/dot/commands/agent.sh (`cmd_mode`), driven through the real
+# dispatcher (`meta.sh agent …`) inside the coverage sandbox. Split from
+# test_dot_agent_dispatch.sh to stay inside the coverage runner's 60s
+# per-file budget.
+#
+# Child stderr is captured to a file and replayed to our own stderr so the
+# xtrace records the coverage runner relies on are not swallowed.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+source "$SCRIPT_DIR/../../framework/assertions.sh"
+source "$SCRIPT_DIR/../../framework/coverage_helpers.sh"
+
+META="$REPO_ROOT/scripts/dot/commands/meta.sh"
+AGENT_MODULE="$REPO_ROOT/scripts/dot/commands/agent.sh"
+REAL_PROFILES="$REPO_ROOT/defaults/dot_config/dotfiles/agent-profiles.json"
+
+trap cov_teardown_sandbox EXIT
+cov_setup_sandbox
+
+STATE_DIR="$XDG_STATE_HOME/dotfiles"
+CHECKPOINT_DIR="$STATE_DIR/checkpoints"
+SESSIONS="$STATE_DIR/agent-sessions.jsonl"
+
+# `timeout` (used by `agent delegate`) is coreutils-only on macOS; shim it so
+# the delegate arm is deterministic on every platform.
+cat >"$DOTFILES_COV_TMPDIR/bin/timeout" <<'EOF'
+#!/usr/bin/env bash
+shift
+exec "$@"
+EOF
+chmod +x "$DOTFILES_COV_TMPDIR/bin/timeout"
+
+# run_cmd <cmd…> — sets OUT / ERR / RC. stderr is replayed (xtrace-safe).
+run_cmd() {
+  local errf="$DOTFILES_COV_TMPDIR/stderr.$$"
+  OUT="$("$@" 2>"$errf" </dev/null)"
+  RC=$?
+  ERR="$(grep -v '^+*@COV@' "$errf" 2>/dev/null || true)"
+  [[ "${DOTFILES_COV_ECHO_STDERR:-0}" == "1" ]] && cat "$errf" >&2
+  rm -f "$errf"
+  return 0
+}
+
+meta() { run_cmd bash "$META" "$@"; }
+
+STRICT_PROFILES="$DOTFILES_COV_TMPDIR/strict-profiles.json"
+jq '.rbac.enforcement = "strict" | .delegation.enabled = true | .profiles.ask.canDelegate = true' \
+  "$REAL_PROFILES" >"$STRICT_PROFILES"
+
+# ── checkpoint ──────────────────────────────────────────────────────────
+test_start "checkpoint_save_requires_command"
+meta agent checkpoint save
+assert_equals 1 "$RC" "rc"
+assert_contains "Usage: dot agent checkpoint save" "$ERR" "usage"
+
+test_start "checkpoint_save_writes_file"
+DOT_AGENT_CHECKPOINT_ID=cp-one meta agent checkpoint save plan echo hello world
+assert_equals 0 "$RC" "rc"
+assert_file_exists "$CHECKPOINT_DIR/cp-one.json" "checkpoint file"
+assert_contains "cp-one" "$OUT" "id printed"
+assert_equals "plan" "$(jq -r .profile "$CHECKPOINT_DIR/cp-one.json")" "profile recorded"
+
+test_start "checkpoint_save_defaults_to_current_profile"
+DOT_AGENT_CHECKPOINT_ID=cp-two meta agent checkpoint save bash -c 'exit 7'
+assert_equals 0 "$RC" "rc"
+assert_equals "ask" "$(jq -r .profile "$CHECKPOINT_DIR/cp-two.json")" "current profile"
+
+test_start "checkpoint_list_shows_saved"
+meta agent checkpoint list
+assert_equals 0 "$RC" "rc"
+assert_contains "cp-one" "$OUT" "listed"
+assert_contains "Agent Checkpoints" "$OUT" "header"
+
+test_start "checkpoint_default_action_is_list"
+meta agent checkpoint
+assert_equals 0 "$RC" "rc"
+assert_contains "cp-two" "$OUT" "listed"
+
+test_start "checkpoint_show_requires_id"
+meta agent checkpoint show
+assert_equals 1 "$RC" "rc"
+assert_contains "Usage: dot agent checkpoint show" "$ERR" "usage"
+
+test_start "checkpoint_show_unknown_id"
+meta agent checkpoint show nope
+assert_equals 1 "$RC" "rc"
+assert_contains "Checkpoint not found" "$ERR" "error"
+
+test_start "checkpoint_show_renders"
+meta agent checkpoint show cp-one
+assert_equals 0 "$RC" "rc"
+assert_contains "hello world" "$OUT" "argv rendered"
+
+test_start "checkpoint_show_json"
+meta agent checkpoint show cp-one --json
+assert_equals 0 "$RC" "rc"
+assert_equals "cp-one" "$(printf '%s' "$OUT" | jq -r .id)" "raw json"
+
+test_start "checkpoint_replay_requires_id"
+meta agent checkpoint replay
+assert_equals 1 "$RC" "rc"
+assert_contains "Usage: dot agent checkpoint replay" "$ERR" "usage"
+
+test_start "checkpoint_replay_unknown_id"
+meta agent checkpoint replay nope
+assert_equals 1 "$RC" "rc"
+assert_contains "Checkpoint not found" "$ERR" "error"
+
+test_start "checkpoint_replay_runs_saved_command"
+meta agent checkpoint replay cp-one
+assert_equals 0 "$RC" "rc"
+assert_contains "hello world" "$OUT" "replayed command output"
+assert_file_contains "$SESSIONS" '"event":"checkpoint_replay_finish"' "logged"
+
+test_start "checkpoint_replay_propagates_failure"
+meta agent checkpoint replay cp-two
+assert_equals 7 "$RC" "rc from replayed command"
+
+test_start "checkpoint_replay_refuses_empty_argv"
+jq '.argv = []' "$CHECKPOINT_DIR/cp-one.json" >"$CHECKPOINT_DIR/cp-empty.json"
+meta agent checkpoint replay cp-empty
+assert_equals 1 "$RC" "rc"
+assert_contains "no replayable command" "$ERR" "error"
+
+test_start "checkpoint_unknown_action"
+meta agent checkpoint bogus
+assert_equals 1 "$RC" "rc"
+assert_contains "Usage: dot agent checkpoint" "$ERR" "usage"
+
+# ── delegate ────────────────────────────────────────────────────────────
+test_start "delegate_requires_name"
+meta agent delegate
+assert_equals 1 "$RC" "rc"
+assert_contains "Usage: dot agent delegate" "$ERR" "usage"
+
+test_start "delegate_requires_command"
+meta agent delegate lint-checker
+assert_equals 1 "$RC" "rc"
+assert_contains "Usage: dot agent delegate" "$ERR" "usage"
+
+test_start "delegate_disabled_in_shipped_config"
+meta agent delegate lint-checker true
+assert_equals 1 "$RC" "rc"
+assert_contains "Delegation is not enabled" "$ERR" "error"
+
+test_start "delegate_refused_when_profile_cannot_delegate"
+NODELEG="$DOTFILES_COV_TMPDIR/nodeleg.json"
+jq '.delegation.enabled = true' "$REAL_PROFILES" >"$NODELEG"
+AGENT_PROFILE_CONFIG="$NODELEG" meta agent delegate lint-checker true
+assert_equals 1 "$RC" "rc"
+assert_contains "cannot delegate" "$ERR" "error"
+
+test_start "delegate_unknown_delegate"
+AGENT_PROFILE_CONFIG="$STRICT_PROFILES" meta agent delegate nobody true
+assert_equals 1 "$RC" "rc"
+assert_contains "Unknown delegate: nobody" "$ERR" "error"
+
+test_start "delegate_runs_command_with_delegate_env"
+AGENT_PROFILE_CONFIG="$STRICT_PROFILES" meta agent delegate lint-checker \
+  bash -c 'echo "d=$DOT_AGENT_DELEGATE parent=$DOT_AGENT_PARENT_PROFILE steps=$DOT_AGENT_MAX_STEPS"'
+assert_equals 0 "$RC" "rc"
+assert_contains "d=lint-checker parent=ask steps=2" "$OUT" "delegate env"
+assert_contains "completed" "$OUT" "success line"
+
+test_start "delegate_reports_failure"
+AGENT_PROFILE_CONFIG="$STRICT_PROFILES" meta agent delegate lint-checker bash -c 'exit 4'
+assert_equals 4 "$RC" "rc"
+assert_contains "failed (exit 4)" "$OUT" "failure line"
+
+echo "RESULTS:$TESTS_RUN:$TESTS_PASSED:$TESTS_FAILED"

--- a/tests/unit/dot-cli/test_dot_agent_dispatch.sh
+++ b/tests/unit/dot-cli/test_dot_agent_dispatch.sh
@@ -1,0 +1,234 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2015-2026 Sebastien Rousseau
+# shellcheck disable=SC1090,SC1091,SC2034
+# Behavioural coverage for the profile arms of scripts/dot/commands/agent.sh
+# (`cmd_mode`: current/list/show/set/run/doctor/card/log) driven through the
+# real dispatcher (`meta.sh mode|agent …`) inside the coverage sandbox. Each
+# arm gets a success path and each `die` guard a failure path; results are
+# asserted on exit code, stdout, stderr and files written under $HOME.
+#
+# Split across three files (…_dispatch / …_checkpoint / …_a2a) so each stays
+# well inside the coverage runner's 60s per-file budget.
+#
+# Child stderr is captured to a file and replayed to our own stderr so the
+# xtrace records the coverage runner relies on are not swallowed.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+source "$SCRIPT_DIR/../../framework/assertions.sh"
+source "$SCRIPT_DIR/../../framework/coverage_helpers.sh"
+
+META="$REPO_ROOT/scripts/dot/commands/meta.sh"
+AGENT_MODULE="$REPO_ROOT/scripts/dot/commands/agent.sh"
+REAL_PROFILES="$REPO_ROOT/defaults/dot_config/dotfiles/agent-profiles.json"
+
+trap cov_teardown_sandbox EXIT
+cov_setup_sandbox
+
+STATE_DIR="$XDG_STATE_HOME/dotfiles"
+CHECKPOINT_DIR="$STATE_DIR/checkpoints"
+SESSIONS="$STATE_DIR/agent-sessions.jsonl"
+
+# `timeout` (used by `agent delegate`) is coreutils-only on macOS; shim it so
+# the delegate arm is deterministic on every platform.
+cat >"$DOTFILES_COV_TMPDIR/bin/timeout" <<'EOF'
+#!/usr/bin/env bash
+shift
+exec "$@"
+EOF
+chmod +x "$DOTFILES_COV_TMPDIR/bin/timeout"
+
+# run_cmd <cmd…> — sets OUT / ERR / RC. stderr is replayed (xtrace-safe).
+run_cmd() {
+  local errf="$DOTFILES_COV_TMPDIR/stderr.$$"
+  OUT="$("$@" 2>"$errf" </dev/null)"
+  RC=$?
+  ERR="$(grep -v '^+*@COV@' "$errf" 2>/dev/null || true)"
+  [[ "${DOTFILES_COV_ECHO_STDERR:-0}" == "1" ]] && cat "$errf" >&2
+  rm -f "$errf"
+  return 0
+}
+
+meta() { run_cmd bash "$META" "$@"; }
+
+test_start "module_defines_cmd_mode"
+assert_file_contains "$AGENT_MODULE" "cmd_mode()" "agent.sh defines cmd_mode"
+
+# ── current / list / show ───────────────────────────────────────────────
+test_start "mode_no_args_reports_current_profile_from_state_file"
+meta mode
+assert_equals 0 "$RC" "rc"
+assert_contains "Agent Mode" "$OUT" "header"
+assert_contains "ask" "$OUT" "sandbox state file says ask"
+
+test_start "mode_flag_only_falls_back_to_current"
+meta mode --verbose
+assert_equals 0 "$RC" "rc"
+assert_contains "Profile" "$OUT" "current arm ran"
+
+test_start "mode_current_without_state_file_uses_default_profile"
+AGENT_STATE_FILE="$HOME/.config/dotfiles/does-not-exist.env" meta mode current
+assert_equals 0 "$RC" "rc"
+assert_contains "ask" "$OUT" "defaultProfile is ask"
+
+test_start "mode_list_marks_current"
+meta mode list
+assert_equals 0 "$RC" "rc"
+assert_contains "Agent Modes" "$OUT" "header"
+assert_contains "[current]" "$OUT" "current marker"
+assert_contains "plan" "$OUT" "other profiles listed"
+
+test_start "agent_alias_dispatches_to_cmd_mode"
+meta agent list
+assert_equals 0 "$RC" "rc"
+assert_contains "Agent Modes" "$OUT" "alias works"
+
+test_start "mode_show_requires_name"
+meta mode show
+assert_equals 1 "$RC" "rc"
+assert_contains "Usage: dot mode show" "$ERR" "usage on stderr"
+
+test_start "mode_show_rejects_unknown_profile"
+meta mode show nope
+assert_equals 1 "$RC" "rc"
+assert_contains "Unknown agent profile: nope" "$ERR" "error"
+
+test_start "mode_show_prints_profile_fields"
+meta mode show plan
+assert_equals 0 "$RC" "rc"
+assert_contains "Max steps" "$OUT" "maxSteps row"
+assert_contains "Description" "$OUT" "description row"
+
+# ── set (+ RBAC) ────────────────────────────────────────────────────────
+test_start "mode_set_requires_name"
+meta mode set
+assert_equals 1 "$RC" "rc"
+assert_contains "Usage: dot mode set" "$ERR" "usage"
+
+test_start "mode_set_rejects_unknown_profile"
+meta mode set nope
+assert_equals 1 "$RC" "rc"
+assert_contains "Unknown agent profile" "$ERR" "error"
+
+test_start "mode_set_writes_state_file"
+STATE="$HOME/.config/dotfiles/agent-mode.env"
+meta mode set plan
+assert_equals 0 "$RC" "rc"
+assert_file_contains "$STATE" "DOT_AGENT_PROFILE=plan" "profile persisted"
+assert_file_contains "$STATE" "DOT_AGENT_MAX_STEPS=" "policy fields persisted"
+assert_file_contains "$SESSIONS" '"event":"set"' "session log appended"
+
+test_start "mode_set_advisory_rbac_warns_but_proceeds"
+printf 'DOT_AGENT_PROFILE=ask\nDOT_AGENT_ROLE=viewer\n' >"$STATE"
+meta mode set apply
+assert_equals 0 "$RC" "rc (advisory)"
+assert_contains "RBAC" "$OUT" "advisory warning printed"
+assert_file_contains "$STATE" "DOT_AGENT_PROFILE=apply" "still applied"
+
+STRICT_PROFILES="$DOTFILES_COV_TMPDIR/strict-profiles.json"
+jq '.rbac.enforcement = "strict" | .delegation.enabled = true | .profiles.ask.canDelegate = true' \
+  "$REAL_PROFILES" >"$STRICT_PROFILES"
+
+test_start "mode_set_strict_rbac_refuses"
+printf 'DOT_AGENT_PROFILE=ask\nDOT_AGENT_ROLE=viewer\n' >"$STATE"
+AGENT_PROFILE_CONFIG="$STRICT_PROFILES" meta mode set apply
+assert_equals 1 "$RC" "rc"
+assert_contains "enforcement: strict" "$ERR" "strict refusal"
+assert_file_contains "$STATE" "DOT_AGENT_PROFILE=ask" "state untouched"
+printf 'DOT_AGENT_PROFILE=ask\n' >"$STATE"
+
+# ── run ─────────────────────────────────────────────────────────────────
+test_start "mode_run_requires_command"
+meta mode run
+assert_equals 1 "$RC" "rc"
+assert_contains "Usage: dot mode run" "$ERR" "usage"
+
+test_start "mode_run_uses_current_profile_and_exports_env"
+meta mode run bash -c 'echo "p=$DOT_AGENT_PROFILE fs=$DOT_AGENT_FILESYSTEM"'
+assert_equals 0 "$RC" "rc"
+assert_contains "p=ask fs=read-only" "$OUT" "profile env exported to child"
+assert_file_contains "$SESSIONS" '"event":"run_finish"' "run logged"
+
+test_start "mode_run_with_explicit_profile"
+meta mode run plan bash -c 'echo "p=$DOT_AGENT_PROFILE"'
+assert_equals 0 "$RC" "rc"
+assert_contains "p=plan" "$OUT" "explicit profile"
+
+test_start "mode_run_propagates_failure_exit_code"
+meta mode run bash -c 'exit 3'
+assert_equals 3 "$RC" "child rc propagated"
+assert_file_contains "$SESSIONS" '"status":"failed"' "failure logged"
+
+# ── doctor ──────────────────────────────────────────────────────────────
+test_start "mode_doctor_ok"
+meta mode doctor
+assert_equals 0 "$RC" "rc"
+assert_contains "Default profile" "$OUT" "default profile reported"
+
+test_start "mode_doctor_invalid_json"
+printf '{not json' >"$DOTFILES_COV_TMPDIR/bad.json"
+AGENT_PROFILE_CONFIG="$DOTFILES_COV_TMPDIR/bad.json" meta mode doctor
+assert_equals 1 "$RC" "rc"
+assert_contains "Invalid JSON" "$ERR" "error"
+
+test_start "mode_doctor_missing_default_profile"
+jq 'del(.defaultProfile)' "$REAL_PROFILES" >"$DOTFILES_COV_TMPDIR/nodefault.json"
+AGENT_PROFILE_CONFIG="$DOTFILES_COV_TMPDIR/nodefault.json" meta mode doctor
+assert_equals 1 "$RC" "rc"
+assert_contains "Default profile missing" "$ERR" "error"
+
+test_start "mode_dies_when_profile_config_missing"
+AGENT_PROFILE_CONFIG="$DOTFILES_COV_TMPDIR/absent.json" meta mode list
+assert_equals 1 "$RC" "rc"
+assert_contains "Agent profile config not found" "$ERR" "error"
+
+test_start "mode_dies_without_jq"
+NOJQ="$DOTFILES_COV_TMPDIR/nojq"
+mkdir -p "$NOJQ"
+# Link every PATH entry into one farm, minus jq, so `command -v jq` fails
+# while the rest of the environment still works. System dirs are linked
+# first because a PATH entry may hold a *directory* whose name shadows a
+# real command (PowerShell ships a `tr` locale dir); the pruning pass then
+# drops any link that did not resolve to a file.
+IFS=: read -ra _dirs <<<"$PATH"
+_link_dirs() {
+  local _d
+  for _d in "$@"; do
+    [[ -d "$_d" ]] && ln -s "$_d"/* "$NOJQ"/ 2>/dev/null
+  done
+  return 0
+}
+_link_dirs /usr/bin /bin /usr/sbin /sbin
+_link_dirs "${_dirs[@]}"
+for _l in "$NOJQ"/*; do [[ -f "$_l" ]] || rm -f "$_l"; done
+_link_dirs /usr/bin /bin /usr/sbin /sbin
+rm -f "$NOJQ/jq"
+PATH="$NOJQ" meta mode list
+assert_equals 1 "$RC" "rc"
+assert_contains "jq is required" "$ERR" "error"
+
+# ── card / log ──────────────────────────────────────────────────────────
+test_start "mode_card_renders_table"
+meta mode card
+assert_equals 0 "$RC" "rc"
+assert_contains "Agent Card" "$OUT" "header"
+assert_contains "Protocols" "$OUT" "protocol row"
+
+test_start "mode_card_json_cats_file"
+meta mode card --json
+assert_equals 0 "$RC" "rc"
+assert_true "printf '%s' \"\$OUT\" | jq -e .name >/dev/null" "raw JSON emitted"
+
+test_start "mode_card_missing_file"
+AGENT_CARD_CONFIG="$DOTFILES_COV_TMPDIR/no-card.json" meta mode card
+assert_equals 1 "$RC" "rc"
+assert_contains "Agent card not found" "$ERR" "error"
+
+test_start "mode_log_tails_sessions"
+meta mode log 2
+assert_equals 0 "$RC" "rc"
+assert_contains '"event":"log"' "$OUT" "tail contains the log event itself"
+
+echo "RESULTS:$TESTS_RUN:$TESTS_PASSED:$TESTS_FAILED"

--- a/tests/unit/dot-cli/test_dot_agent_dispatch.sh
+++ b/tests/unit/dot-cli/test_dot_agent_dispatch.sh
@@ -200,11 +200,23 @@ _link_dirs() {
   done
   return 0
 }
+# Building the farm expands to `ln -s` calls with ~900 arguments each. Under
+# the coverage runner every one of those is an xtrace record tens of KB long,
+# and records that big come back truncated — corrupting the trace around
+# them. Turn tracing off for the farm only, then back on.
+_xtrace_was_on=0
+case "$-" in *x*) _xtrace_was_on=1 ;; esac
+set +x
 _link_dirs /usr/bin /bin /usr/sbin /sbin
 _link_dirs "${_dirs[@]}"
 for _l in "$NOJQ"/*; do [[ -f "$_l" ]] || rm -f "$_l"; done
 _link_dirs /usr/bin /bin /usr/sbin /sbin
 rm -f "$NOJQ/jq"
+# Keep the *current* bash: on macOS the farm would otherwise resolve `bash`
+# to /bin/bash 3.2, whose xtrace truncates the PS4 expansion at 100 chars —
+# every coverage record from the child would be malformed and dropped.
+ln -sf "$(command -v bash)" "$NOJQ/bash"
+[[ "$_xtrace_was_on" == "1" ]] && set -x
 PATH="$NOJQ" meta mode list
 assert_equals 1 "$RC" "rc"
 assert_contains "jq is required" "$ERR" "error"

--- a/tests/unit/dot-cli/test_dot_ai_commands_lib.sh
+++ b/tests/unit/dot-cli/test_dot_ai_commands_lib.sh
@@ -1,0 +1,332 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2015-2026 Sebastien Rousseau
+# shellcheck disable=SC1090,SC1091,SC2034
+# Behavioural coverage for lib/dot/ai-commands.sh — the `dot ai` subcommand
+# bodies. The library is sourced the way ai.sh sources it (utils.sh first),
+# with `run_ai_with_context` supplied by the caller as ai.sh does.
+#
+# Every AI CLI, the gateway helper and the /vibe delegator are sandbox stubs
+# that record their argv, so provider dispatch, install mapping and the cost
+# and delegate paths are asserted without a single real tool or network call.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+source "$SCRIPT_DIR/../../framework/assertions.sh"
+source "$SCRIPT_DIR/../../framework/coverage_helpers.sh"
+
+AI_COMMANDS="$REPO_ROOT/lib/dot/ai-commands.sh"
+REAL_BASH="$(command -v bash)"
+
+trap cov_teardown_sandbox EXIT
+cov_setup_sandbox
+
+BIN="$DOTFILES_COV_TMPDIR/bin"
+OUTF="$DOTFILES_COV_TMPDIR/ai-out.txt"
+ERRF="$DOTFILES_COV_TMPDIR/ai-err.txt"
+export AI_CALLS="$DOTFILES_COV_TMPDIR/ai-calls.txt"
+
+# stub <name> — a recording stub that also echoes any stdin it is given.
+stub() {
+  cat >"$BIN/$1" <<STUB
+#!$REAL_BASH
+printf '$1 %s\\n' "\$*" >>"\$AI_CALLS"
+if [[ ! -t 0 ]]; then
+  while IFS= read -r _l || [[ -n "\$_l" ]]; do printf '$1-stdin %s\\n' "\$_l" >>"\$AI_CALLS"; done
+fi
+exit 0
+STUB
+  chmod +x "$BIN/$1"
+}
+
+for t in claude codex copilot agy goose crush amp cursor-agent grok kimi \
+  kiro-cli sgpt ollama opencode aider autohand vibe qwen zai \
+  dot-ai-proxy dot-ai-serve mise; do
+  stub "$t"
+done
+
+# run_ai_with_context is defined by the ai.sh dispatcher, not by the library;
+# provide the same seam here so _ai_oneshot can be exercised.
+ai() {
+  : >"$AI_CALLS"
+  (
+    source "$REPO_ROOT/lib/dot/utils.sh"
+    run_ai_with_context() {
+      printf 'run_ai_with_context %s\n' "$*" >>"$AI_CALLS"
+    }
+    source "$AI_COMMANDS"
+    "$@"
+  ) >"$OUTF" 2>"$ERRF" </dev/null
+  RC=$?
+  # stderr goes to a file and is replayed to ours: redirecting it away would
+  # take the child's xtrace with it, losing the coverage of every line the
+  # failing path executed.
+  [[ "${DOTFILES_COV_ECHO_STDERR:-0}" == "1" ]] && cat "$ERRF" >&2
+  return 0
+}
+out_has() { assert_file_contains "$OUTF" "$1" "${2:-output contains $1}"; }
+err_has() { assert_file_contains "$ERRF" "$1" "${2:-stderr contains $1}"; }
+called() { assert_file_contains "$AI_CALLS" "$1" "invoked $1"; }
+
+# ai_min — same, but with PATH cut down to the sandbox stubs plus the system
+# directories. The host running this suite really does have some of the fleet
+# installed, so the "not installed" branches need everything else hidden.
+ai_min() {
+  PATH="$BIN:${REAL_BASH%/*}:/usr/bin:/bin:/usr/sbin:/sbin" ai "$@"
+}
+
+test_start "library_exists_and_parses"
+assert_file_exists "$AI_COMMANDS" "ai-commands.sh must exist"
+assert_true "bash -n '$AI_COMMANDS'" "valid bash syntax"
+
+# ── provider dispatch ───────────────────────────────────────────────────
+test_start "claude_receives_the_prompt_on_stdin"
+ai _ai_invoke_provider claude "write a test"
+assert_equals 0 "$RC" "rc"
+called "claude-stdin write a test"
+
+test_start "flag_style_providers_get_the_prompt_as_an_argument"
+ai _ai_invoke_provider copilot "hello"
+assert_equals 0 "$RC" "rc"
+called "copilot -sp hello"
+ai _ai_invoke_provider goose "hello"
+called "goose run -t hello"
+ai _ai_invoke_provider crush "hello"
+called "crush run hello"
+ai _ai_invoke_provider amp "hello"
+called "amp -x hello"
+ai _ai_invoke_provider cursor "hello"
+called "cursor-agent -p hello"
+ai _ai_invoke_provider grok "hello"
+called "grok --no-auto-update -p hello"
+ai _ai_invoke_provider kimi "hello"
+called "kimi -p hello --quiet"
+
+test_start "stdin_style_providers_pipe_the_prompt"
+ai _ai_invoke_provider agy "hello"
+called "agy chat"
+ai _ai_invoke_provider kiro "hello"
+called "kiro-cli chat"
+ai _ai_invoke_provider sgpt "hello"
+called "sgpt --chat shell-gpt"
+ai _ai_invoke_provider ollama "hello"
+called "ollama run llama3.2"
+ai _ai_invoke_provider opencode "hello"
+called "opencode query"
+ai _ai_invoke_provider aider "hello"
+called "aider --msg -"
+ai _ai_invoke_provider vibe "hello"
+called "vibe chat"
+ai _ai_invoke_provider qwen "hello"
+called "qwen chat"
+ai _ai_invoke_provider zai "hello"
+called "zai chat"
+ai _ai_invoke_provider autohand "hello"
+called "autohand chat"
+ai _ai_invoke_provider codex "hello"
+called "codex-stdin hello"
+
+test_start "an_unsupported_tool_is_rejected_with_rc2"
+ai _ai_invoke_provider nosuchtool "hello"
+assert_equals 2 "$RC" "rc"
+out_has "Unsupported tool" "error"
+
+test_start "a_failing_provider_propagates_its_exit_code"
+cat >"$BIN/claude" <<STUB
+#!$REAL_BASH
+exit 9
+STUB
+chmod +x "$BIN/claude"
+ai _ai_invoke_provider claude "hello"
+assert_equals 9 "$RC" "rc"
+stub claude
+
+# ── oneshot ─────────────────────────────────────────────────────────────
+test_start "oneshot_defaults_to_claude"
+ai _ai_oneshot "explain this"
+assert_equals 0 "$RC" "rc"
+called "run_ai_with_context claude explain this"
+
+test_start "oneshot_accepts_a_leading_tool_name"
+ai _ai_oneshot codex "explain this"
+assert_equals 0 "$RC" "rc"
+called "run_ai_with_context codex explain this"
+
+test_start "a_non_tool_first_word_stays_part_of_the_prompt"
+ai _ai_oneshot "codexish prompt"
+assert_equals 0 "$RC" "rc"
+called "run_ai_with_context claude codexish prompt"
+
+# ── cockpit / chat ──────────────────────────────────────────────────────
+test_start "cockpit_runs_the_fallback_when_the_tui_is_absent"
+ai _ai_cockpit printf 'fallback ran\n'
+assert_equals 0 "$RC" "rc"
+out_has "fallback ran" "fallback output"
+
+test_start "chat_without_a_tool_falls_back_to_status"
+ai bash -c 'cmd_ai_status() { echo "status listing"; }; source "$0"; cmd_ai_chat' "$AI_COMMANDS"
+assert_equals 0 "$RC" "rc"
+out_has "status listing" "status shown"
+
+test_start "chat_with_an_uninstalled_tool_reports_it"
+ai cmd_ai_chat definitely-not-installed
+assert_equals 1 "$RC" "rc"
+out_has "not installed" "error"
+
+# ── serve ───────────────────────────────────────────────────────────────
+test_start "serve_start_routes_the_fleet_through_the_proxy"
+ai _ai_serve
+assert_equals 0 "$RC" "rc"
+called "dot-ai-proxy start"
+called "dot-ai-proxy local on"
+
+test_start "serve_stop_unroutes_and_stops"
+ai _ai_serve stop
+assert_equals 0 "$RC" "rc"
+called "dot-ai-proxy local off"
+called "dot-ai-proxy stop"
+
+test_start "serve_status_logs_and_setup_are_forwarded"
+ai _ai_serve status
+called "dot-ai-proxy status"
+ai _ai_serve logs -f
+called "dot-ai-proxy logs -f"
+ai _ai_serve setup
+called "dot-ai-proxy setup"
+
+test_start "serve_rejects_an_unknown_subcommand"
+ai _ai_serve nonsense
+assert_equals 1 "$RC" "rc"
+out_has "dot ai serve [stop|status|logs|setup]" "usage"
+
+test_start "serve_requires_the_proxy_helper"
+rm -f "$BIN/dot-ai-proxy"
+ai_min _ai_serve
+assert_equals 1 "$RC" "rc"
+out_has "not found — run: chezmoi apply" "hint"
+stub dot-ai-proxy
+
+# ── doctor ──────────────────────────────────────────────────────────────
+test_start "doctor_reports_the_fleet_and_the_gateway"
+ai cmd_ai_doctor
+assert_equals 0 "$RC" "rc"
+out_has "AI doctor" "header"
+out_has "claude CLI" "engine row"
+out_has "gateway engine" "gateway row"
+out_has "Fleet" "fleet tally"
+called "dot-ai-proxy status"
+
+test_start "doctor_flags_a_missing_engine_and_gateway"
+NONE="$DOTFILES_COV_TMPDIR/nofleet"
+mkdir -p "$NONE"
+ln -sf "$REAL_BASH" "$NONE/bash"
+for c in printf cat sed grep tr cut awk dirname basename head tty locale uname date \
+  rm mkdir realpath readlink mktemp chmod wc touch sort id; do
+  p="$(command -v "$c" 2>/dev/null)" && ln -sf "$p" "$NONE/$c"
+done
+PATH="$NONE" ai cmd_ai_doctor
+assert_equals 0 "$RC" "rc"
+out_has "not installed (the gateway engine needs it)" "engine missing"
+out_has "dot-ai-serve not deployed" "gateway missing"
+out_has "0/19 tools installed" "empty fleet"
+
+# ── install ─────────────────────────────────────────────────────────────
+test_start "install_reports_a_complete_fleet"
+ai_min cmd_ai_install
+assert_equals 0 "$RC" "rc"
+out_has "all tools already installed" "nothing to do"
+
+test_start "installing_an_already_present_tool_is_a_no_op"
+ai_min cmd_ai_install codex
+assert_equals 0 "$RC" "rc"
+out_has "already installed" "no-op"
+
+test_start "a_missing_tool_is_installed_through_mise"
+rm -f "$BIN/opencode"
+ai_min cmd_ai_install opencode
+assert_equals 0 "$RC" "rc"
+called "mise use -g npm:opencode-ai@latest"
+out_has "installed" "success line"
+stub opencode
+
+test_start "a_tool_with_no_installer_mapping_is_skipped"
+ai_min cmd_ai_install definitely-not-a-tool
+assert_equals 0 "$RC" "rc"
+out_has "no installer mapping — skipping" "warning"
+
+test_start "native_installers_are_preferred_for_the_tools_that_have_one"
+rm -f "$BIN/claude" "$BIN/goose"
+ai_min cmd_ai_install
+assert_equals 0 "$RC" "rc"
+out_has "Installing" "progress line"
+stub claude
+stub goose
+
+test_start "an_empty_fleet_routes_each_tool_to_its_installer"
+# With nothing on PATH every tool is missing, so each native-installer arm
+# and the mise mapping arm runs. The native installers fetch over the
+# network, which cannot happen here (no curl on this PATH), and the
+# library's contract is that a failed install is reported, never fatal.
+PATH="$NONE" ai cmd_ai_install
+assert_equals 0 "$RC" "rc"
+out_has "Installing" "progress line"
+out_has "19 missing tool(s)" "the whole fleet is missing"
+out_has "mise not available" "the mise arm reports the missing installer"
+out_has "run 'dot ai tools' to verify" "closing hint"
+
+# ── delegate / cost ─────────────────────────────────────────────────────
+VIBE_TOOLS="$HOME/.claude/skills/vibe/tools"
+mkdir -p "$VIBE_TOOLS"
+cat >"$VIBE_TOOLS/vibe-delegate" <<STUB
+#!$REAL_BASH
+printf 'vibe-delegate %s\\n' "\$*" >>"\$AI_CALLS"
+STUB
+cat >"$VIBE_TOOLS/delegate-report" <<STUB
+#!$REAL_BASH
+printf 'delegate-report %s\\n' "\$*" >>"\$AI_CALLS"
+STUB
+chmod +x "$VIBE_TOOLS/vibe-delegate" "$VIBE_TOOLS/delegate-report"
+
+test_start "delegate_requires_a_prompt"
+ai cmd_ai_delegate
+assert_equals 1 "$RC" "rc"
+out_has "dot ai delegate" "usage"
+
+test_start "delegate_passes_cwd_prompt_and_bounds_to_the_delegator"
+ai cmd_ai_delegate "add a changelog entry" 4 reviewer 90
+assert_equals 0 "$RC" "rc"
+called "vibe-delegate"
+assert_file_contains "$AI_CALLS" "add a changelog entry 4 reviewer 90" "argv forwarded"
+
+test_start "delegate_defaults_the_optional_bounds"
+ai cmd_ai_delegate "just the prompt"
+assert_equals 0 "$RC" "rc"
+assert_file_contains "$AI_CALLS" "just the prompt 10  180" "defaults applied"
+
+test_start "delegate_requires_the_vibe_cli"
+rm -f "$BIN/vibe"
+ai_min cmd_ai_delegate "prompt"
+assert_equals 1 "$RC" "rc"
+out_has "mise use -g pipx:mistral-vibe" "install hint"
+stub vibe
+
+test_start "delegate_reports_a_missing_delegator_tool"
+mv "$VIBE_TOOLS/vibe-delegate" "$VIBE_TOOLS/vibe-delegate.bak"
+ai cmd_ai_delegate "prompt"
+assert_equals 1 "$RC" "rc"
+err_has "not found at" "error names the path"
+err_has "chezmoi apply" "hint"
+mv "$VIBE_TOOLS/vibe-delegate.bak" "$VIBE_TOOLS/vibe-delegate"
+
+test_start "cost_forwards_to_the_delegate_report"
+ai cmd_ai_cost --since 7d
+assert_equals 0 "$RC" "rc"
+called "delegate-report --since 7d"
+
+test_start "deprecation_notice_names_the_new_command"
+ai _ai_deprecated "dot ai chat"
+assert_equals 0 "$RC" "rc"
+err_has "use: dot ai chat" "hint"
+
+echo "RESULTS:$TESTS_RUN:$TESTS_PASSED:$TESTS_FAILED"

--- a/tests/unit/dot-cli/test_dot_completion_output.sh
+++ b/tests/unit/dot-cli/test_dot_completion_output.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2015-2026 Sebastien Rousseau
+# shellcheck disable=SC1090,SC1091,SC2034
+# Behavioural coverage for scripts/dot/commands/completion.sh: the generated
+# completion for each supported shell is asserted against the canonical
+# `_dot_help_specs` registry in bin/dot — commands appear, subcommands are
+# split parent/child, and the quoting-hostile characters are stripped.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+source "$SCRIPT_DIR/../../framework/assertions.sh"
+source "$SCRIPT_DIR/../../framework/coverage_helpers.sh"
+
+COMPLETION="$REPO_ROOT/scripts/dot/commands/completion.sh"
+
+trap cov_teardown_sandbox EXIT
+cov_setup_sandbox
+
+OUTF="$DOTFILES_COV_TMPDIR/completion.txt"
+ERRF="$DOTFILES_COV_TMPDIR/completion-err.txt"
+
+# completion <shell> — `dot completion <shell>`: $1 is the command name.
+completion() {
+  bash "$COMPLETION" completion "$@" >"$OUTF" </dev/null
+  RC=$?
+  return 0
+}
+out_has() { assert_file_contains "$OUTF" "$1" "${2:-output contains $1}"; }
+
+test_start "script_exists_and_parses"
+assert_file_exists "$COMPLETION" "completion.sh must exist"
+assert_true "bash -n '$COMPLETION'" "valid bash syntax"
+
+test_start "no_shell_prints_usage"
+completion
+assert_equals 0 "$RC" "rc"
+out_has "Usage: dot completion <bash|zsh|fish|nu>" "usage"
+
+test_start "help_prints_usage"
+completion --help
+assert_equals 0 "$RC" "rc"
+out_has "Generate shell completion" "usage body"
+
+test_start "unknown_shell_fails_with_a_hint"
+# stderr to its own file (never merged into stdout): redirecting it away
+# would take the child's xtrace with it.
+bash "$COMPLETION" completion tcsh >"$OUTF" 2>"$ERRF" </dev/null
+RC=$?
+[[ "${DOTFILES_COV_ECHO_STDERR:-0}" == "1" ]] && cat "$ERRF" >&2
+assert_equals 1 "$RC" "rc"
+assert_file_contains "$ERRF" "unknown shell 'tcsh'" "error names the shell"
+assert_file_contains "$ERRF" "want: bash|zsh|fish|nu" "hint"
+
+test_start "bash_completion_is_a_single_complete_w_line"
+completion bash
+assert_equals 0 "$RC" "rc"
+out_has "# dot bash completion" "header comment"
+out_has "complete -W" "word list"
+out_has "doctor" "a real command is present"
+assert_true "grep -q \"' dot\$\" '$OUTF' || grep -q \"complete -W '.*' dot\" '$OUTF'" "ends with the dot binding"
+
+test_start "zsh_completion_is_a_compdef_function"
+completion zsh
+assert_equals 0 "$RC" "rc"
+out_has "#compdef dot" "compdef header"
+out_has "_describe" "describe call"
+out_has "'doctor:" "name:description pair"
+# Only the trailing `_dot "$@"` call may carry a double quote: every
+# description has its quoting-hostile characters stripped.
+assert_equals "1" "$(grep -c '\"' "$OUTF")" "descriptions carry no double quotes"
+
+test_start "fish_completion_covers_commands_and_subcommands"
+completion fish
+assert_equals 0 "$RC" "rc"
+out_has "complete -c dot -f" "reset line"
+out_has "__fish_use_subcommand" "top-level completions"
+out_has "__fish_seen_subcommand_from" "subcommand completions"
+out_has "-a doctor" "a real command"
+
+test_start "nu_completion_declares_an_extern"
+completion nu
+assert_equals 0 "$RC" "rc"
+out_has "export extern dot" "extern declaration"
+out_has "def dot_commands" "completer function"
+out_has 'value: "doctor"' "a real command"
+
+test_start "nushell_is_an_accepted_alias_for_nu"
+completion nushell
+assert_equals 0 "$RC" "rc"
+out_has "export extern dot" "same generator"
+
+test_start "every_shell_lists_the_same_command_set"
+completion bash
+bash_names="$(grep -o "complete -W '[^']*'" "$OUTF" | sed "s/complete -W '//; s/'$//" | tr ' ' '\n' | sort -u | grep -c .)"
+completion zsh
+zsh_names="$(grep -c "^    '" "$OUTF")"
+assert_equals "$bash_names" "$zsh_names" "bash and zsh agree on the command count"
+assert_true "[[ $bash_names -gt 10 ]]" "the registry is non-trivial"
+
+echo "RESULTS:$TESTS_RUN:$TESTS_PASSED:$TESTS_FAILED"

--- a/tests/unit/dot-cli/test_dot_diagnostics_dispatch.sh
+++ b/tests/unit/dot-cli/test_dot_diagnostics_dispatch.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2015-2026 Sebastien Rousseau
+# shellcheck disable=SC1090,SC1091,SC2034
+# Behavioural coverage for scripts/dot/commands/diagnostics.sh — the `dot`
+# diagnostics dispatcher. Every arm hands off with `exec bash <script>`,
+# `exec chezmoi …` or `command dot-load-benchmark`, so the suite puts a
+# recording stub for each of those first on PATH and asserts *what the
+# dispatcher handed off to*. The dispatcher itself is started through an
+# absolute bash path so the stub only ever catches the hand-off.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+source "$SCRIPT_DIR/../../framework/assertions.sh"
+source "$SCRIPT_DIR/../../framework/coverage_helpers.sh"
+
+DIAG="$REPO_ROOT/scripts/dot/commands/diagnostics.sh"
+REAL_BASH="$(command -v bash)"
+
+trap cov_teardown_sandbox EXIT
+cov_setup_sandbox
+
+BIN="$DOTFILES_COV_TMPDIR/bin"
+OUTF="$DOTFILES_COV_TMPDIR/out.txt"
+export DISPATCH_LOG="$DOTFILES_COV_TMPDIR/dispatch.log"
+
+# The stub's own shebang must name the real bash by absolute path: a
+# `#!/usr/bin/env bash` shebang would resolve back through PATH to the stub
+# itself and fork-bomb.
+cat >"$BIN/bash" <<STUB
+#!$REAL_BASH
+printf '%s\n' "\$*" >>"\$DISPATCH_LOG"
+exit 0
+STUB
+cat >"$BIN/dot-load-benchmark" <<STUB
+#!$REAL_BASH
+printf 'dot-load-benchmark %s\n' "\$*" >>"\$DISPATCH_LOG"
+exit 0
+STUB
+cat >"$BIN/dot-load-benchmark-pty" <<STUB
+#!$REAL_BASH
+printf 'dot-load-benchmark-pty %s\n' "\$*" >>"\$DISPATCH_LOG"
+exit 0
+STUB
+cat >"$BIN/chezmoi" <<STUB
+#!$REAL_BASH
+printf 'chezmoi %s\n' "\$*" >>"\$DISPATCH_LOG"
+exit 0
+STUB
+chmod +x "$BIN/bash" "$BIN/dot-load-benchmark" "$BIN/dot-load-benchmark-pty" "$BIN/chezmoi"
+
+# diag <args…> — run the dispatcher via the real bash, capture stdout+status.
+diag() {
+  : >"$DISPATCH_LOG"
+  "$REAL_BASH" "$DIAG" "$@" >"$OUTF" </dev/null
+  RC=$?
+  return 0
+}
+out_has() { assert_file_contains "$OUTF" "$1" "${2:-output contains $1}"; }
+# handed_to <needle> — assert the dispatcher exec'd the expected target.
+handed_to() { assert_file_contains "$DISPATCH_LOG" "$1" "hands off to $1"; }
+
+test_start "script_exists_and_parses"
+assert_file_exists "$DIAG" "diagnostics.sh must exist"
+assert_true "bash -n '$DIAG'" "valid bash syntax"
+
+test_start "help_lists_the_commands"
+diag --help
+assert_equals 0 "$RC" "rc"
+out_has "Usage: diagnostics.sh" "usage"
+out_has "doctor, heal, health" "command list"
+
+test_start "no_command_prints_usage_and_fails"
+diag
+assert_equals 1 "$RC" "rc"
+out_has "Usage: diagnostics.sh" "usage"
+
+test_start "unknown_command_fails"
+diag definitely-not-a-command
+assert_equals 1 "$RC" "rc"
+
+test_start "doctor_prefers_the_unified_doctor"
+diag doctor --json
+assert_equals 0 "$RC" "rc"
+handed_to "scripts/diagnostics/doctor-unified.sh --json"
+
+test_start "drift_hands_off_to_the_drift_dashboard"
+diag drift --json
+assert_equals 0 "$RC" "rc"
+handed_to "scripts/diagnostics/drift-dashboard.sh --json"
+
+# Each remaining arm is a one-line `run_script` hand-off; assert the pairing
+# of subcommand to target script (and that arguments are forwarded).
+run_script_case() {
+  local sub="$1" target="$2"
+  test_start "${sub//-/_}_hands_off_to_${target##*/}"
+  diag "$sub" --flag-forwarded
+  assert_equals 0 "$RC" "rc"
+  handed_to "$target --flag-forwarded"
+}
+
+run_script_case heal scripts/ops/heal.sh
+run_script_case health scripts/diagnostics/health.sh
+run_script_case health-check scripts/diagnostics/health.sh
+run_script_case security-score scripts/diagnostics/security-score.sh
+run_script_case scorecard scripts/diagnostics/scorecard.sh
+run_script_case score scripts/diagnostics/scorecard.sh
+run_script_case perf scripts/diagnostics/perf.sh
+run_script_case conflicts scripts/diagnostics/conflicts.sh
+run_script_case locks scripts/diagnostics/version-locks.sh
+run_script_case snapshot scripts/diagnostics/snapshot.sh
+run_script_case attest scripts/diagnostics/workstation-attestation.sh
+run_script_case attestation scripts/diagnostics/workstation-attestation.sh
+run_script_case rollback scripts/ops/rollback.sh
+run_script_case history scripts/diagnostics/history-analysis.sh
+run_script_case benchmark scripts/diagnostics/benchmark.sh
+run_script_case verify scripts/diagnostics/verify.sh
+run_script_case restore scripts/dot/commands/restore.sh
+run_script_case chaos scripts/ops/chaos.sh
+run_script_case teleport scripts/ops/teleport.sh
+run_script_case secret-audit scripts/diagnostics/secret-governance.sh
+run_script_case bundle scripts/ops/bundle.sh
+run_script_case smoke-test scripts/diagnostics/smoke-test.sh
+run_script_case intelligence lib/dot/bento.sh
+
+test_start "load_bench_calls_the_deployed_binary"
+diag load-bench --quick
+assert_equals 0 "$RC" "rc"
+handed_to "dot-load-benchmark --quick"
+
+test_start "load_bench_pty_calls_the_pty_binary"
+diag load-bench-pty --quick
+assert_equals 0 "$RC" "rc"
+handed_to "dot-load-benchmark-pty --quick"
+
+test_start "metrics_reports_from_the_local_log"
+METRICS="$XDG_STATE_HOME/dotfiles/metrics.jsonl"
+mkdir -p "$(dirname "$METRICS")"
+printf '{"metric":"shell_startup_mean","value":42,"unit":"ms"}\n' >"$METRICS"
+diag metrics 5
+assert_equals 0 "$RC" "rc"
+out_has "Recent Metrics" "header"
+out_has "shell_startup_mean" "metric row"
+
+echo "RESULTS:$TESTS_RUN:$TESTS_PASSED:$TESTS_FAILED"

--- a/tests/unit/dot-cli/test_dot_env_emit_manifest.sh
+++ b/tests/unit/dot-cli/test_dot_env_emit_manifest.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2015-2026 Sebastien Rousseau
+# shellcheck disable=SC1090,SC1091,SC2034
+# Behavioural coverage for scripts/dot/commands/env-emit.sh (`dot env emit`):
+# flag parsing, format validation, dependency checks, the v1 JSON manifest,
+# the NDJSON variant and atomic --output writing.
+#
+# The file only *defines* dot_env_emit, so the suite sources it and calls the
+# function. `mise` is a sandbox stub returning a fixed `mise ls --json`
+# payload, so the manifest is deterministic and no real toolchain is read.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+source "$SCRIPT_DIR/../../framework/assertions.sh"
+source "$SCRIPT_DIR/../../framework/coverage_helpers.sh"
+
+EMIT="$REPO_ROOT/scripts/dot/commands/env-emit.sh"
+
+trap cov_teardown_sandbox EXIT
+cov_setup_sandbox
+
+BIN="$DOTFILES_COV_TMPDIR/bin"
+OUTF="$DOTFILES_COV_TMPDIR/emit-out.txt"
+ERRF="$DOTFILES_COV_TMPDIR/emit-err.txt"
+
+cat >"$BIN/mise" <<'STUB'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "ls" ]]; then
+  cat "$MISE_LS_FIXTURE"
+  exit "${MISE_LS_RC:-0}"
+fi
+exit 0
+STUB
+chmod +x "$BIN/mise"
+export MISE_LS_FIXTURE="$DOTFILES_COV_TMPDIR/mise-ls.json"
+cat >"$MISE_LS_FIXTURE" <<'JSON'
+{
+  "node": [
+    {"version":"24.15.0","requested_version":"24","install_path":"/opt/node/24.15.0","active":true,
+     "source":{"type":"tool-versions","path":"/home/u/.tool-versions"}}
+  ],
+  "rust": [
+    {"version":"1.95.0"}
+  ]
+}
+JSON
+
+# emit <args…> — call dot_env_emit in a subshell, report to $OUTF.
+emit() {
+  (
+    source "$EMIT"
+    dot_env_emit "$@"
+  ) >"$OUTF" 2>"$ERRF" </dev/null
+  RC=$?
+  # stderr goes to a file and is replayed to ours: redirecting it away would
+  # take the child's xtrace with it, losing the coverage of every line the
+  # failing path executed.
+  [[ "${DOTFILES_COV_ECHO_STDERR:-0}" == "1" ]] && cat "$ERRF" >&2
+  return 0
+}
+out_has() { assert_file_contains "$OUTF" "$1" "${2:-output contains $1}"; }
+err_has() { assert_file_contains "$ERRF" "$1" "${2:-stderr contains $1}"; }
+
+test_start "script_exists_and_parses"
+assert_file_exists "$EMIT" "env-emit.sh must exist"
+assert_true "bash -n '$EMIT'" "valid bash syntax"
+
+test_start "help_documents_the_formats_and_returns_0"
+emit --help
+assert_equals 0 "$RC" "rc"
+out_has "Usage: dot env emit" "usage"
+out_has "ndjson" "ndjson documented"
+
+test_start "short_help_flag_works_too"
+emit -h
+assert_equals 0 "$RC" "rc"
+out_has "Usage: dot env emit" "usage"
+
+test_start "unknown_flag_is_rejected"
+emit --nope
+assert_equals 1 "$RC" "rc"
+out_has "unknown flag: --nope" "error"
+
+test_start "unsupported_format_is_rejected"
+emit --format yaml
+assert_equals 1 "$RC" "rc"
+out_has "unsupported format: yaml" "error"
+
+test_start "default_manifest_matches_the_v1_schema_shape"
+emit
+assert_equals 0 "$RC" "rc"
+assert_equals "1.0.0" "$(jq -r .manifest_version <"$OUTF")" "manifest_version"
+assert_equals "dot env emit" "$(jq -r .emitter.name <"$OUTF")" "emitter name"
+assert_equals "2" "$(jq -r '.tools | length' <"$OUTF")" "one record per installed version"
+assert_equals "node" "$(jq -r '.tools[0].name' <"$OUTF")" "tool name"
+assert_equals "24.15.0" "$(jq -r '.tools[0].version' <"$OUTF")" "tool version"
+assert_equals "/home/u/.tool-versions" "$(jq -r '.tools[0].source' <"$OUTF")" "source path"
+assert_equals "orphan" "$(jq -r '.tools[1].source' <"$OUTF")" "sourceless tool is an orphan"
+assert_equals "false" "$(jq -r '.tools[1].active' <"$OUTF")" "active defaults to false"
+assert_true "[[ -n \$(jq -r .host.hostname <'$OUTF') ]]" "host recorded"
+
+test_start "compact_output_is_one_line"
+emit --compact
+assert_equals 0 "$RC" "rc"
+assert_equals "1" "$(wc -l <"$OUTF" | tr -d ' ')" "single line"
+assert_equals "node" "$(jq -r '.tools[0].name' <"$OUTF")" "still valid JSON"
+
+test_start "pretty_is_the_default_and_can_be_asked_for"
+emit --pretty
+assert_equals 0 "$RC" "rc"
+assert_true "[[ \$(wc -l <'$OUTF') -gt 10 ]]" "multi-line"
+
+test_start "ndjson_puts_the_header_first_and_one_tool_per_line"
+emit --format ndjson
+assert_equals 0 "$RC" "rc"
+assert_equals "3" "$(wc -l <"$OUTF" | tr -d ' ')" "header + two tools"
+assert_equals "1.0.0" "$(head -1 "$OUTF" | jq -r .manifest_version)" "header line"
+assert_equals "node" "$(sed -n 2p "$OUTF" | jq -r .name)" "first tool line"
+
+test_start "format_can_be_given_with_an_equals_sign"
+emit --format=ndjson
+assert_equals 0 "$RC" "rc"
+assert_equals "3" "$(wc -l <"$OUTF" | tr -d ' ')" "same as the spaced form"
+
+test_start "output_flag_writes_the_manifest_atomically"
+TARGET="$DOTFILES_COV_TMPDIR/env.json"
+emit --output "$TARGET"
+assert_equals 0 "$RC" "rc"
+assert_file_exists "$TARGET" "manifest written"
+assert_equals "2" "$(jq -r '.tools | length' <"$TARGET")" "content is the manifest"
+out_has "wrote 2 tools" "summary names the count"
+assert_true "! ls '$DOTFILES_COV_TMPDIR'/env.json.?????? >/dev/null 2>&1" "no temp file left behind"
+
+test_start "output_flag_accepts_the_short_and_equals_forms"
+emit -o "$TARGET.short"
+assert_equals 0 "$RC" "rc"
+assert_file_exists "$TARGET.short" "short form"
+emit --output="$TARGET.eq"
+assert_equals 0 "$RC" "rc"
+assert_file_exists "$TARGET.eq" "equals form"
+
+test_start "a_failing_mise_is_reported_as_exit_3"
+MISE_LS_RC=1 emit
+assert_equals 3 "$RC" "rc"
+out_has "mise ls --json failed" "error"
+
+test_start "missing_dependencies_are_reported_as_exit_2"
+NODEP="$DOTFILES_COV_TMPDIR/nodep"
+mkdir -p "$NODEP"
+ln -sf "$(command -v bash)" "$NODEP/bash"
+for c in sed grep cat date uname mktemp mv tr cut awk dirname basename printf tty locale realpath readlink head; do
+  p="$(command -v "$c" 2>/dev/null)" && ln -sf "$p" "$NODEP/$c"
+done
+ln -sf "$BIN/mise" "$NODEP/mise"
+PATH="$NODEP" emit
+assert_equals 2 "$RC" "rc without jq"
+out_has "jq required" "error names jq"
+rm -f "$NODEP/mise"
+ln -sf "$(command -v jq)" "$NODEP/jq"
+PATH="$NODEP" emit
+assert_equals 2 "$RC" "rc without mise"
+out_has "mise required" "error names mise"
+
+echo "RESULTS:$TESTS_RUN:$TESTS_PASSED:$TESTS_FAILED"

--- a/tests/unit/functions/test_functions_file_ops_behaviour.sh
+++ b/tests/unit/functions/test_functions_file_ops_behaviour.sh
@@ -182,28 +182,42 @@ assert_equals 0 "$RC" "rc"
 out_has "[INFO] hello from the fallback" "fallback logger"
 
 # ── hiddenfiles ─────────────────────────────────────────────────────────
-test_start "hiddenfiles_help_lists_both_actions"
-fn files/hiddenfiles.sh hiddenfiles --help
-assert_equals 0 "$RC" "rc"
-out_has "Hidden Files Visibility Toggle" "banner"
-out_has "hiddenfiles [show|hide]" "usage"
+# The function refuses to run anywhere but macOS, so each platform gets the
+# arm it actually reaches.
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  test_start "hiddenfiles_refuses_to_run_off_macos"
+  fn files/hiddenfiles.sh hiddenfiles
+  assert_equals 1 "$RC" "rc"
+  out_has "hiddenfiles: macOS only" "refusal"
 
-test_start "hiddenfiles_rejects_an_unknown_action"
-fn files/hiddenfiles.sh hiddenfiles sideways
-assert_equals 1 "$RC" "rc"
-out_has "Invalid argument: 'sideways'" "error"
+  test_start "hiddenfiles_refuses_before_reading_its_arguments"
+  fn files/hiddenfiles.sh hiddenfiles --help
+  assert_equals 1 "$RC" "rc"
+  out_has "hiddenfiles: macOS only" "the guard runs before the help arm"
+else
+  test_start "hiddenfiles_help_lists_both_actions"
+  fn files/hiddenfiles.sh hiddenfiles --help
+  assert_equals 0 "$RC" "rc"
+  out_has "Hidden Files Visibility Toggle" "banner"
+  out_has "hiddenfiles [show|hide]" "usage"
 
-test_start "hiddenfiles_defaults_to_hiding"
-# `defaults` and `osascript` are sandbox no-op shims.
-fn files/hiddenfiles.sh hiddenfiles
-assert_equals 0 "$RC" "rc"
-out_has "Hiding hidden files" "action"
-out_has "Finder settings updated successfully" "completion"
+  test_start "hiddenfiles_rejects_an_unknown_action"
+  fn files/hiddenfiles.sh hiddenfiles sideways
+  assert_equals 1 "$RC" "rc"
+  out_has "Invalid argument: 'sideways'" "error"
 
-test_start "hiddenfiles_can_show_them_too"
-fn files/hiddenfiles.sh hiddenfiles show
-assert_equals 0 "$RC" "rc"
-out_has "Showing hidden files" "action"
+  test_start "hiddenfiles_defaults_to_hiding"
+  # `defaults` and `osascript` are sandbox no-op shims.
+  fn files/hiddenfiles.sh hiddenfiles
+  assert_equals 0 "$RC" "rc"
+  out_has "Hiding hidden files" "action"
+  out_has "Finder settings updated successfully" "completion"
+
+  test_start "hiddenfiles_can_show_them_too"
+  fn files/hiddenfiles.sh hiddenfiles show
+  assert_equals 0 "$RC" "rc"
+  out_has "Showing hidden files" "action"
+fi
 
 # ── emoji ───────────────────────────────────────────────────────────────
 test_start "emoji_reports_a_missing_picker"

--- a/tests/unit/functions/test_functions_file_ops_behaviour.sh
+++ b/tests/unit/functions/test_functions_file_ops_behaviour.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2015-2026 Sebastien Rousseau
+# shellcheck disable=SC1090,SC1091,SC2034
+# Behavioural coverage for the shell functions shipped under
+# defaults/.chezmoitemplates/functions: ren, rd, last, hiddenfiles, emoji and
+# whoisport. Each function is sourced and called for real inside the coverage
+# sandbox, against files created in a throwaway directory — including the
+# interactive confirmation prompts, which are answered on stdin.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+source "$SCRIPT_DIR/../../framework/assertions.sh"
+source "$SCRIPT_DIR/../../framework/coverage_helpers.sh"
+
+FN_DIR="$REPO_ROOT/defaults/.chezmoitemplates/functions"
+
+trap cov_teardown_sandbox EXIT
+cov_setup_sandbox
+
+WORK="$DOTFILES_COV_TMPDIR/work"
+OUTF="$DOTFILES_COV_TMPDIR/out.txt"
+ERRF="$DOTFILES_COV_TMPDIR/err.txt"
+MERGED="$DOTFILES_COV_TMPDIR/merged.txt"
+mkdir -p "$WORK"
+
+# fn <file> <call…> — source a function file and run one call in a subshell,
+# with the sandbox work dir as cwd. stdin comes from $STDIN_FILE when set.
+STDIN_FILE=/dev/null
+fn() {
+  local file="$1"
+  shift
+  (
+    cd "$WORK" || exit 1
+    source "$FN_DIR/$file"
+    "$@"
+    # The child's stderr must stay a *stream we replay*, not be merged into the
+    # captured output: `2>&1` would fold the child's xtrace into $OUTF, and the
+    # coverage runner would then see none of the lines it executed. Assertions
+    # read stdout plus stderr-minus-xtrace.
+  ) >"$OUTF" 2>"$ERRF" <"$STDIN_FILE"
+  RC=$?
+  [[ "${DOTFILES_COV_ECHO_STDERR:-0}" == "1" ]] && cat "$ERRF" >&2
+  return 0
+}
+out_has() {
+  {
+    cat "$OUTF"
+    grep -v '^+*@COV@' "$ERRF" 2>/dev/null
+  } >"$MERGED"
+  assert_file_contains "$MERGED" "$1" "${2:-output contains $1}"
+}
+out_lacks() {
+  {
+    cat "$OUTF"
+    grep -v '^+*@COV@' "$ERRF" 2>/dev/null
+  } >"$MERGED"
+  if grep -qF -- "$1" "$MERGED"; then
+    ((TESTS_FAILED++)) || true
+    printf '%b\n' "  ${RED}✗${NC} $CURRENT_TEST: ${2:-output should not contain $1}"
+  else
+    ((TESTS_PASSED++)) || true
+    printf '%b\n' "  ${GREEN}✓${NC} $CURRENT_TEST: ${2:-output lacks $1}"
+  fi
+}
+
+# ── ren ─────────────────────────────────────────────────────────────────
+test_start "ren_requires_two_arguments"
+fn files/ren.sh ren
+assert_equals 1 "$RC" "rc"
+out_has "Usage: ren OLD_EXT NEW_EXT" "usage"
+fn files/ren.sh ren txt
+assert_equals 1 "$RC" "rc"
+
+test_start "ren_reports_when_nothing_matches"
+rm -f "$WORK"/*
+fn files/ren.sh ren txt md
+assert_equals 0 "$RC" "rc"
+out_has "No files found with extension .txt" "warning"
+
+test_start "ren_cancels_on_a_negative_answer"
+: >"$WORK/a.txt"
+printf 'n\n' >"$DOTFILES_COV_TMPDIR/stdin"
+STDIN_FILE="$DOTFILES_COV_TMPDIR/stdin" fn files/ren.sh ren txt md
+assert_equals 0 "$RC" "rc"
+out_has "Operation cancelled" "cancellation"
+assert_file_exists "$WORK/a.txt" "file untouched"
+
+test_start "ren_renames_every_match_when_confirmed"
+: >"$WORK/b.txt"
+printf 'y\n' >"$DOTFILES_COV_TMPDIR/stdin"
+STDIN_FILE="$DOTFILES_COV_TMPDIR/stdin" fn files/ren.sh ren txt md
+assert_equals 0 "$RC" "rc"
+out_has "The following files will be renamed" "preview"
+out_has "Successfully renamed: 2" "summary counts both files"
+assert_file_exists "$WORK/a.md" "first file renamed"
+assert_file_exists "$WORK/b.md" "second file renamed"
+assert_file_not_exists "$WORK/a.txt" "original gone"
+
+# ── rd ──────────────────────────────────────────────────────────────────
+test_start "rd_requires_exactly_one_argument"
+fn files/rd.sh rd
+assert_equals 1 "$RC" "rc"
+out_has "Please add one argument" "usage"
+fn files/rd.sh rd one two
+assert_equals 1 "$RC" "rc"
+
+test_start "rd_rejects_a_path_that_is_not_a_directory"
+fn files/rd.sh rd "$WORK/nope"
+assert_equals 1 "$RC" "rc"
+out_has "Directory does not exist" "error"
+
+test_start "rd_refuses_protected_paths"
+fn files/rd.sh rd /tmp
+assert_equals 1 "$RC" "rc"
+out_has "Refusing to delete protected path" "guard"
+fn files/rd.sh rd "$HOME"
+assert_equals 1 "$RC" "rc"
+out_has "Refusing to delete protected path" "guard covers \$HOME"
+
+test_start "rd_prompts_before_deleting_a_top_level_home_directory"
+# rd compares the *physical* path against $HOME, so the guard only engages
+# when HOME itself is physical (on macOS /var is a symlink to /private/var).
+PHYS_HOME="$(cd "$HOME" && pwd -P)"
+mkdir -p "$PHYS_HOME/toplevel"
+printf 'n\n' >"$DOTFILES_COV_TMPDIR/stdin"
+STDIN_FILE="$DOTFILES_COV_TMPDIR/stdin" HOME="$PHYS_HOME" fn files/rd.sh rd "$PHYS_HOME/toplevel"
+assert_equals 1 "$RC" "rc"
+out_has "About to delete top-level home directory" "warning"
+out_has "Aborted." "abort"
+assert_dir_exists "$PHYS_HOME/toplevel" "directory kept"
+
+test_start "rd_deletes_a_confirmed_top_level_home_directory"
+printf 'y\n' >"$DOTFILES_COV_TMPDIR/stdin"
+STDIN_FILE="$DOTFILES_COV_TMPDIR/stdin" HOME="$PHYS_HOME" fn files/rd.sh rd "$PHYS_HOME/toplevel"
+assert_equals 0 "$RC" "rc"
+out_has "Successfully deleted" "confirmation"
+assert_dir_not_exists "$PHYS_HOME/toplevel" "directory removed"
+
+test_start "rd_deletes_a_nested_directory_without_prompting"
+mkdir -p "$WORK/nested/deep"
+fn files/rd.sh rd "$WORK/nested"
+assert_equals 0 "$RC" "rc"
+out_has "Successfully deleted" "confirmation"
+assert_dir_not_exists "$WORK/nested" "directory removed"
+
+# ── last ────────────────────────────────────────────────────────────────
+test_start "last_help_documents_the_time_range"
+fn misc/last.sh last --help
+assert_equals 0 "$RC" "rc"
+out_has "Recently Modified Files Viewer" "banner"
+out_has "Maximum time range is 7 days" "limit documented"
+
+test_start "last_rejects_a_non_numeric_range"
+fn misc/last.sh last abc
+assert_equals 1 "$RC" "rc"
+out_has "Invalid input: 'abc'" "error"
+
+test_start "last_rejects_a_range_beyond_seven_days"
+fn misc/last.sh last 10081
+assert_equals 1 "$RC" "rc"
+out_has "Time range too large" "error"
+
+test_start "last_lists_recently_modified_files"
+: >"$WORK/fresh.txt"
+fn misc/last.sh last 60
+assert_equals 0 "$RC" "rc"
+out_has "Listing files modified in the last 60 minutes" "header"
+out_has "fresh.txt" "file listed"
+
+test_start "last_defaults_to_sixty_minutes"
+fn misc/last.sh last
+assert_equals 0 "$RC" "rc"
+out_has "last 60 minutes" "default range"
+
+test_start "last_falls_back_to_its_own_logging_helpers"
+# The function file defines log_error/log_info only when they are not
+# already defined; calling it in a clean subshell exercises that fallback.
+fn misc/last.sh log_info "hello from the fallback"
+assert_equals 0 "$RC" "rc"
+out_has "[INFO] hello from the fallback" "fallback logger"
+
+# ── hiddenfiles ─────────────────────────────────────────────────────────
+test_start "hiddenfiles_help_lists_both_actions"
+fn files/hiddenfiles.sh hiddenfiles --help
+assert_equals 0 "$RC" "rc"
+out_has "Hidden Files Visibility Toggle" "banner"
+out_has "hiddenfiles [show|hide]" "usage"
+
+test_start "hiddenfiles_rejects_an_unknown_action"
+fn files/hiddenfiles.sh hiddenfiles sideways
+assert_equals 1 "$RC" "rc"
+out_has "Invalid argument: 'sideways'" "error"
+
+test_start "hiddenfiles_defaults_to_hiding"
+# `defaults` and `osascript` are sandbox no-op shims.
+fn files/hiddenfiles.sh hiddenfiles
+assert_equals 0 "$RC" "rc"
+out_has "Hiding hidden files" "action"
+out_has "Finder settings updated successfully" "completion"
+
+test_start "hiddenfiles_can_show_them_too"
+fn files/hiddenfiles.sh hiddenfiles show
+assert_equals 0 "$RC" "rc"
+out_has "Showing hidden files" "action"
+
+# ── emoji ───────────────────────────────────────────────────────────────
+test_start "emoji_reports_a_missing_picker"
+DOTFILES_DIR="$WORK/no-such-dotfiles" fn interactive/emoji.sh emoji
+assert_equals 1 "$RC" "rc"
+out_has "Emoji picker not found" "error"
+
+test_start "emoji_runs_the_picker_from_the_configured_source_dir"
+mkdir -p "$WORK/fake-dotfiles/scripts/tools"
+cat >"$WORK/fake-dotfiles/scripts/tools/emoji-picker.sh" <<'STUB'
+#!/usr/bin/env bash
+echo "picker ran: $*"
+STUB
+chmod +x "$WORK/fake-dotfiles/scripts/tools/emoji-picker.sh"
+DOTFILES_DIR="$WORK/fake-dotfiles" fn interactive/emoji.sh emoji --search cat
+assert_equals 0 "$RC" "rc"
+out_has "picker ran: --search cat" "args forwarded"
+
+# ── whoisport ───────────────────────────────────────────────────────────
+test_start "whoisport_probes_the_requested_port"
+cat >"$DOTFILES_COV_TMPDIR/bin/fuser" <<'STUB'
+#!/usr/bin/env bash
+printf '%s: 4242\n' "$1"
+STUB
+chmod +x "$DOTFILES_COV_TMPDIR/bin/fuser"
+fn system/whoisport.sh whoisport 8080
+out_has "/proc/ 4242/exe" "looks up the reported pid's exe"
+
+echo "RESULTS:$TESTS_RUN:$TESTS_PASSED:$TESTS_FAILED"

--- a/tests/unit/ops/test_ops_card_and_hooks.sh
+++ b/tests/unit/ops/test_ops_card_and_hooks.sh
@@ -71,7 +71,15 @@ out_has "Security" "security row"
 out_has "Hydrated" "footer"
 
 test_start "bento_names_the_running_platform"
-out_has "macOS" "macOS detected on this host"
+# The card detects the OS itself: macOS on Darwin, WSL when
+# /proc/sys/kernel/osrelease says so, Linux otherwise.
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  out_has "macOS" "macOS detected"
+elif grep -qiE '(microsoft|wsl)' /proc/sys/kernel/osrelease 2>/dev/null; then
+  out_has "WSL" "WSL detected"
+else
+  out_has "Linux" "Linux detected"
+fi
 
 # ── prepare-commit-msg ──────────────────────────────────────────────────
 MSG="$DOTFILES_COV_TMPDIR/COMMIT_EDITMSG"

--- a/tests/unit/ops/test_ops_card_and_hooks.sh
+++ b/tests/unit/ops/test_ops_card_and_hooks.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2015-2026 Sebastien Rousseau
+# shellcheck disable=SC1090,SC1091,SC2034
+# Behavioural coverage for three small entry points, driven inside the
+# coverage sandbox so nothing on the host is rendered or committed:
+#
+#   lib/dot/bento.sh                       — the intelligence card
+#   scripts/git-hooks/prepare-commit-msg   — commit-message branding hook
+#   scripts/ci/check-copyright-headers.sh  — compat shim for the moved script
+#
+# Split from test_ops_small_entrypoints.sh so both files stay inside the
+# coverage runner's 60s per-file budget.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+source "$SCRIPT_DIR/../../framework/assertions.sh"
+source "$SCRIPT_DIR/../../framework/coverage_helpers.sh"
+
+LOCKS="$REPO_ROOT/scripts/diagnostics/version-locks.sh"
+TUNING="$REPO_ROOT/scripts/tuning/linux.sh"
+PREWARM="$REPO_ROOT/scripts/ops/prewarm.sh"
+TELEPORT="$REPO_ROOT/scripts/ops/teleport.sh"
+AI_SETUP="$REPO_ROOT/scripts/ops/ai-setup.sh"
+BENTO="$REPO_ROOT/lib/dot/bento.sh"
+HOOK="$REPO_ROOT/scripts/git-hooks/prepare-commit-msg"
+COPYRIGHT_SHIM="$REPO_ROOT/scripts/ci/check-copyright-headers.sh"
+REAL_BASH="$(command -v bash)"
+
+trap cov_teardown_sandbox EXIT
+cov_setup_sandbox
+
+BIN="$DOTFILES_COV_TMPDIR/bin"
+OUTF="$DOTFILES_COV_TMPDIR/out.txt"
+ERRF="$DOTFILES_COV_TMPDIR/err.txt"
+MERGED="$DOTFILES_COV_TMPDIR/merged.txt"
+export CALLS="$DOTFILES_COV_TMPDIR/calls.txt"
+
+run() {
+  : >"$CALLS"
+  "$@" >"$OUTF" 2>"$ERRF" </dev/null
+  RC=$?
+  [[ "${DOTFILES_COV_ECHO_STDERR:-0}" == "1" ]] && cat "$ERRF" >&2
+  return 0
+}
+out_has() {
+  {
+    cat "$OUTF"
+    grep -v '^+*@COV@' "$ERRF" 2>/dev/null
+  } >"$MERGED"
+  assert_file_contains "$MERGED" "$1" "${2:-output contains $1}"
+}
+called() { assert_file_contains "$CALLS" "$1" "invoked $1"; }
+record_stub() {
+  cat >"$BIN/$1" <<STUB
+#!$REAL_BASH
+printf '$1 %s\\n' "\$*" >>"\$CALLS"
+exit "\${${2:-STUB_RC}:-0}"
+STUB
+  chmod +x "$BIN/$1"
+}
+
+# ── bento ───────────────────────────────────────────────────────────────
+test_start "bento_renders_the_intelligence_card"
+run bash "$BENTO"
+assert_equals 0 "$RC" "rc"
+out_has "D O T F I L E S" "banner"
+out_has "Platform" "platform row"
+out_has "Security" "security row"
+out_has "Hydrated" "footer"
+
+test_start "bento_names_the_running_platform"
+out_has "macOS" "macOS detected on this host"
+
+# ── prepare-commit-msg ──────────────────────────────────────────────────
+MSG="$DOTFILES_COV_TMPDIR/COMMIT_EDITMSG"
+SIGNATURE="$HOME/.euxis/data/config/branding/signature.txt"
+
+test_start "hook_is_a_no_op_without_a_message_file"
+run bash "$HOOK"
+assert_equals 0 "$RC" "rc"
+run bash "$HOOK" "$DOTFILES_COV_TMPDIR/absent-msg"
+assert_equals 0 "$RC" "rc"
+
+test_start "hook_skips_merge_and_squash_commits"
+printf 'feat: something\n' >"$MSG"
+run bash "$HOOK" "$MSG" merge
+assert_equals 0 "$RC" "rc"
+assert_true "! grep -q ARCHITECT '$MSG'" "message untouched"
+run bash "$HOOK" "$MSG" squash
+assert_equals 0 "$RC" "rc"
+
+test_start "hook_is_a_no_op_without_a_signature_file"
+run bash "$HOOK" "$MSG"
+assert_equals 0 "$RC" "rc"
+assert_equals "1" "$(wc -l <"$MSG" | tr -d ' ')" "message unchanged"
+
+test_start "hook_appends_the_signature_once"
+mkdir -p "$(dirname "$SIGNATURE")"
+printf -- '-- THE ARCHITECT --\n' >"$SIGNATURE"
+run bash "$HOOK" "$MSG"
+assert_equals 0 "$RC" "rc"
+assert_file_contains "$MSG" "THE ARCHITECT" "signature appended"
+run bash "$HOOK" "$MSG"
+assert_equals 0 "$RC" "rc"
+assert_equals "1" "$(grep -c 'THE ARCHITECT' "$MSG")" "not appended twice"
+
+# ── copyright-header compat shim ────────────────────────────────────────
+test_start "the_ci_shim_delegates_to_the_moved_validator"
+# An extension nothing matches keeps the delegated scan instant while still
+# proving the shim reached tools/ci/check-copyright-headers.sh.
+run bash "$COPYRIGHT_SHIM" --extensions=zzz --excludes=node_modules
+assert_equals 0 "$RC" "rc"
+out_has "No files matched extensions: zzz" "the real validator ran"
+
+echo "RESULTS:$TESTS_RUN:$TESTS_PASSED:$TESTS_FAILED"

--- a/tests/unit/ops/test_ops_maintenance_scripts.sh
+++ b/tests/unit/ops/test_ops_maintenance_scripts.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2015-2026 Sebastien Rousseau
+# shellcheck disable=SC1090,SC1091,SC2034
+# Behavioural coverage for three small maintenance entry points, all driven
+# inside the coverage sandbox against a throwaway $HOME:
+#
+#   scripts/tools/log-rotate.sh   — size threshold, rotation, gzip chain
+#   scripts/ops/chezmoi-update.sh — flag assembly, --force default, --async
+#   scripts/uninstall.sh          — confirmation gate and artefact removal
+#
+# `chezmoi` is a sandbox stub, so nothing on the host is applied or purged.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+source "$SCRIPT_DIR/../../framework/assertions.sh"
+source "$SCRIPT_DIR/../../framework/coverage_helpers.sh"
+
+ROTATE="$REPO_ROOT/scripts/tools/log-rotate.sh"
+UPDATE="$REPO_ROOT/scripts/ops/chezmoi-update.sh"
+UNINSTALL="$REPO_ROOT/scripts/uninstall.sh"
+
+trap cov_teardown_sandbox EXIT
+cov_setup_sandbox
+
+OUTF="$DOTFILES_COV_TMPDIR/out.txt"
+BIN="$DOTFILES_COV_TMPDIR/bin"
+run() {
+  bash "$@" >"$OUTF" </dev/null
+  RC=$?
+  return 0
+}
+out_has() { assert_file_contains "$OUTF" "$1" "${2:-output contains $1}"; }
+
+# ── log-rotate ──────────────────────────────────────────────────────────
+LOG="$HOME/.local/share/dotfiles.log"
+mkdir -p "$(dirname "$LOG")"
+
+test_start "log_rotate_is_a_no_op_without_a_log"
+rm -f "$LOG"
+run "$ROTATE"
+assert_equals 0 "$RC" "rc"
+assert_file_not_exists "$LOG" "nothing created"
+
+test_start "log_rotate_leaves_a_small_log_alone"
+printf 'small\n' >"$LOG"
+run "$ROTATE"
+assert_equals 0 "$RC" "rc"
+assert_file_contains "$LOG" "small" "log untouched"
+assert_file_not_exists "$LOG.1.gz" "no rotation"
+
+test_start "log_rotate_gzips_an_oversized_log_and_truncates_it"
+# 1 MiB + a marker line is over the threshold.
+dd if=/dev/zero bs=1024 count=1024 2>/dev/null | tr '\0' 'x' >"$LOG"
+printf 'marker\n' >>"$LOG"
+run "$ROTATE"
+assert_equals 0 "$RC" "rc"
+assert_file_exists "$LOG.1.gz" "rotated + gzipped"
+assert_equals "0" "$(wc -c <"$LOG" | tr -d ' ')" "live log truncated"
+
+test_start "log_rotate_shifts_existing_generations"
+dd if=/dev/zero bs=1024 count=1025 2>/dev/null | tr '\0' 'x' >"$LOG"
+printf 'plain-generation\n' >"$LOG.2"
+run "$ROTATE"
+assert_equals 0 "$RC" "rc"
+assert_file_exists "$LOG.2.gz" "gz generation shifted"
+assert_file_exists "$LOG.3.gz" "plain generation gzipped on the way"
+assert_file_not_exists "$LOG.2" "plain generation consumed"
+
+# ── chezmoi-update ──────────────────────────────────────────────────────
+# Record the argv chezmoi is called with so flag assembly can be asserted.
+cat >"$BIN/chezmoi" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$CHEZMOI_CALLS"
+exit 0
+STUB
+chmod +x "$BIN/chezmoi"
+export CHEZMOI_CALLS="$DOTFILES_COV_TMPDIR/chezmoi-calls.txt"
+STATE_DIR="$XDG_STATE_HOME/dotfiles/update"
+
+test_start "update_forces_apply_by_default"
+: >"$CHEZMOI_CALLS"
+run "$UPDATE"
+assert_equals 0 "$RC" "rc"
+out_has "Updating dotfiles" "progress line"
+assert_file_contains "$CHEZMOI_CALLS" "update --force" "unattended by default"
+assert_file_contains "$STATE_DIR/last.status" "0" "status recorded"
+
+test_start "interactive_apply_drops_the_force_flag"
+: >"$CHEZMOI_CALLS"
+DOTFILES_INTERACTIVE_APPLY=1 run "$UPDATE"
+assert_equals 0 "$RC" "rc"
+assert_equals "update" "$(cat "$CHEZMOI_CALLS")" "no extra flags"
+
+test_start "extra_flags_and_verbose_are_appended"
+: >"$CHEZMOI_CALLS"
+DOTFILES_CHEZMOI_UPDATE_FLAGS="--dry-run --force" DOTFILES_CHEZMOI_VERBOSE=1 run "$UPDATE"
+assert_equals 0 "$RC" "rc"
+assert_file_contains "$CHEZMOI_CALLS" "update --dry-run --force --verbose" "flags assembled once"
+
+test_start "async_mode_returns_immediately_and_leaves_a_notice"
+: >"$CHEZMOI_CALLS"
+rm -f "$STATE_DIR/notice"
+run "$UPDATE" --async
+assert_equals 0 "$RC" "rc"
+out_has "Update running in background" "message"
+assert_file_exists "$STATE_DIR/notice" "notice stamped"
+assert_file_exists "$STATE_DIR/last.log" "log file created"
+
+test_start "async_mode_can_be_requested_by_environment"
+rm -f "$STATE_DIR/notice"
+DOTFILES_ASYNC_UPDATE=1 run "$UPDATE"
+assert_equals 0 "$RC" "rc"
+out_has "Update running in background" "message"
+assert_file_exists "$STATE_DIR/notice" "notice stamped"
+
+# ── uninstall ───────────────────────────────────────────────────────────
+seed_artifacts() {
+  mkdir -p "$HOME/.local/bin" "$XDG_CACHE_HOME/dotfiles" \
+    "$XDG_STATE_HOME/dotfiles" "$XDG_CONFIG_HOME/chezmoi" \
+    "$XDG_DATA_HOME/zsh/completions" "$XDG_DATA_HOME/bash-completion/completions"
+  : >"$HOME/.local/bin/dot"
+  : >"$HOME/.local/bin/dot-ai"
+  : >"$XDG_DATA_HOME/zsh/completions/_dot"
+  : >"$XDG_DATA_HOME/bash-completion/completions/dot"
+  : >"$XDG_DATA_HOME/dotfiles.log"
+  : >"$XDG_CACHE_HOME/dotfiles/marker"
+  : >"$XDG_STATE_HOME/dotfiles/marker"
+}
+
+test_start "uninstall_aborts_without_confirmation"
+seed_artifacts
+printf 'n\n' | bash "$UNINSTALL" >"$OUTF"
+RC=$?
+assert_equals 0 "$RC" "rc"
+out_has "Aborted." "abort message"
+assert_file_exists "$HOME/.local/bin/dot" "artefacts left alone"
+assert_dir_exists "$XDG_CONFIG_HOME/chezmoi" "chezmoi config left alone"
+
+test_start "uninstall_proceeds_when_confirmed_at_the_prompt"
+seed_artifacts
+printf 'y\n' | bash "$UNINSTALL" >"$OUTF"
+RC=$?
+assert_equals 0 "$RC" "rc"
+out_has "Uninstall complete." "completion"
+assert_file_not_exists "$HOME/.local/bin/dot" "launcher removed"
+assert_dir_not_exists "$XDG_CACHE_HOME/dotfiles" "caches removed"
+
+test_start "force_skips_the_prompt_and_removes_every_artefact"
+seed_artifacts
+run "$UNINSTALL" --force
+assert_equals 0 "$RC" "rc"
+out_has "Reverting chezmoi-managed files" "chezmoi step ran"
+out_has "Removing shell completions" "completions step ran"
+assert_file_not_exists "$XDG_DATA_HOME/zsh/completions/_dot" "zsh completion removed"
+assert_file_not_exists "$XDG_DATA_HOME/bash-completion/completions/dot" "bash completion removed"
+assert_file_not_exists "$XDG_DATA_HOME/dotfiles.log" "log removed"
+assert_dir_not_exists "$XDG_STATE_HOME/dotfiles" "state removed"
+assert_file_contains "$CHEZMOI_CALLS" "purge --force" "chezmoi purge invoked"
+
+test_start "uninstall_skips_chezmoi_when_it_is_not_installed"
+seed_artifacts
+NOCM="$DOTFILES_COV_TMPDIR/nocm"
+mkdir -p "$NOCM"
+ln -sf "$(command -v bash)" "$NOCM/bash"
+for c in rm printf echo cat sed grep; do
+  p="$(command -v "$c" 2>/dev/null)" && ln -sf "$p" "$NOCM/$c"
+done
+PATH="$NOCM" run "$UNINSTALL" --force
+assert_equals 0 "$RC" "rc"
+assert_true "! grep -q 'Reverting chezmoi-managed' '$OUTF'" "chezmoi step skipped"
+out_has "Uninstall complete." "still completes"
+
+echo "RESULTS:$TESTS_RUN:$TESTS_PASSED:$TESTS_FAILED"

--- a/tests/unit/ops/test_ops_small_entrypoints.sh
+++ b/tests/unit/ops/test_ops_small_entrypoints.sh
@@ -1,0 +1,271 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2015-2026 Sebastien Rousseau
+# shellcheck disable=SC1090,SC1091,SC2034
+# Behavioural coverage for the remaining small entry points, each driven with
+# sandbox fixtures and stubs so nothing on the host is tuned, warmed,
+# deployed or committed:
+#
+#   scripts/diagnostics/version-locks.sh   — pin summary from a source tree
+#   scripts/tuning/linux.sh                — opt-in sysctl tuning
+#   scripts/ops/prewarm.sh                 — shell-init cache warming
+#   scripts/ops/teleport.sh                — ephemeral remote deploy
+#   scripts/ops/ai-setup.sh                — AI CLI authentication sweep
+#   lib/dot/bento.sh                       — the intelligence card
+#   scripts/git-hooks/prepare-commit-msg   — commit-message branding hook
+#   scripts/ci/check-copyright-headers.sh  — compat shim for the moved script
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+source "$SCRIPT_DIR/../../framework/assertions.sh"
+source "$SCRIPT_DIR/../../framework/coverage_helpers.sh"
+
+LOCKS="$REPO_ROOT/scripts/diagnostics/version-locks.sh"
+TUNING="$REPO_ROOT/scripts/tuning/linux.sh"
+PREWARM="$REPO_ROOT/scripts/ops/prewarm.sh"
+TELEPORT="$REPO_ROOT/scripts/ops/teleport.sh"
+AI_SETUP="$REPO_ROOT/scripts/ops/ai-setup.sh"
+BENTO="$REPO_ROOT/lib/dot/bento.sh"
+HOOK="$REPO_ROOT/scripts/git-hooks/prepare-commit-msg"
+COPYRIGHT_SHIM="$REPO_ROOT/scripts/ci/check-copyright-headers.sh"
+REAL_BASH="$(command -v bash)"
+
+trap cov_teardown_sandbox EXIT
+cov_setup_sandbox
+
+BIN="$DOTFILES_COV_TMPDIR/bin"
+OUTF="$DOTFILES_COV_TMPDIR/out.txt"
+ERRF="$DOTFILES_COV_TMPDIR/err.txt"
+MERGED="$DOTFILES_COV_TMPDIR/merged.txt"
+export CALLS="$DOTFILES_COV_TMPDIR/calls.txt"
+
+run() {
+  : >"$CALLS"
+  "$@" >"$OUTF" 2>"$ERRF" </dev/null
+  RC=$?
+  [[ "${DOTFILES_COV_ECHO_STDERR:-0}" == "1" ]] && cat "$ERRF" >&2
+  return 0
+}
+out_has() {
+  {
+    cat "$OUTF"
+    grep -v '^+*@COV@' "$ERRF" 2>/dev/null
+  } >"$MERGED"
+  assert_file_contains "$MERGED" "$1" "${2:-output contains $1}"
+}
+called() { assert_file_contains "$CALLS" "$1" "invoked $1"; }
+record_stub() {
+  cat >"$BIN/$1" <<STUB
+#!$REAL_BASH
+printf '$1 %s\\n' "\$*" >>"\$CALLS"
+exit "\${${2:-STUB_RC}:-0}"
+STUB
+  chmod +x "$BIN/$1"
+}
+
+# ── version-locks ───────────────────────────────────────────────────────
+SRC="$DOTFILES_COV_TMPDIR/source"
+mkdir -p "$SRC/defaults/dot_config/mise/conf.d" "$SRC/defaults/dot_config/shell"
+printf 'defaults\n' >"$SRC/.chezmoiroot"
+cat >"$SRC/defaults/dot_config/mise/conf.d/00-dotfiles.toml" <<'TOML'
+[settings]
+idiomatic_version_file = true
+
+[tools]
+node = "24.15.0"
+rust = "1.95.0"
+
+[env]
+FOO = "bar"
+TOML
+printf '24.15.0\n' >"$SRC/defaults/dot_node-version"
+printf 'save-exact=true\n' >"$SRC/defaults/dot_noderc.tmpl"
+printf 'brew "git"\n' >"$SRC/defaults/dot_config/shell/Brewfile"
+printf 'brew "jq"\n' >"$SRC/defaults/dot_config/shell/Brewfile.cli"
+printf '{"version":"0.2.0"}\n' >"$SRC/package.json"
+
+test_start "version_locks_summarises_every_pin_from_the_source_tree"
+run env CHEZMOI_SOURCE_DIR="$SRC" bash "$LOCKS"
+assert_equals 0 "$RC" "rc"
+out_has "Version Locks" "header"
+out_has "mise toolchain" "section"
+out_has "node" "tool row"
+out_has "24.15.0" "tool version"
+out_has "rust" "second tool row"
+out_has "noderc" "noderc row"
+out_has "brew" "Brewfile row"
+out_has "brew-cli" "Brewfile.cli row"
+out_has "package.json version pinned" "repo-root artefact"
+out_has "Prefer LTS and explicit pins" "policy note"
+
+test_start "version_locks_reports_a_source_tree_without_a_mise_config"
+BARE="$DOTFILES_COV_TMPDIR/bare"
+mkdir -p "$BARE"
+run env CHEZMOI_SOURCE_DIR="$BARE" bash "$LOCKS"
+assert_equals 0 "$RC" "rc"
+out_has "config not found" "warning"
+assert_true "! grep -q 'Brewfile present' '$MERGED'" "no package-manager rows"
+
+test_start "version_locks_falls_back_to_the_home_dotfiles_checkout"
+# No CHEZMOI_SOURCE_DIR: the sandbox HOME has ~/.dotfiles pointing at the repo.
+run bash "$LOCKS"
+assert_equals 0 "$RC" "rc"
+out_has "Version Locks" "still reports"
+
+test_start "version_locks_falls_back_to_the_xdg_chezmoi_checkout"
+XDG_SRC="$DOTFILES_COV_TMPDIR/xdg-home"
+mkdir -p "$XDG_SRC/.local/share/chezmoi"
+run env HOME="$XDG_SRC" CHEZMOI_SOURCE_DIR="" bash "$LOCKS"
+assert_equals 0 "$RC" "rc"
+out_has "Version Locks" "reports against the XDG checkout"
+out_has "config not found" "an empty checkout has no mise config"
+
+# ── linux tuning ────────────────────────────────────────────────────────
+test_start "tuning_is_opt_in"
+run bash "$TUNING"
+assert_equals 0 "$RC" "rc"
+out_has "Re-run with DOTFILES_TUNING=1" "opt-in hint"
+
+test_start "tuning_rejects_an_unknown_profile"
+run env DOTFILES_TUNING=1 DOTFILES_PROFILE=toaster bash "$TUNING"
+assert_equals 1 "$RC" "rc"
+out_has "must be laptop, desktop, or server (got: toaster)" "error"
+
+test_start "tuning_applies_the_profile_through_sudo"
+# `sudo` is a sandbox no-op shim, so nothing is actually set.
+for profile in laptop desktop server; do
+  run env DOTFILES_TUNING=1 DOTFILES_PROFILE="$profile" bash "$TUNING"
+  assert_equals 0 "$RC" "rc ($profile)"
+  out_has "Applying tuning" "announcement ($profile)"
+  out_has "Linux tuning complete" "completion ($profile)"
+done
+out_has "vm.swappiness" "memory settings applied"
+out_has "net.ipv4.tcp_syncookies" "security settings applied"
+
+test_start "tuning_skips_sysctl_without_sudo"
+NOSUDO="$DOTFILES_COV_TMPDIR/nosudo"
+mkdir -p "$NOSUDO"
+ln -sf "$REAL_BASH" "$NOSUDO/bash"
+for c in printf echo cat tty locale uname sed grep tr dirname basename mkdir rm mv cut date head wc chmod touch id sort ln; do
+  p="$(command -v "$c" 2>/dev/null)" && ln -sf "$p" "$NOSUDO/$c"
+done
+run env PATH="$NOSUDO" DOTFILES_TUNING=1 "$REAL_BASH" "$TUNING"
+assert_equals 0 "$RC" "rc"
+out_has "not available; skipping sysctl tuning" "explanation"
+
+# ── prewarm ─────────────────────────────────────────────────────────────
+test_start "prewarm_caches_every_tool_it_finds"
+record_stub starship
+record_stub zoxide
+record_stub atuin
+record_stub direnv
+run bash "$PREWARM"
+assert_equals 0 "$RC" "rc"
+out_has "Pre-warming Shell Caches" "header"
+out_has "Cache Pre-warming Complete" "completion"
+out_has "Zsh" "per-shell sections"
+out_has "Nushell" "nushell section"
+out_has "Shell completions" "completions section"
+assert_dir_exists "$XDG_CACHE_HOME/zsh" "zsh cache dir created"
+
+test_start "prewarm_reports_a_tool_whose_init_produces_nothing"
+# The stubs print nothing, so every cache write is empty and reported as a
+# failure rather than silently written.
+out_has "Failed to cache" "empty init reported"
+assert_true "! [[ -s '$XDG_CACHE_HOME/zsh/starship-init.zsh' ]]" "no empty cache file kept"
+
+test_start "prewarm_writes_a_cache_when_the_tool_emits_something"
+cat >"$BIN/starship" <<STUB
+#!$REAL_BASH
+printf 'starship %s\\n' "\$*" >>"\$CALLS"
+echo "eval starship init"
+STUB
+chmod +x "$BIN/starship"
+run bash "$PREWARM"
+assert_equals 0 "$RC" "rc"
+assert_file_contains "$XDG_CACHE_HOME/zsh/starship-init.zsh" "eval starship init" "cache written"
+assert_file_contains "$XDG_CACHE_HOME/bash/starship-init.bash" "eval starship init" "per-shell cache"
+called "starship init zsh"
+
+test_start "prewarm_generates_the_zsh_completions_it_can"
+cat >"$BIN/gh" <<STUB
+#!$REAL_BASH
+printf 'gh %s\\n' "\$*" >>"\$CALLS"
+echo "#compdef gh"
+STUB
+chmod +x "$BIN/gh"
+run bash "$PREWARM"
+assert_equals 0 "$RC" "rc"
+called "gh completion -s zsh"
+assert_file_contains "$XDG_DATA_HOME/zsh/completions/_gh" "#compdef gh" "completion written"
+
+test_start "prewarm_refuses_to_run_twice_at_once"
+LOCK="${XDG_RUNTIME_DIR:-/tmp}/dotfiles-prewarm.lock"
+NOFLOCK="$DOTFILES_COV_TMPDIR/noflock"
+mkdir -p "$NOFLOCK" "${LOCK}.d"
+ln -sf "$REAL_BASH" "$NOFLOCK/bash"
+for c in printf echo cat tty locale uname sed grep tr dirname basename mkdir rm mv cut date head wc chmod touch id sort ln rmdir; do
+  p="$(command -v "$c" 2>/dev/null)" && ln -sf "$p" "$NOFLOCK/$c"
+done
+run env PATH="$NOFLOCK" "$REAL_BASH" "$PREWARM"
+assert_equals 0 "$RC" "rc"
+out_has "Another instance is active" "lock respected"
+rmdir "${LOCK}.d"
+
+# ── teleport ────────────────────────────────────────────────────────────
+test_start "teleport_requires_a_target"
+run bash "$TELEPORT"
+assert_equals 1 "$RC" "rc"
+out_has "Usage: dot teleport user@host" "usage"
+
+test_start "teleport_rejects_an_unsafe_target"
+run bash "$TELEPORT" 'user@host; rm -rf /'
+assert_equals 1 "$RC" "rc"
+out_has "Invalid SSH target" "error"
+out_has "Expected format: user@hostname" "hint"
+
+test_start "teleport_pipes_the_chezmoi_archive_over_ssh"
+record_stub ssh
+cat >"$BIN/chezmoi" <<STUB
+#!$REAL_BASH
+printf 'chezmoi %s\\n' "\$*" >>"\$CALLS"
+printf 'archive-bytes\\n'
+STUB
+chmod +x "$BIN/chezmoi"
+run bash "$TELEPORT" deploy@example.com
+assert_equals 0 "$RC" "rc"
+out_has "Teleporting dotfiles to deploy@example.com" "announcement"
+out_has "Teleport successful" "completion"
+called "chezmoi archive"
+called "ssh deploy@example.com tar xz -C"
+
+# ── ai-setup ────────────────────────────────────────────────────────────
+test_start "ai_setup_walks_the_whole_fleet"
+for t in claude agy codex copilot goose kiro-cli kimi aider autohand vibe qwen zai; do
+  record_stub "$t"
+done
+run bash "$AI_SETUP"
+assert_equals 0 "$RC" "rc"
+out_has "Universal AI Toolchain Setup" "header"
+out_has "AI Setup Complete" "completion"
+out_has "Setting up Claude CLI" "per-tool section"
+called "claude --version"
+called "codex --version"
+
+test_start "ai_setup_skips_a_login_flow_when_stdin_is_not_a_terminal"
+out_has "non-interactive shell; skipping login" "kiro login deferred"
+assert_true "! grep -q 'kiro-cli login' '$CALLS'" "login not attempted"
+
+test_start "ai_setup_reports_a_tool_that_is_not_installed"
+NOAI="$DOTFILES_COV_TMPDIR/noai"
+mkdir -p "$NOAI"
+ln -sf "$REAL_BASH" "$NOAI/bash"
+for c in printf echo cat tty locale uname sed grep tr dirname basename mkdir rm mv cut date head wc chmod touch id sort ln; do
+  p="$(command -v "$c" 2>/dev/null)" && ln -sf "$p" "$NOAI/$c"
+done
+run env PATH="$NOAI" "$REAL_BASH" "$AI_SETUP"
+assert_equals 0 "$RC" "rc"
+out_has "Binary not found" "missing tool reported"
+
+echo "RESULTS:$TESTS_RUN:$TESTS_PASSED:$TESTS_FAILED"

--- a/tests/unit/ops/test_ops_small_entrypoints.sh
+++ b/tests/unit/ops/test_ops_small_entrypoints.sh
@@ -155,6 +155,12 @@ assert_equals 0 "$RC" "rc"
 out_has "not available; skipping sysctl tuning" "explanation"
 
 # ── prewarm ─────────────────────────────────────────────────────────────
+# prewarm.sh locks on $XDG_RUNTIME_DIR (falling back to /tmp), a path shared
+# by every process on the machine. Point it inside the sandbox so a suite
+# running in parallel can neither take our lock nor see us holding it.
+export XDG_RUNTIME_DIR="$DOTFILES_COV_TMPDIR/run"
+mkdir -p "$XDG_RUNTIME_DIR"
+
 test_start "prewarm_caches_every_tool_it_finds"
 record_stub starship
 record_stub zoxide
@@ -201,7 +207,7 @@ called "gh completion -s zsh"
 assert_file_contains "$XDG_DATA_HOME/zsh/completions/_gh" "#compdef gh" "completion written"
 
 test_start "prewarm_refuses_to_run_twice_at_once"
-LOCK="${XDG_RUNTIME_DIR:-/tmp}/dotfiles-prewarm.lock"
+LOCK="$XDG_RUNTIME_DIR/dotfiles-prewarm.lock"
 NOFLOCK="$DOTFILES_COV_TMPDIR/noflock"
 mkdir -p "$NOFLOCK" "${LOCK}.d"
 ln -sf "$REAL_BASH" "$NOFLOCK/bash"
@@ -226,7 +232,17 @@ out_has "Invalid SSH target" "error"
 out_has "Expected format: user@hostname" "hint"
 
 test_start "teleport_pipes_the_chezmoi_archive_over_ssh"
-record_stub ssh
+# The ssh stub must *drain* the archive: teleport pipes `chezmoi archive`
+# into it under `set -o pipefail`, so a stub that exits without reading
+# gives the writer SIGPIPE and the script exits 141 (seen on Linux, where
+# the timing differs from macOS).
+cat >"$BIN/ssh" <<STUB
+#!$REAL_BASH
+printf 'ssh %s\n' "\$*" >>"\$CALLS"
+cat >/dev/null
+exit 0
+STUB
+chmod +x "$BIN/ssh"
 cat >"$BIN/chezmoi" <<STUB
 #!$REAL_BASH
 printf 'chezmoi %s\\n' "\$*" >>"\$CALLS"

--- a/tests/unit/qa/test_qa_coverage_gates_behaviour.sh
+++ b/tests/unit/qa/test_qa_coverage_gates_behaviour.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2015-2026 Sebastien Rousseau
+# shellcheck disable=SC1090,SC1091,SC2034
+# Behavioural coverage for the two documentation gates in scripts/qa:
+# docs-coverage.sh and traceability-coverage.sh. Both are run against the
+# repository as it stands (they are read-only reporters) and then re-run with
+# an impossible threshold to drive the failure verdict.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+source "$SCRIPT_DIR/../../framework/assertions.sh"
+source "$SCRIPT_DIR/../../framework/coverage_helpers.sh"
+
+DOCS="$REPO_ROOT/scripts/qa/docs-coverage.sh"
+TRACE="$REPO_ROOT/scripts/qa/traceability-coverage.sh"
+
+trap cov_teardown_sandbox EXIT
+cov_setup_sandbox
+
+OUTF="$DOTFILES_COV_TMPDIR/out.txt"
+ERRF="$DOTFILES_COV_TMPDIR/err.txt"
+MERGED="$DOTFILES_COV_TMPDIR/merged.txt"
+
+gate() {
+  # stderr is replayed, not merged, so the child's xtrace still reaches the
+  # coverage trace while its "Missing …" lines stay assertable.
+  "$@" >"$OUTF" 2>"$ERRF" </dev/null
+  RC=$?
+  [[ "${DOTFILES_COV_ECHO_STDERR:-0}" == "1" ]] && cat "$ERRF" >&2
+  return 0
+}
+out_has() {
+  {
+    cat "$OUTF"
+    grep -v '^+*@COV@' "$ERRF" 2>/dev/null
+  } >"$MERGED"
+  assert_file_contains "$MERGED" "$1" "${2:-output contains $1}"
+}
+
+# ── docs-coverage ───────────────────────────────────────────────────────
+test_start "docs_coverage_reports_a_ratio_and_its_threshold"
+gate bash "$DOCS"
+assert_equals 0 "$RC" "the repository meets its own docs threshold"
+out_has "Docs coverage:" "ratio reported"
+out_has "Threshold: 100%" "threshold reported"
+out_has "PASS: public dot commands" "verdict"
+
+test_start "docs_coverage_counts_every_checked_surface"
+# commands from bin/dot + 9 AI providers + 40 utilities + the function groups.
+total="$(sed -n 's/^Docs coverage: [0-9]*\/\([0-9]*\) .*/\1/p' "$OUTF")"
+assert_true "[[ ${total:-0} -gt 100 ]]" "more than a hundred checks run"
+covered="$(sed -n 's/^Docs coverage: \([0-9]*\)\/.*/\1/p' "$OUTF")"
+assert_equals "$total" "$covered" "every documented surface is present"
+
+test_start "docs_coverage_fails_an_unreachable_threshold"
+gate env MIN_DOCS_COVERAGE=101 bash "$DOCS"
+assert_equals 1 "$RC" "rc"
+out_has "Threshold: 101%" "threshold echoed"
+out_has "FAIL: docs coverage below MIN_DOCS_COVERAGE=101%" "verdict"
+
+# ── traceability-coverage ───────────────────────────────────────────────
+test_start "traceability_reports_a_ratio_and_its_threshold"
+gate bash "$TRACE"
+assert_equals 0 "$RC" "the repository meets its own traceability threshold"
+out_has "Traceability coverage:" "ratio reported"
+out_has "Threshold: 100%" "threshold reported"
+out_has "PASS: core internal behaviors" "verdict"
+
+test_start "traceability_checks_every_behaviour_row_and_command_module"
+total="$(sed -n 's/^Traceability coverage: [0-9]*\/\([0-9]*\) .*/\1/p' "$OUTF")"
+assert_true "[[ ${total:-0} -gt 50 ]]" "the matrix is non-trivial"
+covered="$(sed -n 's/^Traceability coverage: \([0-9]*\)\/.*/\1/p' "$OUTF")"
+assert_equals "$total" "$covered" "every referenced path exists"
+
+test_start "traceability_fails_an_unreachable_threshold"
+gate env MIN_TRACEABILITY_COVERAGE=101 bash "$TRACE"
+assert_equals 1 "$RC" "rc"
+out_has "Threshold: 101%" "threshold echoed"
+out_has "FAIL: traceability coverage below MIN_TRACEABILITY_COVERAGE=101%" "verdict"
+
+echo "RESULTS:$TESTS_RUN:$TESTS_PASSED:$TESTS_FAILED"

--- a/tests/unit/security/test_security_governance_and_telemetry.sh
+++ b/tests/unit/security/test_security_governance_and_telemetry.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2015-2026 Sebastien Rousseau
+# shellcheck disable=SC1090,SC1091,SC2034
+# Behavioural coverage for three security-side scripts, all driven with
+# sandbox stubs so nothing on the host is scanned, disabled or re-keyed:
+#
+#   scripts/diagnostics/secret-governance.sh — staged-content secret scan
+#   scripts/security/telemetry-kill.sh       — opt-in telemetry disabling
+#   scripts/secrets/age-init.sh              — age key + chezmoi config setup
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+source "$SCRIPT_DIR/../../framework/assertions.sh"
+source "$SCRIPT_DIR/../../framework/coverage_helpers.sh"
+
+GOVERNANCE="$REPO_ROOT/scripts/diagnostics/secret-governance.sh"
+TELEMETRY="$REPO_ROOT/scripts/security/telemetry-kill.sh"
+AGE_INIT="$REPO_ROOT/scripts/secrets/age-init.sh"
+REAL_BASH="$(command -v bash)"
+
+trap cov_teardown_sandbox EXIT
+cov_setup_sandbox
+
+BIN="$DOTFILES_COV_TMPDIR/bin"
+OUTF="$DOTFILES_COV_TMPDIR/out.txt"
+ERRF="$DOTFILES_COV_TMPDIR/err.txt"
+MERGED="$DOTFILES_COV_TMPDIR/merged.txt"
+export GOV_FIX="$DOTFILES_COV_TMPDIR/gov"
+mkdir -p "$GOV_FIX"
+: >"$GOV_FIX/staged"
+: >"$GOV_FIX/content"
+
+run() {
+  "$@" >"$OUTF" 2>"$ERRF" </dev/null
+  RC=$?
+  [[ "${DOTFILES_COV_ECHO_STDERR:-0}" == "1" ]] && cat "$ERRF" >&2
+  return 0
+}
+out_has() {
+  {
+    cat "$OUTF"
+    grep -v '^+*@COV@' "$ERRF" 2>/dev/null
+  } >"$MERGED"
+  assert_file_contains "$MERGED" "$1" "${2:-output contains $1}"
+}
+
+# ── secret-governance ───────────────────────────────────────────────────
+# `git diff --cached --name-only` lists the staged paths and `git show :path`
+# prints their staged content; both come from fixtures.
+cat >"$BIN/git" <<STUB
+#!$REAL_BASH
+for a in "\$@"; do
+  case "\$a" in
+    diff) cat "\$GOV_FIX/staged"; exit 0 ;;
+    show) cat "\$GOV_FIX/content"; exit 0 ;;
+  esac
+done
+exit 0
+STUB
+chmod +x "$BIN/git"
+
+test_start "governance_passes_when_nothing_is_staged"
+: >"$GOV_FIX/staged"
+run bash "$GOVERNANCE"
+assert_equals 0 "$RC" "rc"
+out_has "no staged files" "message"
+
+test_start "governance_passes_on_clean_staged_content"
+printf 'src/app.ts\n' >"$GOV_FIX/staged"
+printf 'const answer = 42;\n' >"$GOV_FIX/content"
+run bash "$GOVERNANCE"
+assert_equals 0 "$RC" "rc"
+out_has "Secret governance passed." "verdict"
+
+test_start "governance_flags_a_plaintext_secret_pattern"
+printf 'api_key = "super-secret-value"\n' >"$GOV_FIX/content"
+run bash "$GOVERNANCE"
+assert_equals 1 "$RC" "rc"
+out_has "potential plaintext secret pattern detected" "finding"
+out_has "Secret governance failed: 1 violation(s)." "verdict"
+
+test_start "governance_strict_mode_catches_a_leaked_managed_value"
+# Strict mode compares the staged content against every value the secrets
+# provider knows. Drive the file-backed `plain-enc` provider: the index and
+# store live in the sandbox and `age -d` is a stub that prints the plaintext.
+SECRETS_HOME="$DOTFILES_COV_TMPDIR/secrets"
+mkdir -p "$SECRETS_HOME/store"
+printf 'API_TOKEN\nSHORT\n' >"$SECRETS_HOME/index.txt"
+printf 'leaked-token-value\n' >"$SECRETS_HOME/store/API_TOKEN.plain"
+printf 'abc\n' >"$SECRETS_HOME/store/SHORT.plain"
+: >"$SECRETS_HOME/store/API_TOKEN.age"
+: >"$SECRETS_HOME/store/SHORT.age"
+printf 'AGE-SECRET-KEY-TEST\n' >"$SECRETS_HOME/key.txt"
+printf '#!%s\n' "$REAL_BASH" >"$BIN/age"
+cat >>"$BIN/age" <<'STUB'
+# `age -d -i <key> <file>` → print the plaintext stored beside <file>.
+last=""
+for a in "$@"; do last="$a"; done
+cat "${last%.age}.plain"
+STUB
+chmod +x "$BIN/age"
+export DOTFILES_SECRETS_PROVIDER=plain-enc
+export DOT_SECRETS_HOME="$SECRETS_HOME"
+export DOT_SECRETS_STORE_DIR="$SECRETS_HOME/store"
+export DOT_SECRETS_INDEX_FILE="$SECRETS_HOME/index.txt"
+export DOT_SECRETS_AGE_KEY="$SECRETS_HOME/key.txt"
+
+printf 'token = leaked-token-value\n' >"$GOV_FIX/content"
+run env DOTFILES_SECRETS_STRICT_MODE=1 "$REAL_BASH" "$GOVERNANCE"
+assert_equals 1 "$RC" "rc"
+out_has "exact managed secret value leaked for key: API_TOKEN" "finding names the key"
+out_has "Secret governance failed: 1 violation(s)." "verdict"
+
+test_start "governance_strict_mode_ignores_short_and_absent_values"
+printf 'nothing to see here\n' >"$GOV_FIX/content"
+run env DOTFILES_SECRETS_STRICT_MODE=1 "$REAL_BASH" "$GOVERNANCE"
+assert_equals 0 "$RC" "rc"
+out_has "Secret governance passed." "verdict"
+unset DOTFILES_SECRETS_PROVIDER DOT_SECRETS_HOME DOT_SECRETS_STORE_DIR \
+  DOT_SECRETS_INDEX_FILE DOT_SECRETS_AGE_KEY
+
+# ── telemetry-kill ──────────────────────────────────────────────────────
+test_start "telemetry_kill_is_opt_in"
+run bash "$TELEMETRY"
+assert_equals 1 "$RC" "rc"
+out_has "disabled by default" "refusal"
+out_has "DOTFILES_TELEMETRY=1" "opt-in hint"
+
+test_start "telemetry_kill_dry_run_lists_the_commands_it_would_run"
+run bash "$TELEMETRY" --dry-run
+assert_equals 0 "$RC" "rc"
+out_has "dry-run (no changes will be made)" "mode announced"
+out_has "[dry-run]" "commands echoed, not executed"
+out_has "Disabling" "platform section reached"
+
+test_start "telemetry_kill_dry_run_accepts_the_short_flag"
+run bash "$TELEMETRY" -n
+assert_equals 0 "$RC" "rc"
+out_has "dry-run" "mode announced"
+
+test_start "telemetry_kill_reports_an_unsupported_platform"
+cat >"$BIN/uname" <<STUB
+#!$REAL_BASH
+[[ "\${1:-}" == "-s" ]] && echo "Plan9" && exit 0
+echo "Plan9"
+STUB
+chmod +x "$BIN/uname"
+run bash "$TELEMETRY" --dry-run
+assert_equals 1 "$RC" "rc"
+out_has "Unsupported OS" "error"
+rm -f "$BIN/uname"
+
+# ── age-init ────────────────────────────────────────────────────────────
+cat >"$BIN/age-keygen" <<STUB
+#!$REAL_BASH
+if [[ "\${1:-}" == "-o" ]]; then
+  printf '# created: 2026-01-01\\nAGE-SECRET-KEY-TEST\\n' >"\$2"
+  exit 0
+fi
+if [[ "\${1:-}" == "-y" ]]; then
+  echo "age1testrecipientvalue"
+  exit 0
+fi
+exit 0
+STUB
+chmod +x "$BIN/age-keygen"
+
+test_start "age_init_creates_a_key_and_writes_the_chezmoi_config"
+CFG="$HOME/.config/chezmoi/chezmoi.toml"
+KEY="$HOME/.config/chezmoi/key.txt"
+rm -f "$CFG" "$KEY"
+run bash "$AGE_INIT"
+assert_equals 0 "$RC" "rc"
+out_has "Age key created at" "key creation reported"
+out_has "Updated" "config update reported"
+assert_file_exists "$KEY" "key written"
+assert_file_contains "$CFG" 'encryption = "age"' "encryption declared at top level"
+assert_file_contains "$CFG" "[age]" "age section written"
+assert_file_contains "$CFG" "age1testrecipientvalue" "recipient recorded"
+
+test_start "age_init_keeps_an_existing_key_and_rewrites_the_age_block"
+printf 'encryption = "gpg"\n\n[age]\nidentity = "stale"\n\n[data]\nname = "keep"\n' >"$CFG"
+run bash "$AGE_INIT"
+assert_equals 0 "$RC" "rc"
+out_has "Age key already exists" "key reused"
+assert_file_contains "$CFG" "keep" "unrelated config preserved"
+assert_file_contains "$CFG" "age1testrecipientvalue" "recipient refreshed"
+assert_true "[[ \$(grep -c '^encryption =' '$CFG') -eq 1 ]]" "no duplicate encryption key"
+assert_true "! grep -q 'stale' '$CFG'" "previous age block removed"
+
+test_start "age_init_requires_age_keygen"
+NOAGE="$DOTFILES_COV_TMPDIR/noage"
+mkdir -p "$NOAGE"
+ln -sf "$REAL_BASH" "$NOAGE/bash"
+for c in printf echo mkdir chmod python3 cat; do
+  p="$(command -v "$c" 2>/dev/null)" && ln -sf "$p" "$NOAGE/$c"
+done
+run env PATH="$NOAGE" "$REAL_BASH" "$AGE_INIT"
+assert_equals 1 "$RC" "rc"
+out_has "age-keygen not found" "error"
+
+echo "RESULTS:$TESTS_RUN:$TESTS_PASSED:$TESTS_FAILED"

--- a/tests/unit/security/test_verified_download_guards.sh
+++ b/tests/unit/security/test_verified_download_guards.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2015-2026 Sebastien Rousseau
+# shellcheck disable=SC1090,SC1091,SC2034
+# Behavioural coverage for lib/dot/verified-download.sh — the checksum-pinned
+# fetchers used by the installer. `curl` is a sandbox stub that serves files
+# from a fixture directory, so every guard (non-HTTPS URL, unpinned URL,
+# transport failure, size limits, checksum mismatch, non-script payload) is
+# exercised without a single network call.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+source "$SCRIPT_DIR/../../framework/assertions.sh"
+source "$SCRIPT_DIR/../../framework/coverage_helpers.sh"
+
+LIB="$REPO_ROOT/lib/dot/verified-download.sh"
+
+trap cov_teardown_sandbox EXIT
+cov_setup_sandbox
+
+BIN="$DOTFILES_COV_TMPDIR/bin"
+FIX="$DOTFILES_COV_TMPDIR/served"
+DEST="$DOTFILES_COV_TMPDIR/downloaded"
+ERRF="$DOTFILES_COV_TMPDIR/err.txt"
+mkdir -p "$FIX"
+
+# curl stub: serve $CURL_ROOT/<basename of URL>, or fail with $CURL_RC.
+cat >"$BIN/curl" <<'STUB'
+#!/usr/bin/env bash
+out=""
+url=""
+while (($#)); do
+  case "$1" in
+    -o)
+      out="$2"
+      shift 2
+      ;;
+    -*) shift ;;
+    *)
+      url="$1"
+      shift
+      ;;
+  esac
+done
+[[ "${CURL_RC:-0}" -ne 0 ]] && exit "${CURL_RC}"
+src="$CURL_ROOT/$(basename "$url")"
+[[ -f "$src" ]] || exit 22
+cat "$src" >"$out"
+exit 0
+STUB
+chmod +x "$BIN/curl"
+export CURL_ROOT="$FIX"
+
+sha_of() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  else
+    shasum -a 256 "$1" | awk '{print $1}'
+  fi
+}
+
+# call <fn> <args…> — run one fetcher in a subshell with the lib sourced.
+call() {
+  (
+    source "$LIB"
+    "$@"
+  ) 2>"$ERRF"
+  RC=$?
+  [[ "${DOTFILES_COV_ECHO_STDERR:-0}" == "1" ]] && cat "$ERRF" >&2
+  return 0
+}
+err_has() { assert_file_contains "$ERRF" "$1" "${2:-stderr contains $1}"; }
+
+printf '#!/usr/bin/env bash\necho installed\n' >"$FIX/install.sh"
+GOOD_SHA="$(sha_of "$FIX/install.sh")"
+MANIFEST="$DOTFILES_COV_TMPDIR/remote-installers.sha256"
+printf '%s  https://example.com/install.sh\n' "$GOOD_SHA" >"$MANIFEST"
+export DOTFILES_INSTALLER_MANIFEST="$MANIFEST"
+
+test_start "library_exists_and_parses"
+assert_file_exists "$LIB" "verified-download.sh must exist"
+assert_true "bash -n '$LIB'" "valid bash syntax"
+
+# ── download_verified_script ────────────────────────────────────────────
+test_start "a_pinned_installer_is_downloaded_and_verified"
+rm -f "$DEST"
+call download_verified_script https://example.com/install.sh "$DEST"
+assert_equals 0 "$RC" "rc"
+assert_file_exists "$DEST" "payload written"
+assert_file_contains "$DEST" "echo installed" "payload content"
+
+test_start "a_non_https_url_is_refused_before_any_fetch"
+rm -f "$DEST"
+call download_verified_script http://example.com/install.sh "$DEST"
+assert_equals 2 "$RC" "rc"
+err_has "Refusing non-HTTPS installer URL" "error"
+assert_file_not_exists "$DEST" "nothing downloaded"
+
+test_start "an_unreadable_manifest_is_refused"
+call env DOTFILES_INSTALLER_MANIFEST="$DOTFILES_COV_TMPDIR/absent.sha256" \
+  bash -c 'source "$0"; download_verified_script https://example.com/install.sh "$1"' \
+  "$LIB" "$DEST"
+assert_equals 2 "$RC" "rc"
+err_has "checksum manifest not readable" "error"
+
+test_start "the_default_manifest_path_is_the_repo_copy"
+(
+  unset DOTFILES_INSTALLER_MANIFEST
+  call download_verified_script https://example.com/never-pinned.sh "$DEST"
+  assert_equals 2 "$RC" "rc"
+  err_has "not checksum-pinned" "falls back to the tracked manifest"
+)
+
+test_start "an_unpinned_url_is_refused"
+call download_verified_script https://example.com/other.sh "$DEST"
+assert_equals 2 "$RC" "rc"
+err_has "not checksum-pinned" "error"
+
+test_start "a_transport_failure_removes_the_partial_file"
+printf 'partial' >"$DEST"
+CURL_RC=7 call download_verified_script https://example.com/install.sh "$DEST"
+assert_equals 1 "$RC" "rc"
+assert_file_not_exists "$DEST" "partial file cleaned up"
+
+test_start "an_empty_payload_is_rejected"
+: >"$FIX/empty.sh"
+printf '%s  https://example.com/empty.sh\n' "$(sha_of "$FIX/empty.sh")" >>"$MANIFEST"
+call download_verified_script https://example.com/empty.sh "$DEST"
+assert_equals 1 "$RC" "rc"
+err_has "size outside allowed range" "error"
+assert_file_not_exists "$DEST" "cleaned up"
+
+test_start "an_oversized_payload_is_rejected"
+call download_verified_script https://example.com/install.sh "$DEST" 4
+assert_equals 1 "$RC" "rc"
+err_has "size outside allowed range" "error names the limit breach"
+
+test_start "a_checksum_mismatch_is_rejected"
+printf '#!/usr/bin/env bash\necho tampered\n' >"$FIX/tampered.sh"
+printf '%s  https://example.com/tampered.sh\n' "$GOOD_SHA" >>"$MANIFEST"
+call download_verified_script https://example.com/tampered.sh "$DEST"
+assert_equals 1 "$RC" "rc"
+err_has "checksum mismatch" "error"
+assert_file_not_exists "$DEST" "cleaned up"
+
+test_start "a_verified_payload_that_is_not_a_script_is_rejected"
+printf 'plain text, no shebang\n' >"$FIX/notscript.sh"
+printf '%s  https://example.com/notscript.sh\n' "$(sha_of "$FIX/notscript.sh")" >>"$MANIFEST"
+call download_verified_script https://example.com/notscript.sh "$DEST"
+assert_equals 1 "$RC" "rc"
+err_has "not an executable script" "error"
+
+# ── download_verified_asset ─────────────────────────────────────────────
+printf 'binary-release-payload\n' >"$FIX/tool.tar.gz"
+ASSET_SHA="$(sha_of "$FIX/tool.tar.gz")"
+printf '%s  tool.tar.gz\n' "$ASSET_SHA" >"$FIX/checksums.txt"
+
+test_start "a_release_asset_is_downloaded_and_verified"
+rm -f "$DEST"
+call download_verified_asset https://example.com/tool.tar.gz \
+  https://example.com/checksums.txt tool.tar.gz "$DEST"
+assert_equals 0 "$RC" "rc"
+assert_file_contains "$DEST" "binary-release-payload" "payload written"
+
+test_start "starred_checksum_names_are_accepted"
+printf '%s *tool.tar.gz\n' "$ASSET_SHA" >"$FIX/checksums.txt"
+rm -f "$DEST"
+call download_verified_asset https://example.com/tool.tar.gz \
+  https://example.com/checksums.txt tool.tar.gz "$DEST"
+assert_equals 0 "$RC" "rc"
+assert_file_exists "$DEST" "payload written"
+
+test_start "non_https_asset_urls_are_refused"
+call download_verified_asset http://example.com/tool.tar.gz \
+  https://example.com/checksums.txt tool.tar.gz "$DEST"
+assert_equals 2 "$RC" "rc"
+err_has "Refusing non-HTTPS release asset URL" "error"
+
+test_start "an_asset_name_with_a_path_separator_is_refused"
+call download_verified_asset https://example.com/tool.tar.gz \
+  https://example.com/checksums.txt ../etc/passwd "$DEST"
+assert_equals 2 "$RC" "rc"
+err_has "Invalid release asset name" "error"
+
+test_start "an_empty_asset_name_is_refused"
+call download_verified_asset https://example.com/tool.tar.gz \
+  https://example.com/checksums.txt "" "$DEST"
+assert_equals 2 "$RC" "rc"
+err_has "Invalid release asset name" "error"
+
+test_start "a_failing_checksum_fetch_is_reported"
+CURL_RC=7 call download_verified_asset https://example.com/tool.tar.gz \
+  https://example.com/checksums.txt tool.tar.gz "$DEST"
+assert_equals 1 "$RC" "rc"
+
+test_start "an_asset_absent_from_the_manifest_is_refused"
+printf '%s  other.tar.gz\n' "$ASSET_SHA" >"$FIX/checksums.txt"
+call download_verified_asset https://example.com/tool.tar.gz \
+  https://example.com/checksums.txt tool.tar.gz "$DEST"
+assert_equals 1 "$RC" "rc"
+err_has "absent or ambiguous in checksum manifest" "error"
+
+test_start "an_asset_checksum_mismatch_is_refused"
+printf '%s  tool.tar.gz\n' "$GOOD_SHA" >"$FIX/checksums.txt"
+call download_verified_asset https://example.com/tool.tar.gz \
+  https://example.com/checksums.txt tool.tar.gz "$DEST"
+assert_equals 1 "$RC" "rc"
+err_has "Release asset checksum mismatch" "error"
+assert_file_not_exists "$DEST" "cleaned up"
+
+test_start "an_oversized_asset_is_refused"
+printf '%s  tool.tar.gz\n' "$ASSET_SHA" >"$FIX/checksums.txt"
+call download_verified_asset https://example.com/tool.tar.gz \
+  https://example.com/checksums.txt tool.tar.gz "$DEST" 4
+assert_equals 1 "$RC" "rc"
+err_has "Release asset size outside allowed range" "error"
+
+test_start "an_oversized_checksum_manifest_is_refused"
+# The manifest guard trips at 2 MiB.
+dd if=/dev/zero bs=1024 count=2100 2>/dev/null | tr '\0' 'x' >"$FIX/checksums.txt"
+call download_verified_asset https://example.com/tool.tar.gz \
+  https://example.com/checksums.txt tool.tar.gz "$DEST"
+assert_equals 1 "$RC" "rc"
+err_has "exceeds the 2 MiB safety limit" "error"
+
+test_start "a_missing_sha256_tool_is_reported"
+NOSHA="$DOTFILES_COV_TMPDIR/nosha"
+mkdir -p "$NOSHA"
+ln -sf "$(command -v bash)" "$NOSHA/bash"
+for c in awk cat printf rm wc tr head grep mktemp dirname basename cut sed; do
+  p="$(command -v "$c" 2>/dev/null)" && ln -sf "$p" "$NOSHA/$c"
+done
+ln -sf "$BIN/curl" "$NOSHA/curl"
+printf '%s  https://example.com/install.sh\n' "$GOOD_SHA" >"$MANIFEST"
+PATH="$NOSHA" call download_verified_script https://example.com/install.sh "$DEST"
+assert_equals 1 "$RC" "rc"
+err_has "SHA-256 verifier not found" "error"
+
+echo "RESULTS:$TESTS_RUN:$TESTS_PASSED:$TESTS_FAILED"

--- a/tests/unit/theme/test_theme_merge_wallpaper_pairs.sh
+++ b/tests/unit/theme/test_theme_merge_wallpaper_pairs.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2015-2026 Sebastien Rousseau
+# shellcheck disable=SC1090,SC1091,SC2034
+# Behavioural coverage for scripts/theme/merge-wallpaper.sh: dependency
+# checks, --help, --dry-run, single-family and sweep modes, and the failure
+# path when the encoder rejects a pair.
+#
+# `heif-enc`, `magick` and `exiftool` are recording stubs in the sandbox and
+# the wallpaper directory is a throwaway under $DOTFILES_COV_TMPDIR, so no
+# real image is ever read, written or deleted.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+source "$SCRIPT_DIR/../../framework/assertions.sh"
+source "$SCRIPT_DIR/../../framework/coverage_helpers.sh"
+
+MERGE="$REPO_ROOT/scripts/theme/merge-wallpaper.sh"
+REAL_BASH="$(command -v bash)"
+
+trap cov_teardown_sandbox EXIT
+cov_setup_sandbox
+
+BIN="$DOTFILES_COV_TMPDIR/bin"
+OUTF="$DOTFILES_COV_TMPDIR/out.txt"
+ERRF="$DOTFILES_COV_TMPDIR/err.txt"
+MERGED="$DOTFILES_COV_TMPDIR/merged.txt"
+WALLS="$DOTFILES_COV_TMPDIR/wallpapers"
+export MERGE_CALLS="$DOTFILES_COV_TMPDIR/calls.txt"
+mkdir -p "$WALLS"
+
+cat >"$BIN/magick" <<STUB
+#!$REAL_BASH
+printf 'magick %s\\n' "\$*" >>"\$MERGE_CALLS"
+# Last argument is the output path; produce a plausible JPEG for heif-enc.
+printf 'jpeg-bytes\\n' >"\${!#}"
+exit 0
+STUB
+cat >"$BIN/heif-enc" <<STUB
+#!$REAL_BASH
+printf 'heif-enc %s\\n' "\$*" >>"\$MERGE_CALLS"
+[[ "\${HEIF_ENC_RC:-0}" -ne 0 ]] && exit "\$HEIF_ENC_RC"
+out=""
+while ((\$#)); do
+  [[ "\$1" == "-o" ]] && out="\$2"
+  shift
+done
+printf 'heic-bytes\\n' >"\$out"
+exit 0
+STUB
+cat >"$BIN/exiftool" <<STUB
+#!$REAL_BASH
+printf 'exiftool %s\\n' "\$*" >>"\$MERGE_CALLS"
+exit 0
+STUB
+chmod +x "$BIN/magick" "$BIN/heif-enc" "$BIN/exiftool"
+
+merge() {
+  : >"$MERGE_CALLS"
+  # stderr is replayed rather than merged so the child's xtrace still reaches
+  # the coverage trace.
+  DOTFILES_WALLPAPER_DIR="$WALLS" bash "$MERGE" "$@" >"$OUTF" 2>"$ERRF" </dev/null
+  RC=$?
+  [[ "${DOTFILES_COV_ECHO_STDERR:-0}" == "1" ]] && cat "$ERRF" >&2
+  return 0
+}
+out_has() {
+  {
+    cat "$OUTF"
+    grep -v '^+*@COV@' "$ERRF" 2>/dev/null
+  } >"$MERGED"
+  assert_file_contains "$MERGED" "$1" "${2:-output contains $1}"
+}
+called() { assert_file_contains "$MERGE_CALLS" "$1" "invoked $1"; }
+
+pair() {
+  printf 'dark-pixels\n' >"$WALLS/$1-dark.${2:-heic}"
+  printf 'light-pixels\n' >"$WALLS/$1-light.${2:-heic}"
+}
+
+test_start "script_exists_and_parses"
+assert_file_exists "$MERGE" "merge-wallpaper.sh must exist"
+assert_true "bash -n '$MERGE'" "valid bash syntax"
+
+test_start "help_documents_the_merge"
+merge --help
+assert_equals 0 "$RC" "rc"
+out_has "Usage: merge-wallpaper.sh" "usage"
+out_has "switches appearance automatically on macOS" "explanation"
+
+test_start "the_encoder_is_required"
+NOENC="$DOTFILES_COV_TMPDIR/noenc"
+mkdir -p "$NOENC"
+ln -sf "$REAL_BASH" "$NOENC/bash"
+for c in printf echo cat basename mktemp rm mv; do
+  p="$(command -v "$c" 2>/dev/null)" && ln -sf "$p" "$NOENC/$c"
+done
+PATH="$NOENC" merge
+assert_equals 1 "$RC" "rc"
+out_has "heif-enc required" "error names libheif"
+
+test_start "imagemagick_is_required"
+ln -sf "$BIN/heif-enc" "$NOENC/heif-enc"
+PATH="$NOENC" merge
+assert_equals 1 "$RC" "rc"
+out_has "ImageMagick (magick) required" "error"
+
+test_start "dry_run_reports_the_pairs_without_touching_them"
+pair macos-tahoe
+merge --dry-run
+assert_equals 0 "$RC" "rc"
+out_has "would merge" "preview"
+out_has "macos-tahoe" "family named"
+out_has "Done: 1 merged, 0 failed" "summary"
+assert_file_exists "$WALLS/macos-tahoe-dark.heic" "inputs untouched"
+assert_file_not_exists "$WALLS/macos-tahoe.heic" "no output written"
+assert_true "! [[ -s '$MERGE_CALLS' ]]" "no encoder invoked"
+
+test_start "a_pair_is_merged_into_one_dynamic_heic"
+merge
+assert_equals 0 "$RC" "rc"
+out_has "merged →" "confirmation"
+out_has "Done: 1 merged, 0 failed" "summary"
+out_has "dot theme rebuild --force" "follow-up hint"
+assert_file_exists "$WALLS/macos-tahoe.heic" "output written"
+assert_file_not_exists "$WALLS/macos-tahoe-dark.heic" "dark input consumed"
+assert_file_not_exists "$WALLS/macos-tahoe-light.heic" "light input consumed"
+called "magick"
+called "heif-enc -q 90"
+called "exiftool -overwrite_original"
+
+test_start "a_named_family_is_merged_on_its_own"
+pair alpha
+pair beta
+merge alpha
+assert_equals 0 "$RC" "rc"
+out_has "alpha — merged" "named family merged"
+assert_file_exists "$WALLS/alpha.heic" "output written"
+assert_file_exists "$WALLS/beta-dark.heic" "other family left alone"
+
+test_start "jpeg_and_png_pairs_are_found_too"
+rm -f "$WALLS"/*
+pair gamma jpg
+pair delta png
+merge
+assert_equals 0 "$RC" "rc"
+out_has "Done: 2 merged, 0 failed" "both families merged"
+assert_file_exists "$WALLS/gamma.heic" "jpg pair merged"
+assert_file_exists "$WALLS/delta.heic" "png pair merged"
+
+test_start "an_unpaired_family_is_reported_as_a_failure"
+rm -f "$WALLS"/*
+printf 'dark-only\n' >"$WALLS/lonely-dark.heic"
+merge
+assert_equals 0 "$RC" "rc"
+out_has "missing dark or light variant" "reason"
+out_has "Done: 0 merged, 1 failed" "summary"
+
+test_start "a_named_family_with_no_files_fails"
+merge nosuchfamily
+assert_equals 1 "$RC" "rc"
+out_has "nosuchfamily — missing dark or light variant" "reason"
+
+test_start "an_encoder_failure_is_reported_and_keeps_the_inputs"
+rm -f "$WALLS"/*
+pair epsilon
+HEIF_ENC_RC=1 merge
+assert_equals 0 "$RC" "rc"
+out_has "heif-enc failed" "reason"
+out_has "Done: 0 merged, 1 failed" "summary"
+assert_file_exists "$WALLS/epsilon-dark.heic" "inputs kept"
+assert_file_not_exists "$WALLS/epsilon.heic" "no output"
+
+test_start "an_empty_wallpaper_directory_merges_nothing"
+rm -f "$WALLS"/*
+merge
+assert_equals 0 "$RC" "rc"
+out_has "Done: 0 merged, 0 failed" "summary"
+
+echo "RESULTS:$TESTS_RUN:$TESTS_PASSED:$TESTS_FAILED"

--- a/tests/unit/tools/test_bin_system_utils_behaviour.sh
+++ b/tests/unit/tools/test_bin_system_utils_behaviour.sh
@@ -1,0 +1,361 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2015-2026 Sebastien Rousseau
+# shellcheck disable=SC1090,SC1091,SC2034
+# Behavioural coverage for the system-facing utilities in
+# defaults/dot_local/bin: kill-port, notify, gd, antigravity,
+# dot-launch-or-focus and corralctl-sync.
+#
+# Everything they would touch on the host — lsof/kill, osascript,
+# notify-send, fzf/delta/git, niri and corralctl — is a recording stub in the
+# sandbox, so process signals, notifications and window management are
+# asserted by what the utility *asked for*, never performed.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+source "$SCRIPT_DIR/../../framework/assertions.sh"
+source "$SCRIPT_DIR/../../framework/coverage_helpers.sh"
+
+BIN_DIR="$REPO_ROOT/defaults/dot_local/bin"
+REAL_BASH="$(command -v bash)"
+
+trap cov_teardown_sandbox EXIT
+cov_setup_sandbox
+
+BIN="$DOTFILES_COV_TMPDIR/bin"
+OUTF="$DOTFILES_COV_TMPDIR/out.txt"
+ERRF="$DOTFILES_COV_TMPDIR/err.txt"
+MERGED="$DOTFILES_COV_TMPDIR/merged.txt"
+export CALLS="$DOTFILES_COV_TMPDIR/calls.txt"
+
+record_stub() {
+  cat >"$BIN/$1" <<STUB
+#!$REAL_BASH
+printf '$1 %s\\n' "\$*" >>"\$CALLS"
+exit 0
+STUB
+  chmod +x "$BIN/$1"
+}
+
+util() {
+  local name="$1"
+  shift
+  : >"$CALLS"
+  # The child's stderr must stay a *stream we replay*, not be merged into the
+  # captured output: `2>&1` would fold the child's xtrace into $OUTF, and the
+  # coverage runner would then see none of the lines it executed. Assertions
+  # read stdout plus stderr-minus-xtrace.
+  bash "$BIN_DIR/executable_$name" "$@" >"$OUTF" 2>"$ERRF" </dev/null
+  RC=$?
+  [[ "${DOTFILES_COV_ECHO_STDERR:-0}" == "1" ]] && cat "$ERRF" >&2
+  return 0
+}
+out_has() {
+  {
+    cat "$OUTF"
+    grep -v '^+*@COV@' "$ERRF" 2>/dev/null
+  } >"$MERGED"
+  assert_file_contains "$MERGED" "$1" "${2:-output contains $1}"
+}
+out_lacks() {
+  {
+    cat "$OUTF"
+    grep -v '^+*@COV@' "$ERRF" 2>/dev/null
+  } >"$MERGED"
+  if grep -qF -- "$1" "$MERGED"; then
+    ((TESTS_FAILED++)) || true
+    printf '%b\n' "  ${RED}✗${NC} $CURRENT_TEST: ${2:-output should not contain $1}"
+  else
+    ((TESTS_PASSED++)) || true
+    printf '%b\n' "  ${GREEN}✓${NC} $CURRENT_TEST: ${2:-output lacks $1}"
+  fi
+}
+
+called() { assert_file_contains "$CALLS" "$1" "invoked $1"; }
+
+# ── kill-port ───────────────────────────────────────────────────────────
+cat >"$BIN/lsof" <<STUB
+#!$REAL_BASH
+printf 'lsof %s\\n' "\$*" >>"\$CALLS"
+cat "\$LSOF_PIDS" 2>/dev/null
+exit 0
+STUB
+cat >"$BIN/ps" <<STUB
+#!$REAL_BASH
+printf 'ps %s\\n' "\$*" >>"\$CALLS"
+echo "  1234 node    node server.js"
+exit 0
+STUB
+cat >"$BIN/kill" <<STUB
+#!$REAL_BASH
+printf 'kill %s\\n' "\$*" >>"\$CALLS"
+exit 0
+STUB
+chmod +x "$BIN/lsof" "$BIN/ps" "$BIN/kill"
+export LSOF_PIDS="$DOTFILES_COV_TMPDIR/pids.txt"
+: >"$LSOF_PIDS"
+
+test_start "kill_port_requires_a_port"
+util kill-port
+assert_equals 1 "$RC" "rc"
+out_has "Usage: kill-port <port>" "usage"
+
+test_start "kill_port_validates_the_port_number"
+util kill-port not-a-port
+assert_equals 1 "$RC" "rc"
+out_has "Invalid port number: not-a-port" "error"
+util kill-port 0
+assert_equals 1 "$RC" "rc"
+util kill-port 65536
+assert_equals 1 "$RC" "rc"
+out_has "Invalid port number: 65536" "upper bound"
+
+test_start "kill_port_reports_an_idle_port"
+: >"$LSOF_PIDS"
+util kill-port 3000
+assert_equals 0 "$RC" "rc"
+out_has "No process found on port 3000" "message"
+
+# `kill` is a shell builtin, so a PATH stub would never be consulted: the
+# signal has to be real. Each case therefore targets a throwaway `sleep`
+# started by this suite, and never a PID we did not create.
+test_start "kill_port_sends_sigterm_by_default"
+sleep 30 &
+VICTIM=$!
+printf '%s\n' "$VICTIM" >"$LSOF_PIDS"
+util kill-port 3000
+assert_equals 0 "$RC" "rc"
+out_has "Sending SIGTERM" "signal announced"
+out_has "Killed PID $VICTIM" "result"
+wait "$VICTIM" 2>/dev/null
+assert_false "kill -0 $VICTIM 2>/dev/null" "the process is gone"
+
+test_start "kill_port_force_sends_sigkill"
+sleep 30 &
+VICTIM=$!
+printf '%s\n' "$VICTIM" >"$LSOF_PIDS"
+util kill-port 8080 --force
+assert_equals 0 "$RC" "rc"
+out_has "Force killing" "announced"
+out_has "Killed PID $VICTIM" "result"
+wait "$VICTIM" 2>/dev/null
+sleep 30 &
+VICTIM=$!
+printf '%s\n' "$VICTIM" >"$LSOF_PIDS"
+util kill-port 8080 -f
+out_has "Killed PID $VICTIM" "short flag behaves the same"
+wait "$VICTIM" 2>/dev/null
+
+test_start "kill_port_kills_every_listed_process"
+sleep 30 &
+FIRST=$!
+sleep 30 &
+SECOND=$!
+printf '%s\n%s\n' "$FIRST" "$SECOND" >"$LSOF_PIDS"
+util kill-port 3000
+assert_equals 0 "$RC" "rc"
+out_has "Killed PID $FIRST" "first process"
+out_has "Killed PID $SECOND" "second process"
+wait "$FIRST" "$SECOND" 2>/dev/null
+
+test_start "kill_port_reports_a_process_it_cannot_signal"
+sleep 5 &
+GONE=$!
+kill "$GONE" 2>/dev/null
+wait "$GONE" 2>/dev/null
+printf '%s\n' "$GONE" >"$LSOF_PIDS"
+util kill-port 3000
+assert_equals 0 "$RC" "rc"
+out_has "Failed to kill PID $GONE" "failure reported"
+
+NOTOOL="$DOTFILES_COV_TMPDIR/notool"
+mkdir -p "$NOTOOL"
+ln -sf "$REAL_BASH" "$NOTOOL/bash"
+for c in printf echo cat grep sed; do
+  p="$(command -v "$c" 2>/dev/null)" && ln -sf "$p" "$NOTOOL/$c"
+done
+
+test_start "kill_port_without_a_lookup_tool_finds_nothing_to_kill"
+# find_pid runs inside a command substitution, so its "no supported tool"
+# message is captured as the PID list rather than printed; the observable
+# behaviour is that no signal is sent.
+: >"$LSOF_PIDS"
+PATH="$NOTOOL" util kill-port 3000
+assert_true "! grep -q 'Killed PID' '$OUTF'" "nothing is signalled"
+
+# ── notify ──────────────────────────────────────────────────────────────
+record_stub osascript
+record_stub notify-send
+
+test_start "notify_uses_osascript_on_macos"
+util notify "Build" "finished"
+assert_equals 0 "$RC" "rc"
+called "display notification"
+assert_file_contains "$CALLS" "with title \"Build\"" "title passed through"
+
+test_start "notify_defaults_the_title"
+util notify
+assert_equals 0 "$RC" "rc"
+assert_file_contains "$CALLS" "Notification" "default title"
+
+# ── antigravity ─────────────────────────────────────────────────────────
+test_start "antigravity_reports_a_missing_upstream_binary"
+util antigravity
+assert_equals 0 "$RC" "rc"
+out_has "not installed; skipping" "no-op message"
+
+test_start "antigravity_answers_version_even_without_the_binary"
+util antigravity --version
+assert_equals 0 "$RC" "rc"
+out_has "antigravity wrapper (upstream not installed)" "version string"
+
+# ── gd ──────────────────────────────────────────────────────────────────
+test_start "gd_requires_its_dependencies"
+PATH="$NOTOOL" util gd
+assert_equals 1 "$RC" "rc"
+out_has "gd requires" "error names the missing tool"
+
+record_stub fzf
+record_stub delta
+cat >"$BIN/git" <<STUB
+#!$REAL_BASH
+printf 'git %s\\n' "\$*" >>"\$CALLS"
+case "\$1" in
+  rev-parse) exit "\${GIT_IN_REPO_RC:-0}" ;;
+  diff) printf 'file-a.txt\\n' ;;
+esac
+exit 0
+STUB
+chmod +x "$BIN/git"
+
+test_start "gd_requires_a_git_repository"
+GIT_IN_REPO_RC=1 util gd
+assert_equals 1 "$RC" "rc"
+out_has "not a git repository" "error"
+
+test_start "gd_pipes_the_diff_into_fzf"
+util gd
+assert_equals 0 "$RC" "rc"
+called "git diff --color=always --name-only"
+called "fzf --preview"
+
+test_start "gd_forwards_git_diff_flags"
+util gd --staged
+assert_equals 0 "$RC" "rc"
+called "git diff --staged --color=always --name-only"
+
+test_start "gd_side_mode_sets_the_delta_feature"
+util gd --side
+assert_equals 0 "$RC" "rc"
+assert_true "! grep -q -- '--side' '$CALLS'" "--side is consumed, not forwarded to git"
+
+# ── dot-launch-or-focus ─────────────────────────────────────────────────
+test_start "launch_or_focus_help_and_usage_errors"
+util dot-launch-or-focus --help
+assert_equals 0 "$RC" "rc"
+out_has "Usage: dot-launch-or-focus <app>" "usage"
+util dot-launch-or-focus
+assert_equals 1 "$RC" "rc"
+util dot-launch-or-focus --unknown-flag
+assert_equals 2 "$RC" "rc"
+out_has "Unknown option: --unknown-flag" "error"
+
+test_start "launch_or_focus_falls_back_to_a_direct_launch_without_niri"
+record_stub ghostty
+util dot-launch-or-focus com.mitchellh.ghostty --extra
+assert_equals 0 "$RC" "rc"
+out_has "requires niri" "explanation"
+called "ghostty --extra"
+
+cat >"$BIN/niri" <<STUB
+#!$REAL_BASH
+printf 'niri %s\\n' "\$*" >>"\$CALLS"
+if [[ "\$2" == "--json" ]]; then cat "\$NIRI_WINDOWS"; fi
+exit 0
+STUB
+chmod +x "$BIN/niri"
+export NIRI_WINDOWS="$DOTFILES_COV_TMPDIR/windows.json"
+
+test_start "launch_or_focus_focuses_a_running_window"
+printf '[{"id":7,"app_id":"com.mitchellh.ghostty"}]\n' >"$NIRI_WINDOWS"
+util dot-launch-or-focus ghostty
+assert_equals 0 "$RC" "rc"
+called "niri msg action focus-window --id 7"
+
+test_start "launch_or_focus_spawns_when_nothing_matches"
+printf '[{"id":7,"app_id":"org.other.app"}]\n' >"$NIRI_WINDOWS"
+util dot-launch-or-focus com.mitchellh.ghostty --new-window
+assert_equals 0 "$RC" "rc"
+called "niri msg action spawn -- ghostty --new-window"
+
+# ── corralctl-sync ──────────────────────────────────────────────────────
+CORRAL="$BIN_DIR/executable_corralctl-sync.sh"
+LOG="$HOME/Library/Logs/corralctl.log"
+mkdir -p "$HOME/Library/Logs" "$HOME/.local/share/mise/shims"
+cat >"$HOME/.local/share/mise/shims/corralctl" <<STUB
+#!$REAL_BASH
+printf 'corralctl %s\\n' "\$*" >>"\$CALLS"
+cat "\$CORRAL_OUTPUT" 2>/dev/null
+exit "\${CORRAL_RC:-0}"
+STUB
+chmod +x "$HOME/.local/share/mise/shims/corralctl"
+cat >"$BIN/osascript" <<STUB
+#!$REAL_BASH
+printf 'osascript %s\\n' "\$*" >>"\$CALLS"
+exit 0
+STUB
+chmod +x "$BIN/osascript"
+export CORRAL_OUTPUT="$DOTFILES_COV_TMPDIR/corral-out.txt"
+
+corral() {
+  : >"$CALLS"
+  bash "$CORRAL" >"$OUTF" 2>"$ERRF" </dev/null
+  RC=$?
+  [[ "${DOTFILES_COV_ECHO_STDERR:-0}" == "1" ]] && cat "$ERRF" >&2
+  return 0
+}
+
+test_start "corralctl_sync_logs_a_successful_run"
+printf '✓ [SYNC] repo-one\n✓ [SYNC] repo-two\n' >"$CORRAL_OUTPUT"
+rm -f "$LOG"
+corral
+assert_equals 0 "$RC" "rc"
+called "corralctl sebastienrousseau -c 8"
+assert_file_contains "$LOG" "corralctl sync started" "run logged"
+assert_file_contains "$LOG" "exit=0 synced=2 errors=0" "counts recorded"
+assert_true "! grep -q osascript '$CALLS'" "no notification on success"
+
+test_start "corralctl_sync_counts_reported_errors"
+# The failure notification is posted through /usr/bin/osascript by absolute
+# path, which no PATH stub can intercept and which would put a real banner on
+# the desktop, so this asserts the log evidence and leaves the notify call
+# itself undriven.
+printf '✓ [SYNC] repo-two\n' >"$CORRAL_OUTPUT"
+corral
+assert_equals 0 "$RC" "rc"
+assert_file_contains "$LOG" "synced=1 errors=0" "counts recorded"
+assert_true "! grep -q osascript '$CALLS'" "no notification for a clean run"
+
+test_start "corralctl_sync_writes_its_whole_run_to_the_log_stream"
+# The run block redirects *everything* into the log file, so point the log at
+# our own stderr to assert what the script actually emits there.
+rm -f "$LOG"
+ln -sf /dev/stderr "$LOG"
+printf '✓ [SYNC] repo-one\n' >"$CORRAL_OUTPUT"
+corral
+assert_equals 0 "$RC" "rc"
+out_has "corralctl sync started" "run banner"
+out_has "[SYNC] repo-one" "tool output relayed"
+out_has "synced=1 errors=0" "counts"
+rm -f "$LOG"
+
+test_start "corralctl_sync_trims_an_oversized_log"
+dd if=/dev/zero bs=1024 count=1100 2>/dev/null | tr '\0' 'x' >"$LOG"
+printf '\n' >>"$LOG"
+: >"$CORRAL_OUTPUT"
+corral
+assert_equals 0 "$RC" "rc"
+assert_true "[[ \$(wc -l <'$LOG') -le 2001 ]]" "log trimmed to the last 2000 lines"
+
+echo "RESULTS:$TESTS_RUN:$TESTS_PASSED:$TESTS_FAILED"

--- a/tests/unit/tools/test_bin_system_utils_behaviour.sh
+++ b/tests/unit/tools/test_bin_system_utils_behaviour.sh
@@ -120,9 +120,22 @@ out_has "No process found on port 3000" "message"
 # `kill` is a shell builtin, so a PATH stub would never be consulted: the
 # signal has to be real. Each case therefore targets a throwaway `sleep`
 # started by this suite, and never a PID we did not create.
+#
+# spawn_victim — start that sleep so it can be signalled safely. `sleep 30 &`
+# alone is not safe: until the child execs it is still *this* bash, carrying
+# this suite's `trap cov_teardown_sandbox EXIT`, so a SIGTERM that arrives in
+# the fork/exec window makes the child delete the shared sandbox out from
+# under the rest of the suite (reproduced on Linux; the window is wider
+# there). Clearing the trap and exec-ing in the child closes it.
+spawn_victim() {
+  (
+    trap - EXIT
+    exec sleep 30
+  ) &
+  VICTIM=$!
+}
 test_start "kill_port_sends_sigterm_by_default"
-sleep 30 &
-VICTIM=$!
+spawn_victim
 printf '%s\n' "$VICTIM" >"$LSOF_PIDS"
 util kill-port 3000
 assert_equals 0 "$RC" "rc"
@@ -132,26 +145,24 @@ wait "$VICTIM" 2>/dev/null
 assert_false "kill -0 $VICTIM 2>/dev/null" "the process is gone"
 
 test_start "kill_port_force_sends_sigkill"
-sleep 30 &
-VICTIM=$!
+spawn_victim
 printf '%s\n' "$VICTIM" >"$LSOF_PIDS"
 util kill-port 8080 --force
 assert_equals 0 "$RC" "rc"
 out_has "Force killing" "announced"
 out_has "Killed PID $VICTIM" "result"
 wait "$VICTIM" 2>/dev/null
-sleep 30 &
-VICTIM=$!
+spawn_victim
 printf '%s\n' "$VICTIM" >"$LSOF_PIDS"
 util kill-port 8080 -f
 out_has "Killed PID $VICTIM" "short flag behaves the same"
 wait "$VICTIM" 2>/dev/null
 
 test_start "kill_port_kills_every_listed_process"
-sleep 30 &
-FIRST=$!
-sleep 30 &
-SECOND=$!
+spawn_victim
+FIRST="$VICTIM"
+spawn_victim
+SECOND="$VICTIM"
 printf '%s\n%s\n' "$FIRST" "$SECOND" >"$LSOF_PIDS"
 util kill-port 3000
 assert_equals 0 "$RC" "rc"
@@ -160,14 +171,14 @@ out_has "Killed PID $SECOND" "second process"
 wait "$FIRST" "$SECOND" 2>/dev/null
 
 test_start "kill_port_reports_a_process_it_cannot_signal"
-sleep 5 &
-GONE=$!
-kill "$GONE" 2>/dev/null
-wait "$GONE" 2>/dev/null
-printf '%s\n' "$GONE" >"$LSOF_PIDS"
+# A PID above every platform's pid_max (Linux 4194304, macOS 99998) can never
+# name a live process, so this drives the failure branch without signalling
+# anything — including without racing a background job's fork/exec window.
+IMPOSSIBLE_PID=2147483646
+printf '%s\n' "$IMPOSSIBLE_PID" >"$LSOF_PIDS"
 util kill-port 3000
 assert_equals 0 "$RC" "rc"
-out_has "Failed to kill PID $GONE" "failure reported"
+out_has "Failed to kill PID $IMPOSSIBLE_PID" "failure reported"
 
 NOTOOL="$DOTFILES_COV_TMPDIR/notool"
 mkdir -p "$NOTOOL"
@@ -188,16 +199,36 @@ assert_true "! grep -q 'Killed PID' '$OUTF'" "nothing is signalled"
 record_stub osascript
 record_stub notify-send
 
-test_start "notify_uses_osascript_on_macos"
+test_start "notify_uses_the_notifier_for_this_platform"
 util notify "Build" "finished"
 assert_equals 0 "$RC" "rc"
-called "display notification"
-assert_file_contains "$CALLS" "with title \"Build\"" "title passed through"
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  called "display notification"
+  assert_file_contains "$CALLS" "with title \"Build\"" "title passed through"
+else
+  called "notify-send Build finished"
+fi
 
 test_start "notify_defaults_the_title"
 util notify
 assert_equals 0 "$RC" "rc"
 assert_file_contains "$CALLS" "Notification" "default title"
+
+test_start "notify_falls_back_to_stdout_without_a_desktop_notifier"
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  # The macOS arm has no fallback: osascript is part of the OS.
+  ((TESTS_PASSED++)) || true
+  printf '%b\n' "  ${GREEN}✓${NC} $CURRENT_TEST: not applicable on macOS"
+else
+  BARE="$DOTFILES_COV_TMPDIR/bare"
+  mkdir -p "$BARE"
+  for c in sh bash printf echo grep uname; do
+    p="$(command -v "$c" 2>/dev/null)" && ln -sf "$p" "$BARE/$c"
+  done
+  PATH="$BARE" util notify "Build" "finished"
+  assert_equals 0 "$RC" "rc"
+  out_has "Build: finished" "message printed to stdout"
+fi
 
 # ── antigravity ─────────────────────────────────────────────────────────
 test_start "antigravity_reports_a_missing_upstream_binary"

--- a/tests/unit/tools/test_bin_text_utils_behaviour.sh
+++ b/tests/unit/tools/test_bin_text_utils_behaviour.sh
@@ -113,6 +113,43 @@ STDIN_FILE="$WORK/in.txt" util hex
 assert_equals 0 "$RC" "rc"
 out_has "6869" "stdin viewed"
 
+test_start "hex_falls_back_to_hexdump_then_od_then_errors"
+# The viewer prefers xxd, then hexdump, then od; hide them one at a time.
+HEXPATH="$DOTFILES_COV_TMPDIR/hexpath"
+mkdir -p "$HEXPATH"
+ln -sf "$(command -v bash)" "$HEXPATH/bash"
+for c in printf echo cat tr sed grep; do
+  p="$(command -v "$c" 2>/dev/null)" && ln -sf "$p" "$HEXPATH/$c"
+done
+for c in hexdump od; do
+  p="$(command -v "$c" 2>/dev/null)" && ln -sf "$p" "$HEXPATH/$c"
+done
+PATH="$HEXPATH" util hex "$WORK/bin.dat"
+assert_equals 0 "$RC" "rc"
+out_has "41 42" "hexdump rendered the bytes"
+rm -f "$HEXPATH/hexdump"
+PATH="$HEXPATH" util hex "$WORK/bin.dat"
+# The od arm passes `-t x1z`, whose `z` format character BSD od rejects, so
+# on macOS the fallback runs and surfaces od's own failure.
+assert_true "[[ $RC -ne 0 ]]" "the od fallback ran"
+assert_true "! grep -q 'required' '$OUTF'" "and it is not the no-tool error"
+rm -f "$HEXPATH/od"
+PATH="$HEXPATH" util hex "$WORK/bin.dat"
+assert_equals 1 "$RC" "rc"
+out_has "xxd, hexdump, or od required" "error names every option"
+
+test_start "hex_colour_mode_pipes_through_bat"
+cat >"$DOTFILES_COV_TMPDIR/bin/bat" <<STUB
+#!$(command -v bash)
+printf 'bat %s\n' "\$*"
+cat
+STUB
+chmod +x "$DOTFILES_COV_TMPDIR/bin/bat"
+util hex -c "$WORK/bin.dat"
+assert_equals 0 "$RC" "rc"
+out_has "bat --language=xxd --style=plain" "colouriser invoked"
+out_has "4142" "bytes still rendered"
+
 # ── hashsum ─────────────────────────────────────────────────────────────
 KNOWN_SHA256="2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824" # "hello"
 KNOWN_MD5="5d41402abc4b2a76b9719d911017c592"

--- a/tests/unit/tools/test_bin_text_utils_behaviour.sh
+++ b/tests/unit/tools/test_bin_text_utils_behaviour.sh
@@ -1,0 +1,331 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2015-2026 Sebastien Rousseau
+# shellcheck disable=SC1090,SC1091,SC2034
+# Behavioural coverage for the text/encoding utilities in
+# defaults/dot_local/bin: lorem, hex, hashsum, jwt, regex and yamlv. Each is
+# run as a real command inside the coverage sandbox and asserted on its
+# output and exit code — no host state is read or written.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+source "$SCRIPT_DIR/../../framework/assertions.sh"
+source "$SCRIPT_DIR/../../framework/coverage_helpers.sh"
+
+BIN_DIR="$REPO_ROOT/defaults/dot_local/bin"
+
+trap cov_teardown_sandbox EXIT
+cov_setup_sandbox
+
+OUTF="$DOTFILES_COV_TMPDIR/out.txt"
+WORK="$DOTFILES_COV_TMPDIR/work"
+mkdir -p "$WORK"
+STDIN_FILE=/dev/null
+
+# util <name> <args…> — run one utility, stdout to $OUTF, status in RC.
+util() {
+  local name="$1"
+  shift
+  # stderr stays attached so the child's xtrace reaches the coverage trace.
+  bash "$BIN_DIR/executable_$name" "$@" >"$OUTF" <"$STDIN_FILE"
+  RC=$?
+  return 0
+}
+out_has() { assert_file_contains "$OUTF" "$1" "${2:-output contains $1}"; }
+
+# ── lorem ───────────────────────────────────────────────────────────────
+test_start "lorem_help_lists_the_types"
+util lorem --help
+assert_equals 0 "$RC" "rc"
+out_has "Usage: lorem [type] [count]" "usage"
+out_has "paragraphs, p" "types listed"
+
+test_start "lorem_rejects_an_unknown_type"
+util lorem sonnets
+assert_equals 1 "$RC" "rc"
+out_has "Unknown type: sonnets" "error"
+
+test_start "lorem_generates_the_requested_number_of_words"
+util lorem words 5
+assert_equals 0 "$RC" "rc"
+assert_equals "5" "$(wc -w <"$OUTF" | tr -d ' ')" "word count"
+assert_true "grep -qE '^[A-Z]' '$OUTF'" "first word is capitalised"
+
+test_start "lorem_generates_sentences"
+util lorem s 3
+assert_equals 0 "$RC" "rc"
+assert_equals "3" "$(wc -l <"$OUTF" | tr -d ' ')" "one sentence per line"
+assert_true "grep -qE '\\.$' '$OUTF'" "sentences end with a full stop"
+
+test_start "lorem_defaults_to_one_paragraph"
+util lorem
+assert_equals 0 "$RC" "rc"
+assert_equals "1" "$(grep -c . "$OUTF")" "a single non-empty paragraph"
+
+test_start "lorem_separates_multiple_paragraphs_with_a_blank_line"
+util lorem p 3
+assert_equals 0 "$RC" "rc"
+assert_equals "3" "$(grep -c . "$OUTF")" "three paragraphs"
+assert_equals "2" "$(grep -c '^$' "$OUTF")" "two separators"
+
+# ── hex ─────────────────────────────────────────────────────────────────
+test_start "hex_help_lists_the_modes"
+util hex --help
+assert_equals 0 "$RC" "rc"
+out_has "Usage: hex [OPTIONS] [INPUT]" "usage"
+
+test_start "hex_rejects_an_unknown_option"
+util hex --nope
+assert_equals 1 "$RC" "rc"
+out_has "Unknown option: --nope" "error"
+
+test_start "hex_encodes_a_string"
+util hex -e hello
+assert_equals 0 "$RC" "rc"
+out_has "68656c6c6f" "hex of 'hello'"
+
+test_start "hex_decodes_a_hex_string"
+util hex --decode "68656c6c6f"
+assert_equals 0 "$RC" "rc"
+out_has "hello" "round trip"
+
+test_start "hex_encodes_stdin_when_no_argument_is_given"
+printf 'hi\n' >"$WORK/in.txt"
+STDIN_FILE="$WORK/in.txt" util hex -e
+assert_equals 0 "$RC" "rc"
+out_has "6869" "hex of 'hi'"
+
+test_start "hex_views_a_file"
+printf 'AB' >"$WORK/bin.dat"
+util hex "$WORK/bin.dat"
+assert_equals 0 "$RC" "rc"
+out_has "4142" "file bytes"
+
+test_start "hex_honours_the_bytes_per_line_flag"
+printf 'ABCD' >"$WORK/bin2.dat"
+util hex -n 2 "$WORK/bin2.dat"
+assert_equals 0 "$RC" "rc"
+assert_equals "2" "$(wc -l <"$OUTF" | tr -d ' ')" "two lines of two bytes"
+
+test_start "hex_views_stdin_when_the_path_is_not_a_file"
+STDIN_FILE="$WORK/in.txt" util hex
+assert_equals 0 "$RC" "rc"
+out_has "6869" "stdin viewed"
+
+# ── hashsum ─────────────────────────────────────────────────────────────
+KNOWN_SHA256="2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824" # "hello"
+KNOWN_MD5="5d41402abc4b2a76b9719d911017c592"
+
+test_start "hashsum_help_documents_the_rename"
+util hashsum --help
+assert_equals 0 "$RC" "rc"
+out_has "renamed from 'hash'" "note"
+
+test_start "hashsum_rejects_an_unknown_option"
+util hashsum --nope
+assert_equals 1 "$RC" "rc"
+out_has "Unknown option: --nope" "error"
+
+test_start "hashsum_defaults_to_sha256"
+util hashsum hello
+assert_equals 0 "$RC" "rc"
+out_has "$KNOWN_SHA256" "sha256 of 'hello'"
+
+test_start "hashsum_supports_every_algorithm_flag"
+util hashsum -m hello
+out_has "$KNOWN_MD5" "md5"
+util hashsum --sha1 hello
+out_has "aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d" "sha1"
+util hashsum -5 hello
+out_has "9b71d224bd62f3785d96d46ad3ea3d73319bfbc2890caadae2dff72519673ca7" "sha512"
+util hashsum -2 hello
+out_has "$KNOWN_SHA256" "sha256"
+
+test_start "hashsum_all_mode_prints_every_algorithm"
+util hashsum -a hello
+assert_equals 0 "$RC" "rc"
+assert_equals "4" "$(grep -c . "$OUTF")" "four rows"
+out_has "$KNOWN_MD5" "md5 row"
+out_has "$KNOWN_SHA256" "sha256 row"
+
+test_start "hashsum_hashes_a_file"
+printf 'hello' >"$WORK/hello.txt"
+util hashsum -f "$WORK/hello.txt"
+assert_equals 0 "$RC" "rc"
+out_has "$KNOWN_SHA256" "same digest as the string"
+
+test_start "hashsum_reports_a_missing_file"
+util hashsum --file "$WORK/absent.txt"
+assert_equals 1 "$RC" "rc"
+out_has "File not found" "error"
+
+test_start "hashsum_check_mode_accepts_a_matching_digest"
+util hashsum -c "$KNOWN_SHA256" hello
+assert_equals 0 "$RC" "rc"
+out_has "Hash matches" "verdict"
+
+test_start "hashsum_check_mode_is_case_insensitive"
+util hashsum -c "$(printf '%s' "$KNOWN_SHA256" | tr 'a-z' 'A-Z')" hello
+assert_equals 0 "$RC" "rc"
+out_has "Hash matches" "verdict"
+
+test_start "hashsum_check_mode_rejects_a_mismatch"
+util hashsum -c "$KNOWN_MD5" hello
+assert_equals 1 "$RC" "rc"
+out_has "Hash mismatch" "verdict"
+out_has "Expected: $KNOWN_MD5" "expected digest echoed"
+
+test_start "hashsum_reads_stdin_when_given_no_input"
+printf 'hello\n' >"$WORK/hello-stdin.txt"
+STDIN_FILE="$WORK/hello-stdin.txt" util hashsum
+assert_equals 0 "$RC" "rc"
+out_has "$KNOWN_SHA256" "digest of the piped string"
+
+# ── jwt ─────────────────────────────────────────────────────────────────
+b64url() { printf '%s' "$1" | base64 | tr '+/' '-_' | tr -d '=\n'; }
+HDR="$(b64url '{"alg":"HS256","typ":"JWT"}')"
+PAST="$(b64url '{"sub":"tester","exp":1000000000,"iat":999999999}')"
+FUTURE="$(b64url '{"sub":"tester","exp":4102444800}')"
+
+test_start "jwt_rejects_a_token_without_a_payload"
+util jwt "onlyonepart"
+assert_equals 1 "$RC" "rc"
+out_has "Invalid JWT format" "error"
+
+test_start "jwt_decodes_header_and_payload"
+util jwt "$HDR.$PAST.signature"
+assert_equals 0 "$RC" "rc"
+out_has "=== Header ===" "header section"
+out_has "HS256" "alg decoded"
+out_has "tester" "payload decoded"
+out_has "=== Signature ===" "signature section"
+out_has "9 characters" "signature length reported"
+
+test_start "jwt_flags_an_expired_token"
+util jwt "$HDR.$PAST.sig"
+assert_equals 0 "$RC" "rc"
+out_has "Token EXPIRED at" "expiry verdict"
+out_has "Issued at" "iat rendered"
+
+test_start "jwt_reports_a_future_expiry"
+util jwt "$HDR.$FUTURE.sig"
+assert_equals 0 "$RC" "rc"
+out_has "Token expires at" "expiry verdict"
+
+test_start "jwt_strips_a_bearer_prefix_and_reads_stdin"
+printf 'Bearer %s.%s.sig\n' "$HDR" "$FUTURE" >"$WORK/token.txt"
+STDIN_FILE="$WORK/token.txt" util jwt
+assert_equals 0 "$RC" "rc"
+out_has "tester" "payload decoded from stdin"
+
+# ── regex ───────────────────────────────────────────────────────────────
+test_start "regex_help_and_missing_pattern"
+util regex --help
+assert_equals 0 "$RC" "rc"
+out_has "Usage: regex [OPTIONS]" "usage"
+util regex
+assert_equals 1 "$RC" "rc"
+out_has "Usage: regex [OPTIONS]" "usage on no args"
+
+test_start "regex_rejects_an_unknown_option"
+util regex --nope
+assert_equals 1 "$RC" "rc"
+out_has "Unknown option: --nope" "error"
+
+test_start "regex_reports_a_match"
+util regex --no-color '[0-9]+' 'abc123def'
+assert_equals 0 "$RC" "rc"
+out_has "Pattern: [0-9]+" "pattern echoed"
+out_has "Pattern matches" "verdict"
+
+test_start "regex_reports_a_miss_with_exit_1"
+util regex --no-color '[0-9]+' 'abcdef'
+assert_equals 1 "$RC" "rc"
+out_has "Pattern does not match" "verdict"
+
+test_start "regex_global_mode_counts_matches"
+util regex --no-color -g '[a-z]+' 'hello world'
+assert_equals 0 "$RC" "rc"
+# `wc -l` pads its count on BSD, so match the row rather than an exact string.
+assert_true "grep -qE 'Found +2 match\(es\)' '$OUTF'" "count"
+
+test_start "regex_global_mode_reports_no_matches"
+util regex --no-color --global '[0-9]+' 'abc'
+assert_equals 1 "$RC" "rc"
+out_has "No matches found" "verdict"
+
+test_start "regex_case_insensitive_and_colour_flags"
+util regex -i -c 'HELLO' 'hello'
+assert_equals 0 "$RC" "rc"
+out_has "Pattern matches" "verdict"
+
+test_start "regex_file_mode_reads_the_file"
+printf '# comment\nplain\n' >"$WORK/config.txt"
+util regex --no-color -f '^#' "$WORK/config.txt"
+assert_equals 0 "$RC" "rc"
+out_has "Pattern matches" "verdict"
+
+test_start "regex_file_mode_requires_a_readable_file"
+util regex -f '^#' "$WORK/absent.txt"
+assert_equals 1 "$RC" "rc"
+out_has "File required for -f mode" "error"
+
+test_start "regex_reads_stdin_when_no_input_is_given"
+printf 'from stdin\n' >"$WORK/stdin.txt"
+STDIN_FILE="$WORK/stdin.txt" util regex --no-color 'stdin'
+assert_equals 0 "$RC" "rc"
+out_has "Pattern matches" "verdict"
+
+# ── yamlv ───────────────────────────────────────────────────────────────
+test_start "yamlv_accepts_a_valid_file"
+printf 'key: value\nlist:\n  - one\n' >"$WORK/good.yaml"
+util yamlv "$WORK/good.yaml"
+assert_equals 0 "$RC" "rc"
+out_has "Valid YAML" "verdict"
+out_has "good.yaml" "source named"
+
+test_start "yamlv_rejects_an_invalid_file"
+printf 'key: [unclosed\n' >"$WORK/bad.yaml"
+util yamlv "$WORK/bad.yaml"
+assert_equals 1 "$RC" "rc"
+out_has "Invalid YAML" "verdict"
+
+test_start "yamlv_quiet_mode_prints_nothing_on_success"
+util yamlv -q "$WORK/good.yaml"
+assert_equals 0 "$RC" "rc"
+assert_equals "0" "$(wc -c <"$OUTF" | tr -d ' ')" "no output"
+
+test_start "yamlv_validates_stdin"
+STDIN_FILE="$WORK/good.yaml" util yamlv
+assert_equals 0 "$RC" "rc"
+out_has "Valid YAML (stdin)" "source is stdin"
+
+test_start "yamlv_falls_back_to_python_when_yq_is_absent"
+NOYQ="$DOTFILES_COV_TMPDIR/noyq"
+mkdir -p "$NOYQ"
+ln -sf "$(command -v bash)" "$NOYQ/bash"
+for c in cat printf echo sed grep tr head; do
+  p="$(command -v "$c" 2>/dev/null)" && ln -sf "$p" "$NOYQ/$c"
+done
+# python3 on PATH here is a mise shim, which needs mise itself; link the real
+# interpreter so the fallback can actually run. Whether *that* interpreter has
+# PyYAML installed is a property of the host, so assert the branch was taken
+# (a verdict was reached) rather than which way it went.
+ln -sf "$(python3 -c 'import sys; print(sys.executable)')" "$NOYQ/python3"
+PATH="$NOYQ" util yamlv "$WORK/good.yaml"
+assert_true "grep -qE '(Valid|Invalid) YAML' '$OUTF'" "the python fallback reached a verdict"
+assert_true "[[ $RC -eq 0 || $RC -eq 1 ]]" "and exited with a validation status"
+
+test_start "yamlv_reports_when_no_validator_is_available"
+NOVAL="$DOTFILES_COV_TMPDIR/noval"
+mkdir -p "$NOVAL"
+ln -sf "$(command -v bash)" "$NOVAL/bash"
+for c in cat printf echo sed grep tr head; do
+  p="$(command -v "$c" 2>/dev/null)" && ln -sf "$p" "$NOVAL/$c"
+done
+PATH="$NOVAL" util yamlv "$WORK/good.yaml"
+assert_equals 1 "$RC" "rc"
+out_has "yq, python3+pyyaml, or ruby required" "error names every option"
+
+echo "RESULTS:$TESTS_RUN:$TESTS_PASSED:$TESTS_FAILED"

--- a/tests/unit/tools/test_bin_text_utils_behaviour.sh
+++ b/tests/unit/tools/test_bin_text_utils_behaviour.sh
@@ -22,19 +22,36 @@ OUTF="$DOTFILES_COV_TMPDIR/out.txt"
 WORK="$DOTFILES_COV_TMPDIR/work"
 mkdir -p "$WORK"
 STDIN_FILE=/dev/null
+LOREM_ERR="$DOTFILES_COV_TMPDIR/lorem-err.txt"
 
 # util <name> <args…> — run one utility, stdout to $OUTF, status in RC.
+# $UTIL_BASH selects the interpreter: `bash` on PATH by default.
+UTIL_BASH="bash"
 util() {
   local name="$1"
   shift
   # stderr stays attached so the child's xtrace reaches the coverage trace.
-  bash "$BIN_DIR/executable_$name" "$@" >"$OUTF" <"$STDIN_FILE"
+  "$UTIL_BASH" "$BIN_DIR/executable_$name" "$@" >"$OUTF" <"$STDIN_FILE"
   RC=$?
   return 0
 }
 out_has() { assert_file_contains "$OUTF" "$1" "${2:-output contains $1}"; }
 
 # ── lorem ───────────────────────────────────────────────────────────────
+# `lorem` documents a bash 4+ requirement: it capitalises with `${word^}`,
+# which bash 3.2 — the system bash on macOS, and what `bash` resolves to on
+# the macos-14 runner — rejects as a bad substitution. Find an interpreter
+# that meets that requirement; when there is none, the generation paths get
+# their documented limitation asserted instead of generated text.
+LOREM_BASH=""
+for _cand in "$(command -v bash)" /opt/homebrew/bin/bash /usr/local/bin/bash; do
+  [[ -n "$_cand" && -x "$_cand" ]] || continue
+  if "$_cand" -c 'v=a; : "${v^}"' 2>/dev/null; then
+    LOREM_BASH="$_cand"
+    break
+  fi
+done
+
 test_start "lorem_help_lists_the_types"
 util lorem --help
 assert_equals 0 "$RC" "rc"
@@ -46,28 +63,41 @@ util lorem sonnets
 assert_equals 1 "$RC" "rc"
 out_has "Unknown type: sonnets" "error"
 
-test_start "lorem_generates_the_requested_number_of_words"
-util lorem words 5
-assert_equals 0 "$RC" "rc"
-assert_equals "5" "$(wc -w <"$OUTF" | tr -d ' ')" "word count"
-assert_true "grep -qE '^[A-Z]' '$OUTF'" "first word is capitalised"
+if [[ -z "$LOREM_BASH" ]]; then
+  test_start "lorem_generation_needs_the_bash_4_it_documents"
+  # Only the generation paths need it: --help and the unknown-type arm above
+  # ran fine on this same interpreter.
+  bash "$BIN_DIR/executable_lorem" words 3 >"$OUTF" 2>"$LOREM_ERR"
+  RC=$?
+  [[ "${DOTFILES_COV_ECHO_STDERR:-0}" == "1" ]] && cat "$LOREM_ERR" >&2
+  assert_true "[[ $RC -ne 0 ]]" "generation fails under bash 3.2"
+  assert_file_contains "$LOREM_ERR" "bad substitution" "the bash 4+ expansion is what fails"
+else
+  UTIL_BASH="$LOREM_BASH"
+  test_start "lorem_generates_the_requested_number_of_words"
+  util lorem words 5
+  assert_equals 0 "$RC" "rc"
+  assert_equals "5" "$(wc -w <"$OUTF" | tr -d ' ')" "word count"
+  assert_true "grep -qE '^[A-Z]' '$OUTF'" "first word is capitalised"
 
-test_start "lorem_generates_sentences"
-util lorem s 3
-assert_equals 0 "$RC" "rc"
-assert_equals "3" "$(wc -l <"$OUTF" | tr -d ' ')" "one sentence per line"
-assert_true "grep -qE '\\.$' '$OUTF'" "sentences end with a full stop"
+  test_start "lorem_generates_sentences"
+  util lorem s 3
+  assert_equals 0 "$RC" "rc"
+  assert_equals "3" "$(wc -l <"$OUTF" | tr -d ' ')" "one sentence per line"
+  assert_true "grep -qE '\\.$' '$OUTF'" "sentences end with a full stop"
 
-test_start "lorem_defaults_to_one_paragraph"
-util lorem
-assert_equals 0 "$RC" "rc"
-assert_equals "1" "$(grep -c . "$OUTF")" "a single non-empty paragraph"
+  test_start "lorem_defaults_to_one_paragraph"
+  util lorem
+  assert_equals 0 "$RC" "rc"
+  assert_equals "1" "$(grep -c . "$OUTF")" "a single non-empty paragraph"
 
-test_start "lorem_separates_multiple_paragraphs_with_a_blank_line"
-util lorem p 3
-assert_equals 0 "$RC" "rc"
-assert_equals "3" "$(grep -c . "$OUTF")" "three paragraphs"
-assert_equals "2" "$(grep -c '^$' "$OUTF")" "two separators"
+  test_start "lorem_separates_multiple_paragraphs_with_a_blank_line"
+  util lorem p 3
+  assert_equals 0 "$RC" "rc"
+  assert_equals "3" "$(grep -c . "$OUTF")" "three paragraphs"
+  assert_equals "2" "$(grep -c '^$' "$OUTF")" "two separators"
+  UTIL_BASH="bash"
+fi
 
 # ── hex ─────────────────────────────────────────────────────────────────
 test_start "hex_help_lists_the_modes"

--- a/tests/unit/tools/test_bin_text_utils_behaviour.sh
+++ b/tests/unit/tools/test_bin_text_utils_behaviour.sh
@@ -129,9 +129,17 @@ assert_equals 0 "$RC" "rc"
 out_has "41 42" "hexdump rendered the bytes"
 rm -f "$HEXPATH/hexdump"
 PATH="$HEXPATH" util hex "$WORK/bin.dat"
-# The od arm passes `-t x1z`, whose `z` format character BSD od rejects, so
-# on macOS the fallback runs and surfaces od's own failure.
-assert_true "[[ $RC -ne 0 ]]" "the od fallback ran"
+# The od arm passes `-t x1z`. GNU od accepts the `z` format character and
+# renders the dump; BSD od (macOS) rejects it, so the arm surfaces od's own
+# failure. Assert whichever this platform's od actually does — and in both
+# cases that it is the od arm, not the no-tool error.
+if od -A x -t x1z -v /dev/null >/dev/null 2>&1; then
+  assert_equals 0 "$RC" "the od fallback rendered the dump"
+  # GNU od spaces the byte columns: "41 42".
+  out_has "41 42" "od rendered the bytes"
+else
+  assert_true "[[ $RC -ne 0 ]]" "the od fallback ran and surfaced od's failure"
+fi
 assert_true "! grep -q 'required' '$OUTF'" "and it is not the no-tool error"
 rm -f "$HEXPATH/od"
 PATH="$HEXPATH" util hex "$WORK/bin.dat"


### PR DESCRIPTION
Twenty-one new test files, 388 assertions, everything sandboxed with PATH-shadowing stubs.

## Three real bugs, each caught by a new assertion and proven by reverting the fix

1. **`dot agent` and `dot mode` reported every failure as success.** The code read the exit status of a negated command, so a genuine failure logged `exit_code=0` and returned zero. This affected `dot mode run`, `dot agent checkpoint replay` and `dot agent delegate`.
2. **An MCP security check never fired on macOS.** Environment-placeholder detection used a GNU-only expression, so under BSD sed the "variable is not set" warning was silently dead.
3. **`lorem` ignored its count argument**, printing one sentence for `lorem s 5`, because a loop variable leaked between functions. Plain `lorem` also exited non-zero.

No exclusions and no seams were added. Every script was driven through its real entry point.

Two files initially overwritten were restored from HEAD and the new suites renamed alongside them; both originals still pass.
Signed-off-by: Sebastien Rousseau <sebastian.rousseau@gmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GkTMSRzg9EVUd11XZ9bbHC

---

THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co
