### PR TITLE
test: raise bash coverage on fleet, ai, security and shell functions; eight bugs fixed

### DIFF
--- a/defaults/.chezmoitemplates/functions/misc/lazy_loaders.sh
+++ b/defaults/.chezmoitemplates/functions/misc/lazy_loaders.sh
@@ -6,6 +6,11 @@
 # Lazy load nvm only when nvm, node, npm, or yarn is called
 if [[ -s "$HOME/.nvm/nvm.sh" ]]; then
   lazy_nvm() {
+    # The trigger names are ALIASES, not functions: `unset -f` alone
+    # leaves them in place, so every later `node`/`npm` call routes
+    # back through this loader and re-sources nvm.sh. Drop the aliases
+    # first so the shell resolves the real functions nvm.sh defines.
+    unalias nvm node npm yarn npx 2>/dev/null || true
     unset -f nvm node npm yarn npx
     export NVM_DIR="$HOME/.nvm"
     [[ -s "$NVM_DIR/nvm.sh" ]] && \. "$NVM_DIR/nvm.sh"
@@ -26,6 +31,11 @@ fi
 # RBENV (Ruby Version Manager)
 if command -v rbenv >/dev/null; then
   lazy_rbenv() {
+    # `unalias` before anything else: `rbenv` here is an alias, and the
+    # command substitution below is parsed at runtime with alias
+    # expansion on (every interactive shell), so `$(rbenv init -)`
+    # re-entered this function and forked without bound.
+    unalias rbenv ruby gem bundle 2>/dev/null || true
     unset -f rbenv ruby gem bundle
     eval "$(rbenv init -)"
     "$@"
@@ -40,6 +50,8 @@ fi
 # SDKMAN (Java/Groovy/Scala Version Manager)
 if [[ -s "$HOME/.sdkman/bin/sdkman-init.sh" ]]; then
   lazy_sdk() {
+    # Same alias-vs-function trap as lazy_nvm above.
+    unalias sdk java gradle mvn kotlin 2>/dev/null || true
     unset -f sdk java gradle mvn kotlin
     source "$HOME/.sdkman/bin/sdkman-init.sh"
     "$@"

--- a/defaults/dot_local/bin/executable_b64
+++ b/defaults/dot_local/bin/executable_b64
@@ -76,7 +76,11 @@ if [ "$MODE" = "encode" ]; then
 else
   # Add padding if needed for URL-safe decode
   if [ "$URL_SAFE" -eq 1 ]; then
-    INPUT=$(printf "%s" "$INPUT" | tr '-_' '+/')
+    # `--` before the set: a leading `-` in `-_` is parsed as an option
+    # by BSD tr ("tr: illegal option -- _"), so `b64 -d -u …` failed on
+    # every macOS host. The encode direction ('+/' → '-_') is unaffected
+    # because its first set starts with `+`.
+    INPUT=$(printf "%s" "$INPUT" | tr -- '-_' '+/')
     while [ $((${#INPUT} % 4)) -ne 0 ]; do INPUT="${INPUT}="; done
   fi
   # macOS/BSD base64 uses -D for decode; GNU coreutils uses -d.

--- a/defaults/dot_local/bin/executable_gl
+++ b/defaults/dot_local/bin/executable_gl
@@ -79,23 +79,30 @@ STRIP_TIMESTAMP="cut -d ' ' -f 2-"
 # shellcheck disable=SC2124
 GIT_LOG_DEFAULT="git log --pretty='${FORMAT_MESSAGE}' ${GIT_ARGS[*]} | ${STRIP_TIMESTAMP}"
 
-fzf \
-  --border --border-label " [ Enter: Show | Ctrl+O: Browser | Ctrl+Y: Copy hash ] " \
-  --disabled --no-sort --query "" \
-  --bind "start:reload(${GIT_LOG_DEFAULT})" \
-  --bind "change:reload:sleep 0.15
-      query={q};
-      if [ -z \"\${query}\" ]; then
-        ${GIT_LOG_DEFAULT}
-      else
-        [[ \"\${query}\" =~ [A-Z] ]] && case= || case=\"--regexp-ignore-case\"
-        (git log \${case} --pretty='${FORMAT_CODE}' ${GIT_ARGS[*]} -G \"\${query}\"
-         git log \${case} --pretty='${FORMAT_MESSAGE}' ${GIT_ARGS[*]} --grep \"\${query}\") |
-         sort --numeric-sort --reverse --unique --key 1,1 |
-         ${STRIP_TIMESTAMP}
-      fi" \
-  --bind "enter:execute(git show {1} -- | delta --paging always)" \
-  --bind "ctrl-o:execute-silent(bash -c 'source ${0}; open_commit_url {1}')" \
-  --bind "ctrl-y:execute-silent(printf '%s' {1} | cb)" \
-  --preview "git show {1} -- | delta --width=\${FZF_PREVIEW_COLUMNS}" \
-  --preview-window="right:70%" || true
+# Only launch the picker when gl is EXECUTED. The Ctrl+O binding below
+# re-enters this file with `bash -c 'source <gl>; open_commit_url …'`
+# to reuse the URL normaliser; without this guard that re-ran the whole
+# script and spawned a second, hidden fzf before the function it wanted
+# could run.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  fzf \
+    --border --border-label " [ Enter: Show | Ctrl+O: Browser | Ctrl+Y: Copy hash ] " \
+    --disabled --no-sort --query "" \
+    --bind "start:reload(${GIT_LOG_DEFAULT})" \
+    --bind "change:reload:sleep 0.15
+        query={q};
+        if [ -z \"\${query}\" ]; then
+          ${GIT_LOG_DEFAULT}
+        else
+          [[ \"\${query}\" =~ [A-Z] ]] && case= || case=\"--regexp-ignore-case\"
+          (git log \${case} --pretty='${FORMAT_CODE}' ${GIT_ARGS[*]} -G \"\${query}\"
+           git log \${case} --pretty='${FORMAT_MESSAGE}' ${GIT_ARGS[*]} --grep \"\${query}\") |
+           sort --numeric-sort --reverse --unique --key 1,1 |
+           ${STRIP_TIMESTAMP}
+        fi" \
+    --bind "enter:execute(git show {1} -- | delta --paging always)" \
+    --bind "ctrl-o:execute-silent(bash -c 'source ${0}; open_commit_url {1}')" \
+    --bind "ctrl-y:execute-silent(printf '%s' {1} | cb)" \
+    --preview "git show {1} -- | delta --width=\${FZF_PREVIEW_COLUMNS}" \
+    --preview-window="right:70%" || true
+fi

--- a/scripts/diagnostics/alias-governance.sh
+++ b/scripts/diagnostics/alias-governance.sh
@@ -54,6 +54,31 @@ if [[ -f "$SCRIPT_DIR/../../package.json" ]]; then
 fi
 repo_version="${repo_version:-0.0.0}"
 
+# ripgrep is preferred but is NOT guaranteed to be installed (the CI
+# runners and minimal setups often lack it, which is why
+# aliases-manifest.sh already carries a grep fallback). Without one
+# here, `rg` exiting 127 reads as "no match": every gated override was
+# reported as ungated, and this gate failed with false errors on any
+# machine without ripgrep.
+_gov_grep_file() { # <ere-pattern> <file>
+  if command -v rg >/dev/null 2>&1; then
+    rg -q "$1" "$2"
+  else
+    grep -qE "$1" "$2"
+  fi
+}
+
+_gov_grep_tree() { # <ere-pattern> <dir>...
+  local pattern="$1"
+  shift
+  if command -v rg >/dev/null 2>&1; then
+    rg -q --glob '*.sh' --glob '*.aliases.sh' --glob '*.tmpl' "$pattern" "$@" 2>/dev/null
+  else
+    grep -rqE --include='*.sh' --include='*.aliases.sh' --include='*.tmpl' \
+      "$pattern" "$@" 2>/dev/null
+  fi
+}
+
 # 1) Duplicate alias names
 dupes="$(awk -F'\t' '{count[$1]++} END {for (k in count) if (count[k] > 1) print k}' "$tmp_manifest" | sort)"
 if [[ -n "$dupes" ]]; then
@@ -77,7 +102,7 @@ while IFS=$'\t' read -r name _value file _line; do
       if [[ "$file" == *"/aliases/gnu/"* ]]; then
         continue
       fi
-      if ! rg -q 'DOTFILES_(ENABLE|SAFE|ALIAS)' "$file"; then
+      if ! _gov_grep_file 'DOTFILES_(ENABLE|SAFE|ALIAS)' "$file"; then
         echo "ERROR: risky override '$name' in $file is not gated by a DOTFILES_* flag"
         errors=$((errors + 1))
       fi
@@ -111,7 +136,9 @@ if [[ -f "$deprecations_file" ]]; then
         alias_found=1
       fi
       function_found=0
-      if rg -q --glob '*.sh' --glob '*.aliases.sh' --glob '*.tmpl' "^[[:space:]]*(function[[:space:]]+)?${alias_name}[[:space:]]*\\(\\)" "$SCRIPT_DIR/../../defaults/.chezmoitemplates/aliases" "$SCRIPT_DIR/../../scripts/dot"; then
+      if _gov_grep_tree "^[[:space:]]*(function[[:space:]]+)?${alias_name}[[:space:]]*\\(\\)" \
+        "$SCRIPT_DIR/../../defaults/.chezmoitemplates/aliases" \
+        "$SCRIPT_DIR/../../scripts/dot"; then
         function_found=1
       fi
       if [[ $alias_found -eq 1 || $function_found -eq 1 ]]; then

--- a/scripts/dot/commands/agents.sh
+++ b/scripts/dot/commands/agents.sh
@@ -148,10 +148,18 @@ cmd_agents() {
         ui_warn "AGENTS.md" "missing — run 'dot agents render'"
         return 1
       fi
-      # Diff the bodies (header comments differ by design).
-      # `--ignore-blank-lines` so the trailing newline from the footer
-      # block doesn't false-positive as drift.
-      if diff -q --ignore-blank-lines <(_agents_body "$claude_md") <(_agents_body "$agents_md") >/dev/null 2>&1; then
+      # Compare the bodies (header comments differ by design), ignoring
+      # blank lines: the rendered file carries an extra one after its
+      # header block. This deliberately does NOT lean on
+      # `diff -q --ignore-blank-lines` — some BSD diff builds (macOS 14's,
+      # for one) short-circuit `-q` to a byte comparison and drop the
+      # ignore flags, which made `check` report drift on a tree it had
+      # just rendered. Stripping the blank lines here is implementation-
+      # independent.
+      local _claude_body _agents_body_text
+      _claude_body="$(_agents_body "$claude_md" | grep -v '^[[:space:]]*$')"
+      _agents_body_text="$(_agents_body "$agents_md" | grep -v '^[[:space:]]*$')"
+      if [[ "$_claude_body" == "$_agents_body_text" ]]; then
         ui_ok "AGENTS.md" "in sync with CLAUDE.md"
         return 0
       fi

--- a/scripts/dot/commands/ai.sh
+++ b/scripts/dot/commands/ai.sh
@@ -23,20 +23,15 @@ AI_STATUS_TTL="${DOTFILES_AI_STATUS_TTL:-300}"
 AI_STATUS_CACHE_FILE="${AI_CACHE_DIR}/status.tsv"
 
 # Fallback to source tree if patterns don't exist in config (common in CI).
-# `.chezmoiroot` moves the chezmoi source tree one level down (it holds
-# `defaults` here), so the patterns ship at
-# <repo>/<chezmoiroot>/dot_config/ai/patterns — probing only
-# <repo>/dot_config/ai/patterns made this fallback a no-op and
-# `dot ai <tool> --style <name>` died with "Pattern not found" on exactly
-# the un-deployed machines the fallback exists for.
+# `.chezmoiroot` moves the source tree one level down (it holds
+# `defaults` here), so probing <repo>/dot_config/… alone made this a
+# no-op and `--style` died with "Pattern not found" off-deployment.
 if [[ ! -d "$PATTERN_DIR" ]]; then
   _AI_SRC="$(cd "$SCRIPT_DIR/../../.." && pwd)"
-  _AI_ROOT_SUB=""
-  if [[ -f "$_AI_SRC/.chezmoiroot" ]]; then
-    _AI_ROOT_SUB="$(head -1 "$_AI_SRC/.chezmoiroot" | tr -d '[:space:]')"
-  fi
-  for _AI_CAND in "$_AI_SRC/dot_config/ai/patterns" \
-    ${_AI_ROOT_SUB:+"$_AI_SRC/$_AI_ROOT_SUB/dot_config/ai/patterns"}; do
+  _AI_SUB=""
+  [[ -f "$_AI_SRC/.chezmoiroot" ]] &&
+    _AI_SUB="/$(head -1 "$_AI_SRC/.chezmoiroot" | tr -d '[:space:]')"
+  for _AI_CAND in "$_AI_SRC/dot_config/ai/patterns" "$_AI_SRC$_AI_SUB/dot_config/ai/patterns"; do
     if [[ -d "$_AI_CAND" ]]; then
       PATTERN_DIR="$_AI_CAND"
       break
@@ -418,10 +413,8 @@ ${prompt}"
         do_install=$(gum confirm "Install $tool via mise ($mise_pkg)?" && echo "yes" || echo "no")
       else
         printf "Install %s via mise (%s)? [y/N] " "$tool" "$mise_pkg"
-        # `|| true`: with stdin at EOF (piped, cron, CI) `read` returns 1
-        # and `set -e` killed the script mid-prompt — no answer, no
-        # install hint, bare rc 1. EOF means "no", which the case below
-        # already handles.
+        # `|| true`: at EOF (piped, cron, CI) `read` returns 1 and
+        # `set -e` killed the script mid-prompt. EOF means "no".
         read -r do_install || true
         case "$do_install" in y | Y | yes) do_install="yes" ;; *) do_install="no" ;; esac
       fi

--- a/scripts/dot/commands/ai.sh
+++ b/scripts/dot/commands/ai.sh
@@ -22,12 +22,26 @@ AI_CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/dotfiles/ai"
 AI_STATUS_TTL="${DOTFILES_AI_STATUS_TTL:-300}"
 AI_STATUS_CACHE_FILE="${AI_CACHE_DIR}/status.tsv"
 
-# Fallback to source tree if patterns don't exist in config (common in CI)
+# Fallback to source tree if patterns don't exist in config (common in CI).
+# `.chezmoiroot` moves the chezmoi source tree one level down (it holds
+# `defaults` here), so the patterns ship at
+# <repo>/<chezmoiroot>/dot_config/ai/patterns — probing only
+# <repo>/dot_config/ai/patterns made this fallback a no-op and
+# `dot ai <tool> --style <name>` died with "Pattern not found" on exactly
+# the un-deployed machines the fallback exists for.
 if [[ ! -d "$PATTERN_DIR" ]]; then
   _AI_SRC="$(cd "$SCRIPT_DIR/../../.." && pwd)"
-  if [[ -d "$_AI_SRC/dot_config/ai/patterns" ]]; then
-    PATTERN_DIR="$_AI_SRC/dot_config/ai/patterns"
+  _AI_ROOT_SUB=""
+  if [[ -f "$_AI_SRC/.chezmoiroot" ]]; then
+    _AI_ROOT_SUB="$(head -1 "$_AI_SRC/.chezmoiroot" | tr -d '[:space:]')"
   fi
+  for _AI_CAND in "$_AI_SRC/dot_config/ai/patterns" \
+    ${_AI_ROOT_SUB:+"$_AI_SRC/$_AI_ROOT_SUB/dot_config/ai/patterns"}; do
+    if [[ -d "$_AI_CAND" ]]; then
+      PATTERN_DIR="$_AI_CAND"
+      break
+    fi
+  done
 fi
 
 _show_ai_bridge_usage() {
@@ -404,7 +418,11 @@ ${prompt}"
         do_install=$(gum confirm "Install $tool via mise ($mise_pkg)?" && echo "yes" || echo "no")
       else
         printf "Install %s via mise (%s)? [y/N] " "$tool" "$mise_pkg"
-        read -r do_install
+        # `|| true`: with stdin at EOF (piped, cron, CI) `read` returns 1
+        # and `set -e` killed the script mid-prompt — no answer, no
+        # install hint, bare rc 1. EOF means "no", which the case below
+        # already handles.
+        read -r do_install || true
         case "$do_install" in y | Y | yes) do_install="yes" ;; *) do_install="no" ;; esac
       fi
       if [[ "$do_install" == "yes" ]]; then

--- a/scripts/dot/commands/fleet.sh
+++ b/scripts/dot/commands/fleet.sh
@@ -206,9 +206,12 @@ cmd_fleet_drift() {
       tail -n "$count" "$_DRIFT_HISTORY_FILE" | while IFS= read -r line; do
         local time status file_count
         # One jq per line (was three: .time, .status, .files|length).
+        # `|| true`: on an unparseable line jq prints nothing, `read`
+        # hits EOF and returns 1, and `set -e` would otherwise abort the
+        # whole listing instead of rendering the `?` placeholders below.
         IFS=$'\t' read -r time status file_count < <(
           printf '%s' "$line" | jq -r '[.time, .status, (.files | length)] | @tsv' 2>/dev/null
-        )
+        ) || true
         [[ -n "$time" ]] || time="?"
         [[ -n "$status" ]] || status="?"
         [[ -n "$file_count" ]] || file_count=0

--- a/scripts/dot/commands/fleet.sh
+++ b/scripts/dot/commands/fleet.sh
@@ -206,7 +206,7 @@ cmd_fleet_drift() {
       tail -n "$count" "$_DRIFT_HISTORY_FILE" | while IFS= read -r line; do
         local time status file_count
         # One jq per line (was three: .time, .status, .files|length).
-        # `|| true`: on an unparseable line jq prints nothing, `read`
+        # `|| true`: on an unparsable line jq prints nothing, `read`
         # hits EOF and returns 1, and `set -e` would otherwise abort the
         # whole listing instead of rendering the `?` placeholders below.
         IFS=$'\t' read -r time status file_count < <(

--- a/scripts/dot/commands/tools.sh
+++ b/scripts/dot/commands/tools.sh
@@ -196,7 +196,15 @@ show_language_package_managers() {
     # mid-output. Capture the pipeline separately so we can fall back
     # cleanly without stray "N/A" lines from pipe-with-|| tricks.
     if pipx_list_out="$(pipx list --short 2>/dev/null)"; then
-      pipx_installed="$(printf '%s' "$pipx_list_out" | wc -l | tr -d ' ')"
+      # Command substitution strips the trailing newline, so counting
+      # with `printf '%s' … | wc -l` reported one package fewer than
+      # installed (and 0 when exactly one was installed). Re-add the
+      # terminator, and treat "no output" as zero rather than one.
+      if [[ -n "$pipx_list_out" ]]; then
+        pipx_installed="$(printf '%s\n' "$pipx_list_out" | wc -l | tr -d ' ')"
+      else
+        pipx_installed=0
+      fi
     else
       pipx_installed="N/A"
     fi

--- a/scripts/qa/check-version-consistency.sh
+++ b/scripts/qa/check-version-consistency.sh
@@ -24,7 +24,10 @@
 
 set -euo pipefail
 
-REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# Honour a caller-supplied REPO_ROOT, matching scorecard-snapshot.sh,
+# a2a-conformance.sh and the other repo-scoped QA scripts. Lets the
+# checker run against a fixture tree without being copied into it.
+REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
 cd "$REPO_ROOT"
 
 # ── Parse flags ─────────────────────────────────────────────────────────

--- a/scripts/qa/check-version-consistency.sh
+++ b/scripts/qa/check-version-consistency.sh
@@ -49,8 +49,12 @@ _log() { ((quiet)) || printf '%s\n' "$*"; }
 _err() { printf 'check-version-consistency: %s\n' "$*" >&2; }
 
 # ── Canonical version ──────────────────────────────────────────────────
-canonical="$(grep -E '^dotfiles_version[[:space:]]*=' defaults/.chezmoidata.toml |
-  head -1 | sed -E 's/.*"([^"]+)".*/\1/')"
+# `|| true`: when the key is absent grep exits 1, and under
+# `set -euo pipefail` that aborted the script right here — rc 1 with no
+# message, indistinguishable from "drift detected", and the documented
+# rc 2 below was unreachable. Let the emptiness check do the reporting.
+canonical="$(grep -E '^dotfiles_version[[:space:]]*=' defaults/.chezmoidata.toml 2>/dev/null |
+  head -1 | sed -E 's/.*"([^"]+)".*/\1/' || true)"
 
 if [[ -z "$canonical" ]]; then
   _err 'failed to read dotfiles_version from defaults/.chezmoidata.toml'

--- a/tests/unit/diagnostics/test_a2a_conformance_fixtures.sh
+++ b/tests/unit/diagnostics/test_a2a_conformance_fixtures.sh
@@ -29,6 +29,22 @@ BASH_BIN="$(command -v bash)"
 trap cov_teardown_sandbox EXIT
 cov_setup_sandbox
 
+# Substring refutation on an already-captured string. The framework's
+# assert_output_not_contains re-runs its arguments through `eval`, so
+# feeding captured output back in breaks on any shell metacharacter the
+# program happened to print.
+_refute_contains() { # <needle> <haystack> <msg>
+  if [[ "$2" != *"$1"* ]]; then
+    ((TESTS_PASSED++)) || true
+    printf '%b\n' "  ${GREEN}✓${NC} $CURRENT_TEST: $3"
+    return 0
+  fi
+  ((TESTS_FAILED++)) || true
+  printf '%b\n' "  ${RED}✗${NC} $CURRENT_TEST: $3"
+  printf '%b\n' "    Should not contain: '$1'"
+  return 1
+}
+
 if ! command -v jq >/dev/null 2>&1; then
   echo "SKIP: jq is required for these fixtures"
   echo "RESULTS:0:0:0"
@@ -155,7 +171,7 @@ _card="$_root/.well-known/agent-card.json"
 jq '.skills = []' "$_card" >"$_card.tmp" && mv "$_card.tmp" "$_card"
 _list="$(_issues "$_root")"
 assert_contains "skills:empty array" "$_list" "an empty array is still an issue"
-assert_output_not_contains "skills:missing or not array" printf '%s' "$_list"
+_refute_contains "skills:missing or not array" "$_list" "a present-but-empty array is not a type error"
 
 test_start "a2a_cross_checks_the_internal_card"
 _root="$(_fixture internal)"

--- a/tests/unit/diagnostics/test_a2a_conformance_fixtures.sh
+++ b/tests/unit/diagnostics/test_a2a_conformance_fixtures.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2015-2026 Sebastien Rousseau
+# shellcheck disable=SC1090,SC1091,SC2034
+#
+# Behaviour tests for scripts/diagnostics/a2a-conformance.sh. The
+# script honours $REPO_ROOT, so every case builds a throwaway agent-card
+# tree and asserts the exact issue it should raise: a healthy tree, each
+# missing document, the specVersion / skills / authentication / signing
+# / capabilities / protocol checks, the internal-card and legacy-doc
+# cross-checks, name consistency, the default-profile lookup, card
+# signing, both output modes and the --strict exit code.
+#
+# AUTO-GENERATED: false (hand-written)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+source "$SCRIPT_DIR/../../framework/assertions.sh"
+source "$SCRIPT_DIR/../../framework/coverage_helpers.sh"
+
+# Hand children a copy of the real stderr so their xtrace still reaches
+# the coverage runner even though the probes capture output with 2>&1.
+exec 21>&2
+export BASH_XTRACEFD=21
+
+A2A="$REPO_ROOT/scripts/diagnostics/a2a-conformance.sh"
+BASH_BIN="$(command -v bash)"
+
+trap cov_teardown_sandbox EXIT
+cov_setup_sandbox
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "SKIP: jq is required for these fixtures"
+  echo "RESULTS:0:0:0"
+  exit 0
+fi
+
+# _fixture <name> — a conformant agent-card tree; prints its root.
+_fixture() {
+  local root="$DOTFILES_COV_TMPDIR/$1"
+  mkdir -p "$root/.well-known" "$root/defaults/dot_config/dotfiles"
+  cat >"$root/.well-known/agent-card.json" <<'JSON'
+{
+  "name": "dotfiles",
+  "specVersion": "0.3",
+  "protocols": ["a2a"],
+  "skills": [{"id": "doctor"}],
+  "authentication": {"schemes": ["none"]},
+  "signing": {"method": "ssh-ed25519"},
+  "capabilities": {"streaming": false}
+}
+JSON
+  cat >"$root/.well-known/agent.json" <<'JSON'
+{"name": "dotfiles", "protocols": ["a2a"], "a2aCard": "/.well-known/agent-card.json"}
+JSON
+  cat >"$root/defaults/dot_config/dotfiles/agent-card.json" <<'JSON'
+{
+  "name": "dotfiles",
+  "specVersion": "0.3",
+  "protocols": ["a2a"],
+  "defaultProfile": "ask",
+  "security": {"cardSigning": {"required": true}}
+}
+JSON
+  cat >"$root/defaults/dot_config/dotfiles/agent-profiles.json" <<'JSON'
+{"profiles": {"ask": {"description": "read-only"}}}
+JSON
+  printf '%s\n' "$root"
+}
+
+_conform() { # <root> [args…]
+  REPO_ROOT="$1" "$BASH_BIN" "$A2A" "${@:2}" 2>&1
+}
+
+# _issues <root> — the issue strings from --json output, one per line.
+_issues() {
+  _conform "$1" --json | jq -r '.issues[]'
+}
+
+test_start "a2a_healthy_tree_reports_healthy_in_both_modes"
+_root="$(_fixture healthy)"
+_out="$(_conform "$_root" --json)"
+_rc=$?
+assert_equals 0 "$_rc" "healthy tree exits 0"
+assert_equals "healthy" "$(printf '%s' "$_out" | jq -r '.status')" "status is healthy"
+assert_equals "0.3" "$(printf '%s' "$_out" | jq -r '.specVersion')" "spec version reported"
+assert_equals "0" "$(printf '%s' "$_out" | jq -r '.issues | length')" "no issues"
+assert_equals "false" "$(printf '%s' "$_out" | jq -r '.strict')" "strict flag defaults to false"
+_out="$(_conform "$_root")"
+assert_contains "A2A v0.3 Conformance" "$_out" "human-readable header printed"
+assert_contains "healthy" "$_out" "human-readable status printed"
+
+test_start "a2a_strict_flag_is_reported_and_kept_green_when_healthy"
+_out="$(_conform "$_root" --strict --json)"
+_rc=$?
+assert_equals 0 "$_rc" "strict on a healthy tree exits 0"
+assert_equals "true" "$(printf '%s' "$_out" | jq -r '.strict')" "strict flag recorded"
+_out="$(_conform "$_root" -s -j)"
+assert_equals "true" "$(printf '%s' "$_out" | jq -r '.strict')" "short flags are equivalent"
+
+test_start "a2a_ignores_unknown_arguments"
+_out="$(_conform "$_root" --json --whatever extra)"
+assert_equals "healthy" "$(printf '%s' "$_out" | jq -r '.status')" "unknown args do not change the verdict"
+
+test_start "a2a_reports_each_missing_document"
+_root="$(_fixture missing)"
+rm -f "$_root/.well-known/agent-card.json" \
+  "$_root/.well-known/agent.json" \
+  "$_root/defaults/dot_config/dotfiles/agent-card.json" \
+  "$_root/defaults/dot_config/dotfiles/agent-profiles.json"
+_out="$(_conform "$_root" --json)"
+assert_equals "issues" "$(printf '%s' "$_out" | jq -r '.status')" "status flips to issues"
+_list="$(printf '%s' "$_out" | jq -r '.issues[]')"
+assert_contains "missing:.well-known/agent-card.json" "$_list" "primary card reported"
+assert_contains "missing:.well-known/agent.json" "$_list" "legacy doc reported"
+assert_contains "missing:agent-card.json" "$_list" "internal card reported"
+assert_contains "missing:agent-profiles.json" "$_list" "profiles reported"
+
+test_start "a2a_human_output_lists_the_issues"
+_out="$(_conform "$_root")"
+assert_contains "Issue" "$_out" "issues are rendered in human mode"
+assert_contains "missing:agent-profiles.json" "$_out" "the specific issue is shown"
+
+test_start "a2a_strict_mode_fails_when_issues_exist"
+_out="$(_conform "$_root" --strict)"
+_rc=$?
+assert_equals 1 "$_rc" "strict + issues exits 1"
+_out="$(_conform "$_root")"
+_rc=$?
+assert_equals 0 "$_rc" "without --strict the same tree exits 0"
+
+test_start "a2a_flags_a_wrong_spec_version_and_a2a_ready_protocol"
+_root="$(_fixture badspec)"
+_card="$_root/.well-known/agent-card.json"
+jq '.specVersion = "0.2" | .protocols = ["a2a-ready"]' "$_card" >"$_card.tmp" && mv "$_card.tmp" "$_card"
+_list="$(_issues "$_root")"
+assert_contains "specVersion:expected 0.3, got 0.2" "$_list" "spec version mismatch named with both values"
+assert_contains "protocols:should use 'a2a' not 'a2a-ready'" "$_list" "legacy protocol name rejected"
+assert_contains "protocols:missing 'a2a'" "$_list" "missing canonical protocol reported"
+
+test_start "a2a_flags_missing_card_sections"
+_root="$(_fixture sections)"
+_card="$_root/.well-known/agent-card.json"
+jq 'del(.skills, .authentication, .signing, .capabilities)' "$_card" >"$_card.tmp" && mv "$_card.tmp" "$_card"
+_list="$(_issues "$_root")"
+assert_contains "skills:missing or not array" "$_list" "skills section required"
+assert_contains "skills:empty array" "$_list" "empty skills reported"
+assert_contains "authentication:missing" "$_list" "authentication required"
+assert_contains "signing:missing method" "$_list" "signing method required"
+assert_contains "capabilities:missing" "$_list" "capabilities required"
+
+test_start "a2a_flags_an_empty_skills_array"
+_root="$(_fixture emptyskills)"
+_card="$_root/.well-known/agent-card.json"
+jq '.skills = []' "$_card" >"$_card.tmp" && mv "$_card.tmp" "$_card"
+_list="$(_issues "$_root")"
+assert_contains "skills:empty array" "$_list" "an empty array is still an issue"
+assert_output_not_contains "skills:missing or not array" printf '%s' "$_list"
+
+test_start "a2a_cross_checks_the_internal_card"
+_root="$(_fixture internal)"
+_ic="$_root/defaults/dot_config/dotfiles/agent-card.json"
+jq '.specVersion = "0.2" | .protocols = ["a2a-ready"] | del(.security)' "$_ic" >"$_ic.tmp" && mv "$_ic.tmp" "$_ic"
+_list="$(_issues "$_root")"
+assert_contains "internal-card:specVersion expected 0.3" "$_list" "internal spec version checked"
+assert_contains "internal-card:should use 'a2a' not 'a2a-ready'" "$_list" "internal protocol checked"
+assert_contains "internal-card:missing cardSigning in security" "$_list" "card signing required"
+
+test_start "a2a_cross_checks_the_legacy_document"
+_root="$(_fixture legacy)"
+_ld="$_root/.well-known/agent.json"
+jq 'del(.a2aCard) | .protocols = ["a2a-ready"]' "$_ld" >"$_ld.tmp" && mv "$_ld.tmp" "$_ld"
+_list="$(_issues "$_root")"
+assert_contains "legacy:missing a2aCard pointer" "$_list" "pointer to the new card required"
+assert_contains "legacy:should use 'a2a' not 'a2a-ready'" "$_list" "legacy protocol name rejected"
+
+test_start "a2a_requires_consistent_names_across_the_three_documents"
+_root="$(_fixture names)"
+_ic="$_root/defaults/dot_config/dotfiles/agent-card.json"
+_ld="$_root/.well-known/agent.json"
+jq '.name = "other"' "$_ic" >"$_ic.tmp" && mv "$_ic.tmp" "$_ic"
+jq '.name = "different"' "$_ld" >"$_ld.tmp" && mv "$_ld.tmp" "$_ld"
+_list="$(_issues "$_root")"
+assert_contains "name:mismatch between a2a-card and internal card" "$_list" "internal-card name checked"
+assert_contains "name:mismatch between a2a-card and legacy doc" "$_list" "legacy name checked"
+
+test_start "a2a_requires_the_default_profile_to_exist"
+_root="$(_fixture profile)"
+_ap="$_root/defaults/dot_config/dotfiles/agent-profiles.json"
+jq '.profiles = {"other": {}}' "$_ap" >"$_ap.tmp" && mv "$_ap.tmp" "$_ap"
+_list="$(_issues "$_root")"
+assert_contains "default-profile:missing in agent-profiles.json" "$_list" "unknown default profile reported"
+
+test_start "a2a_requires_jq"
+_root="$(_fixture nojq)"
+_bare="$DOTFILES_COV_TMPDIR/bare-a2a"
+mkdir -p "$_bare"
+for _t in bash cat printf echo sed tr uname dirname basename tput; do
+  _p="$(command -v "$_t" 2>/dev/null || true)"
+  [[ -n "$_p" ]] && ln -sf "$_p" "$_bare/$_t"
+done
+_out="$(REPO_ROOT="$_root" PATH="$_bare" "$BASH_BIN" "$A2A" --json 2>&1)"
+_rc=$?
+assert_equals 1 "$_rc" "missing jq exits 1"
+assert_contains "jq is required" "$_out" "prerequisite named"
+
+echo "RESULTS:$TESTS_RUN:$TESTS_PASSED:$TESTS_FAILED"

--- a/tests/unit/diagnostics/test_alias_manifest_governance_fixtures.sh
+++ b/tests/unit/diagnostics/test_alias_manifest_governance_fixtures.sh
@@ -37,6 +37,22 @@ BASH_BIN="$(command -v bash)"
 trap cov_teardown_sandbox EXIT
 cov_setup_sandbox
 
+# Substring refutation on an already-captured string. The framework's
+# assert_output_not_contains re-runs its arguments through `eval`, so
+# feeding captured output back in breaks on any shell metacharacter the
+# program happened to print.
+_refute_contains() { # <needle> <haystack> <msg>
+  if [[ "$2" != *"$1"* ]]; then
+    ((TESTS_PASSED++)) || true
+    printf '%b\n' "  ${GREEN}✓${NC} $CURRENT_TEST: $3"
+    return 0
+  fi
+  ((TESTS_FAILED++)) || true
+  printf '%b\n' "  ${RED}✗${NC} $CURRENT_TEST: $3"
+  printf '%b\n' "    Should not contain: '$1'"
+  return 1
+}
+
 # _tree <name> — an empty source tree with both directories the
 # manifest searches (a missing one makes ripgrep exit 2).
 _tree() {
@@ -214,6 +230,47 @@ _rc=$?
 assert_equals 0 "$_rc" "the default checkout is used"
 assert_contains "xdg" "$_out" "its aliases are inventoried"
 assert_contains "$_home/.local/share/chezmoi" "$_out" "rows point into that checkout"
+
+test_start "governance_reaches_the_same_verdict_without_ripgrep"
+# The CI runners have no ripgrep. Before alias-governance.sh grew a grep
+# fallback, `rg` exiting 127 read as "no match" and every gated override
+# was reported as ungated — the repo's own governance run failed with
+# eight phantom errors on Linux.
+_norg="$DOTFILES_COV_TMPDIR/norg"
+mkdir -p "$_norg"
+for _t in bash grep sed awk sort uniq head tail cut wc tr cat printf echo \
+  mktemp rm dirname basename jq; do
+  _p="$("$BASH_BIN" -c "command -v $_t" 2>/dev/null || true)"
+  [[ -n "$_p" ]] && ln -sf "$_p" "$_norg/$_t"
+done
+
+_root="$(_tree g-gated-norg)"
+{
+  echo "# Enable with DOTFILES_ENABLE_CD=1"
+  echo '[ -n ${DOTFILES_ENABLE_CD:-} ] && alias cd=pushd'
+} >"$_root/.chezmoitemplates/aliases/gated.aliases.sh"
+_out="$(env CHEZMOI_SOURCE_DIR="$_root" CI="" PATH="$_norg" "$BASH_BIN" "$GOVERNANCE" 2>&1)"
+_rc=$?
+assert_equals 0 "$_rc" "a gated override still passes without ripgrep"
+assert_contains "OK: risky overrides are gated" "$_out" "the gate is evaluated, not skipped"
+_refute_contains "command not found" "$_out" "no tool is missing from the fallback path"
+
+_root="$(_tree g-risky-norg)"
+printf "alias cd='pushd'\n" >"$_root/.chezmoitemplates/aliases/risky.aliases.sh"
+_out="$(env CHEZMOI_SOURCE_DIR="$_root" CI="" PATH="$_norg" "$BASH_BIN" "$GOVERNANCE" 2>&1)"
+_rc=$?
+assert_equals 1 "$_rc" "an ungated override still fails without ripgrep"
+assert_contains "ERROR: risky override 'cd'" "$_out" "the same error is produced"
+
+# The deprecation window also searches the tree with ripgrep; exercise
+# its grep fallback (recursive + --include globs) too.
+_root="$(_tree g-deprecated-norg)"
+printf "alias dlogsf='docker logs -f'\n" \
+  >"$_root/.chezmoitemplates/aliases/deprecated.aliases.sh"
+_out="$(env CHEZMOI_SOURCE_DIR="$_root" CI="" PATH="$_norg" "$BASH_BIN" "$GOVERNANCE" 2>&1)"
+_rc=$?
+assert_equals 1 "$_rc" "an expired deprecation still fails without ripgrep"
+assert_contains "expired deprecated aliases still present" "$_out" "the same verdict is reached"
 
 test_start "governance_rejects_hardcoded_user_paths"
 _root="$(_tree g-paths)"

--- a/tests/unit/diagnostics/test_alias_manifest_governance_fixtures.sh
+++ b/tests/unit/diagnostics/test_alias_manifest_governance_fixtures.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2015-2026 Sebastien Rousseau
+# shellcheck disable=SC1090,SC1091,SC2034
+#
+# Behaviour tests for the alias inventory pair:
+#
+#   aliases-manifest.sh  — emits name/value/file/line TSV rows for every
+#                          alias in a chezmoi source tree, including the
+#                          `cond && alias x=y` form, and honours
+#                          `.chezmoiroot`.
+#   alias-governance.sh  — grades that manifest: duplicate names, risky
+#                          overrides that are not gated behind a
+#                          DOTFILES_* flag, and hardcoded /Users paths,
+#                          under both the standard and strict policies.
+#
+# Every case runs against a throwaway source tree pointed at through
+# CHEZMOI_SOURCE_DIR, so the assertions never depend on the aliases the
+# repo itself happens to ship.
+#
+# AUTO-GENERATED: false (hand-written)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+source "$SCRIPT_DIR/../../framework/assertions.sh"
+source "$SCRIPT_DIR/../../framework/coverage_helpers.sh"
+
+# Hand children a copy of the real stderr so their xtrace still reaches
+# the coverage runner even though the probes capture output with 2>&1.
+exec 21>&2
+export BASH_XTRACEFD=21
+
+MANIFEST="$REPO_ROOT/scripts/diagnostics/aliases-manifest.sh"
+GOVERNANCE="$REPO_ROOT/scripts/diagnostics/alias-governance.sh"
+BASH_BIN="$(command -v bash)"
+
+trap cov_teardown_sandbox EXIT
+cov_setup_sandbox
+
+# _tree <name> — an empty source tree with both directories the
+# manifest searches (a missing one makes ripgrep exit 2).
+_tree() {
+  local root="$DOTFILES_COV_TMPDIR/$1"
+  mkdir -p "$root/.chezmoitemplates/aliases" "$root/.chezmoitemplates/functions"
+  printf '%s\n' "$root"
+}
+
+_manifest() { # <source-dir> [args…]
+  CHEZMOI_SOURCE_DIR="$1" "$BASH_BIN" "$MANIFEST" "${@:2}" 2>&1
+}
+
+_govern() { # <source-dir> [ENV=value …]
+  local src="$1"
+  shift
+  env CHEZMOI_SOURCE_DIR="$src" CI="" "$@" "$BASH_BIN" "$GOVERNANCE" 2>&1
+}
+
+# ── aliases-manifest.sh ──────────────────────────────────────────────
+test_start "manifest_help_and_unknown_option"
+_root="$(_tree m-help)"
+_out="$(_manifest "$_root" --help)"
+assert_equals 0 "$?" "--help exits 0"
+assert_contains "Usage: aliases-manifest.sh" "$_out" "usage printed"
+_out="$(_manifest "$_root" --bogus)"
+assert_equals 2 "$?" "unknown option exits 2"
+assert_contains "Unknown option: --bogus" "$_out" "option named"
+
+test_start "manifest_emits_name_value_file_line_rows"
+_root="$(_tree m-rows)"
+_af="$_root/.chezmoitemplates/aliases/base.aliases.sh"
+{
+  echo "alias ll='ls -l'"
+  echo "# a comment"
+  echo "alias gs='git status'"
+} >"$_af"
+_out="$(_manifest "$_root")"
+_rc=$?
+assert_equals 0 "$_rc" "manifest exits 0"
+assert_contains "$(printf 'll\t%s\t%s\t1' "'ls -l'" "$_af")" "$_out" "first alias row is name/value/file/line"
+assert_contains "$(printf 'gs\t%s\t%s\t3' "'git status'" "$_af")" "$_out" "line numbers follow the file"
+assert_equals 2 "$(printf '%s\n' "$_out" | wc -l | tr -d ' ')" "comments are not rows"
+
+test_start "manifest_catches_conditionally_defined_aliases"
+_root="$(_tree m-cond)"
+printf 'command -v eza >/dev/null && alias ls="eza"\n' \
+  >"$_root/.chezmoitemplates/aliases/cond.aliases.sh"
+_out="$(_manifest "$_root")"
+assert_equals 0 "$?" "conditional alias tree exits 0"
+assert_contains "ls" "$_out" "the gated alias is still inventoried"
+
+test_start "manifest_takes_the_source_dir_as_an_argument"
+_root="$(_tree m-arg)"
+printf "alias p='pwd'\n" >"$_root/.chezmoitemplates/aliases/p.aliases.sh"
+_out="$(CHEZMOI_SOURCE_DIR="" "$BASH_BIN" "$MANIFEST" "$_root" 2>&1)"
+assert_equals 0 "$?" "explicit source dir exits 0"
+assert_contains "p" "$_out" "aliases from the argument tree are listed"
+
+test_start "manifest_descends_into_the_chezmoiroot_subdirectory"
+_root="$DOTFILES_COV_TMPDIR/m-root"
+mkdir -p "$_root/defaults/.chezmoitemplates/aliases" "$_root/defaults/.chezmoitemplates/functions"
+printf 'defaults\n' >"$_root/.chezmoiroot"
+printf "alias inner='echo inner'\n" \
+  >"$_root/defaults/.chezmoitemplates/aliases/inner.aliases.sh"
+_out="$(_manifest "$_root")"
+_rc=$?
+assert_equals 0 "$_rc" "chezmoiroot tree exits 0"
+assert_contains "inner" "$_out" "aliases below .chezmoiroot are found"
+assert_contains "/defaults/.chezmoitemplates/aliases/inner.aliases.sh" "$_out" "row points at the real file"
+
+# ── alias-governance.sh ──────────────────────────────────────────────
+test_start "governance_passes_a_clean_tree"
+_root="$(_tree g-clean)"
+printf "alias ll='ls -l'\nalias gs='git status'\n" \
+  >"$_root/.chezmoitemplates/aliases/base.aliases.sh"
+_out="$(_govern "$_root")"
+_rc=$?
+assert_equals 0 "$_rc" "clean tree exits 0"
+assert_contains "Policy: standard" "$_out" "default policy reported"
+assert_contains "OK: no duplicate alias names" "$_out" "duplicate check passed"
+assert_contains "OK: risky overrides are gated" "$_out" "override check passed"
+assert_contains "OK: no hardcoded /Users paths in aliases" "$_out" "path check passed"
+assert_contains "Alias governance checks passed." "$_out" "summary line printed"
+
+test_start "governance_warns_about_duplicates_under_the_standard_policy"
+_root="$(_tree g-dup)"
+printf "alias ll='ls -l'\n" >"$_root/.chezmoitemplates/aliases/a.aliases.sh"
+printf "alias ll='ls -lah'\n" >"$_root/.chezmoitemplates/aliases/b.aliases.sh"
+_out="$(_govern "$_root")"
+_rc=$?
+assert_equals 0 "$_rc" "a duplicate is only a warning by default"
+assert_contains "WARN: duplicate alias names detected" "$_out" "warning printed"
+assert_contains "- ll" "$_out" "the duplicate name is listed"
+
+test_start "governance_fails_on_duplicates_under_the_strict_policy"
+_out="$(_govern "$_root" DOTFILES_ALIAS_POLICY=strict)"
+_rc=$?
+assert_equals 1 "$_rc" "strict policy exits 1"
+assert_contains "Policy: strict" "$_out" "strict policy reported"
+assert_contains "ERROR: duplicate alias names detected" "$_out" "duplicates are an error"
+assert_contains "Alias governance checks failed: 1 issue(s)." "$_out" "failure summary counts the issue"
+
+test_start "governance_defaults_to_strict_in_ci"
+_out="$(env CHEZMOI_SOURCE_DIR="$_root" CI=true "$BASH_BIN" "$GOVERNANCE" 2>&1)"
+_rc=$?
+assert_equals 1 "$_rc" "CI without an explicit policy exits 1"
+assert_contains "Policy: strict" "$_out" "CI implies the strict policy"
+
+test_start "governance_rejects_an_ungated_risky_override"
+_root="$(_tree g-risky)"
+printf "alias cd='pushd'\n" >"$_root/.chezmoitemplates/aliases/risky.aliases.sh"
+_out="$(_govern "$_root")"
+_rc=$?
+assert_equals 1 "$_rc" "ungated override exits 1"
+assert_contains "ERROR: risky override 'cd'" "$_out" "the override is named"
+assert_contains "is not gated by a DOTFILES_* flag" "$_out" "the requirement is explained"
+
+test_start "governance_accepts_a_gated_risky_override"
+_root="$(_tree g-gated)"
+# The manifest's conditional-alias pattern only matches a gate with no
+# quote characters before the `&&`, so the fixture uses that form.
+{
+  echo "# Enable with DOTFILES_ENABLE_CD=1"
+  echo '[ -n ${DOTFILES_ENABLE_CD:-} ] && alias cd=pushd'
+} >"$_root/.chezmoitemplates/aliases/gated.aliases.sh"
+_out="$(_govern "$_root")"
+_rc=$?
+assert_equals 0 "$_rc" "gated override exits 0"
+assert_contains "OK: risky overrides are gated" "$_out" "override check passes"
+
+test_start "governance_rejects_hardcoded_user_paths"
+_root="$(_tree g-paths)"
+printf "alias proj='cd /Users/someone/code'\n" \
+  >"$_root/.chezmoitemplates/aliases/paths.aliases.sh"
+_out="$(_govern "$_root")"
+_rc=$?
+assert_equals 1 "$_rc" "hardcoded path exits 1"
+assert_contains "ERROR: hardcoded /Users paths detected in aliases" "$_out" "error printed"
+assert_contains "proj" "$_out" "the offending alias is named"
+
+echo "RESULTS:$TESTS_RUN:$TESTS_PASSED:$TESTS_FAILED"

--- a/tests/unit/diagnostics/test_alias_manifest_governance_fixtures.sh
+++ b/tests/unit/diagnostics/test_alias_manifest_governance_fixtures.sh
@@ -167,6 +167,54 @@ _rc=$?
 assert_equals 0 "$_rc" "gated override exits 0"
 assert_contains "OK: risky overrides are gated" "$_out" "override check passes"
 
+test_start "governance_flags_an_expired_deprecated_alias"
+# scripts/dot/data/alias-deprecations.tsv lists dlogsf as removable
+# since v0.2.487; the repo is past that, so a tree that still defines
+# the alias must fail the deprecation window.
+_root="$(_tree g-deprecated)"
+printf "alias dlogsf='docker logs -f'\n" \
+  >"$_root/.chezmoitemplates/aliases/deprecated.aliases.sh"
+_out="$(_govern "$_root")"
+_rc=$?
+assert_equals 1 "$_rc" "an expired deprecated alias exits 1"
+assert_contains "ERROR: expired deprecated aliases still present" "$_out" "the expired window is reported"
+assert_contains "dlogsf (remove_in=v0.2.487, replacement=dklf)" "$_out" "the replacement is suggested"
+
+test_start "governance_reports_a_clean_deprecation_window"
+_root="$(_tree g-notdeprecated)"
+printf "alias dkl='docker logs'\n" >"$_root/.chezmoitemplates/aliases/ok.aliases.sh"
+_out="$(_govern "$_root")"
+assert_equals 0 "$?" "no expired aliases exits 0"
+assert_contains "OK: no expired deprecated aliases" "$_out" "the window check is reported as passing"
+
+test_start "manifest_falls_back_to_grep_without_ripgrep"
+_root="$(_tree m-nogrep)"
+printf "alias gg='git grep'\n" >"$_root/.chezmoitemplates/aliases/g.aliases.sh"
+_nogrep="$DOTFILES_COV_TMPDIR/nogrep"
+mkdir -p "$_nogrep"
+for _t in bash grep sed head tr cat printf echo dirname basename; do
+  _p="$(command -v "$_t" 2>/dev/null || true)"
+  [[ -n "$_p" ]] && ln -sf "$_p" "$_nogrep/$_t"
+done
+_out="$(CHEZMOI_SOURCE_DIR="$_root" PATH="$_nogrep" "$BASH_BIN" "$MANIFEST" 2>&1)"
+_rc=$?
+assert_equals 0 "$_rc" "the grep fallback exits 0"
+assert_contains "gg" "$_out" "aliases are still inventoried without ripgrep"
+
+test_start "manifest_resolves_the_default_chezmoi_checkout"
+# No CHEZMOI_SOURCE_DIR and no ~/.dotfiles: the manifest falls back to
+# ~/.local/share/chezmoi.
+_home="$DOTFILES_COV_TMPDIR/xdg-home"
+mkdir -p "$_home/.local/share/chezmoi/.chezmoitemplates/aliases" \
+  "$_home/.local/share/chezmoi/.chezmoitemplates/functions"
+printf "alias xdg='echo xdg'\n" \
+  >"$_home/.local/share/chezmoi/.chezmoitemplates/aliases/x.aliases.sh"
+_out="$(env -u CHEZMOI_SOURCE_DIR HOME="$_home" "$BASH_BIN" "$MANIFEST" 2>&1)"
+_rc=$?
+assert_equals 0 "$_rc" "the default checkout is used"
+assert_contains "xdg" "$_out" "its aliases are inventoried"
+assert_contains "$_home/.local/share/chezmoi" "$_out" "rows point into that checkout"
+
 test_start "governance_rejects_hardcoded_user_paths"
 _root="$(_tree g-paths)"
 printf "alias proj='cd /Users/someone/code'\n" \

--- a/tests/unit/diagnostics/test_diagnostics_benchmark_modes.sh
+++ b/tests/unit/diagnostics/test_diagnostics_benchmark_modes.sh
@@ -1,0 +1,262 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2015-2026 Sebastien Rousseau
+# shellcheck disable=SC1090,SC1091,SC2034
+#
+# Behavioural coverage for scripts/diagnostics/benchmark.sh. Every mode
+# (--help, bad flag, basic timing, hyperfine timing with each performance
+# rating, --detailed, --waterfall, --profile, --compare) runs against a
+# sandboxed HOME with PATH-shadowing shims for zsh, hyperfine, the tool
+# initialisers and python3 (a deterministic millisecond clock), so no
+# real shell start-up is ever measured and every run is reproducible.
+# The gum/TTY branches are driven through a pseudo-terminal so the
+# `UI_ENABLED=1` and `UI_COLOR=1` arms execute without a real terminal.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+source "$SCRIPT_DIR/../../framework/assertions.sh"
+source "$SCRIPT_DIR/../../framework/coverage_helpers.sh"
+
+# Keep bash xtrace flowing to the coverage runner's trace stream even
+# when a probe below captures `2>&1`.
+exec 21>&2
+export BASH_XTRACEFD=21
+
+BENCH="$REPO_ROOT/scripts/diagnostics/benchmark.sh"
+
+trap cov_teardown_sandbox EXIT
+cov_setup_sandbox
+
+MB="$DOTFILES_COV_TMPDIR/bin"
+REAL_PY="$(command -v python3)"
+REAL_BASH="$(command -v bash)"
+REAL_JQ="$(command -v jq || true)"
+
+# ── Shims ────────────────────────────────────────────────────────────
+# zsh: returns instantly; under --profile it prints a fake zprof table.
+cat >"$MB/zsh" <<'SHIM'
+#!/usr/bin/env bash
+case "$*" in
+  *zprof*) printf 'num  calls  time  self  name\n 1)  1  0.10  0.10  compinit\n' ;;
+  *) : ;;
+esac
+exit 0
+SHIM
+# Tool initialisers probed by benchmark_components / render_waterfall.
+for t in starship atuin zoxide fzf direnv; do
+  printf '#!/usr/bin/env bash\nexit 0\n' >"$MB/$t"
+done
+# python3: deterministic monotonic clock. Each call advances by
+# BENCH_PY_STEP ms (default 7) so every time_command() measures a
+# stable, non-zero duration; BENCH_PY_STEP=0 yields all-zero timings.
+cat >"$MB/python3" <<'SHIM'
+#!/usr/bin/env bash
+clock="${BENCH_PY_CLOCK:?}"
+n=$(cat "$clock" 2>/dev/null || echo 0)
+n=$((n + 1))
+printf '%s\n' "$n" >"$clock"
+printf '%s\n' "$((n * ${BENCH_PY_STEP:-7}))"
+SHIM
+# hyperfine: writes the --export-json file with a mean taken from
+# BENCH_MEAN_S so every performance rating can be selected by the test.
+cat >"$MB/hyperfine" <<'SHIM'
+#!/usr/bin/env bash
+out=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --export-json) out="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+mean="${BENCH_MEAN_S:-0.05}"
+printf '{"results":[{"mean":%s,"min":%s,"max":%s}]}\n' "$mean" "$mean" "$mean" >"$out"
+echo "hyperfine-shim ran"
+exit 0
+SHIM
+# gum: only reached when stdout is a TTY (pty runs below).
+cat >"$MB/gum" <<'SHIM'
+#!/usr/bin/env bash
+case "${1:-}" in
+  style | format | join) shift; printf '%s\n' "$*" ;;
+  *) : ;;
+esac
+exit 0
+SHIM
+chmod +x "$MB"/zsh "$MB"/starship "$MB"/atuin "$MB"/zoxide "$MB"/fzf "$MB"/direnv "$MB"/python3 "$MB"/hyperfine "$MB"/gum
+ln -sf "$REAL_BASH" "$MB/bash"
+[[ -n "$REAL_JQ" ]] && ln -sf "$REAL_JQ" "$MB/jq"
+
+export BENCH_PY_CLOCK="$DOTFILES_COV_TMPDIR/pyclock"
+BENCH_DIR="$XDG_DATA_HOME/dotfiles/benchmarks"
+
+# PATH without hyperfine (and without the host's real tools).
+PATH_NO_HF="$MB:/usr/bin:/bin"
+# PATH with a hyperfine shim.
+HF_DIR="$DOTFILES_COV_TMPDIR/hfbin"
+mkdir -p "$HF_DIR"
+mv "$MB/hyperfine" "$HF_DIR/hyperfine"
+PATH_HF="$HF_DIR:$PATH_NO_HF"
+
+reset_clock() { rm -f "$BENCH_PY_CLOCK"; }
+
+# run_bench <PATH> <args…> — sets OUT / RC.
+run_bench() {
+  local p="$1"
+  shift
+  reset_clock
+  set +e
+  OUT="$(PATH="$p" bash "$BENCH" "$@" 2>&1)"
+  RC=$?
+  set -e
+}
+
+# run_bench_pty <PATH> <args…> — same, but stdout is a pseudo-terminal
+# so ui_init detects gum + colour (UI_ENABLED=1 / UI_COLOR=1).
+run_bench_pty() {
+  local p="$1"
+  shift
+  reset_clock
+  set +e
+  OUT="$(PATH="$p" TERM=xterm "$REAL_PY" -c '
+import os, pty, sys
+sys.exit(os.waitstatus_to_exitcode(pty.spawn(sys.argv[1:])))
+' bash "$BENCH" "$@" 2>&1 </dev/null)"
+  RC=$?
+  set -e
+}
+
+# ── --help / bad flag ───────────────────────────────────────────────
+test_start "benchmark_help"
+run_bench "$PATH_NO_HF" --help
+assert_equals 0 "$RC" "--help exits 0"
+assert_contains "Usage: dot benchmark" "$OUT" "--help prints usage"
+
+test_start "benchmark_short_help"
+run_bench "$PATH_NO_HF" -h
+assert_equals 0 "$RC" "-h exits 0"
+
+test_start "benchmark_unknown_option"
+run_bench "$PATH_NO_HF" --bogus
+assert_equals 2 "$RC" "unknown option exits 2"
+assert_contains "Unknown option: --bogus" "$OUT" "unknown option is reported"
+
+# ── Basic timing (no hyperfine) ─────────────────────────────────────
+test_start "benchmark_basic_timing_without_hyperfine"
+run_bench "$PATH_NO_HF"
+assert_equals 0 "$RC" "basic timing exits 0"
+assert_contains "hyperfine not installed" "$OUT" "falls back to basic timing"
+# 5 runs × 7ms step → average 7ms.
+assert_contains "Average startup time: 7ms" "$OUT" "average from deterministic clock"
+assert_contains "dot benchmark --compare" "$OUT" "prints history tip"
+
+# ── hyperfine timing + every performance rating ─────────────────────
+test_start "benchmark_hyperfine_excellent"
+run_bench "$PATH_HF"
+assert_equals 0 "$RC" "hyperfine path exits 0"
+assert_contains "hyperfine-shim ran" "$OUT" "hyperfine is invoked"
+assert_contains "Mean: 50ms" "$OUT" "mean parsed from export json"
+assert_contains "Excellent (<100ms)" "$OUT" "rating excellent"
+assert_file_exists "$BENCH_DIR/latest.json" "latest.json written"
+# A timestamped history copy sits alongside latest.json.
+hist_count=$(find "$BENCH_DIR" -name '[0-9]*_[0-9]*.json' | wc -l | tr -d ' ')
+assert_equals 1 "$hist_count" "one timestamped history file saved"
+
+test_start "benchmark_hyperfine_good"
+BENCH_MEAN_S=0.15 run_bench "$PATH_HF"
+assert_contains "Good (<200ms)" "$OUT" "rating good"
+
+test_start "benchmark_hyperfine_acceptable"
+BENCH_MEAN_S=0.3 run_bench "$PATH_HF"
+assert_contains "Acceptable (<500ms)" "$OUT" "rating acceptable"
+
+test_start "benchmark_hyperfine_slow"
+BENCH_MEAN_S=0.7 run_bench "$PATH_HF"
+assert_contains "Slow (>500ms)" "$OUT" "rating slow"
+
+# ── --detailed ──────────────────────────────────────────────────────
+test_start "benchmark_detailed"
+run_bench "$PATH_NO_HF" --detailed
+assert_equals 0 "$RC" "--detailed exits 0"
+assert_contains "Per-Component Timing" "$OUT" "component header"
+assert_contains "zshenv (bootloader)" "$OUT" "zshenv row"
+for t in starship atuin zoxide fzf direnv; do
+  assert_contains "$t init" "$OUT" "$t init row"
+done
+assert_contains "Average startup time" "$OUT" "detailed still runs the benchmark"
+
+# ── --waterfall ─────────────────────────────────────────────────────
+test_start "benchmark_waterfall"
+run_bench "$PATH_NO_HF" -w
+assert_equals 0 "$RC" "--waterfall exits 0"
+assert_contains "Startup Waterfall" "$OUT" "waterfall header"
+assert_contains "rc.d/20-zinit (plugins)" "$OUT" "zinit bar"
+# 8 components × 7ms.
+assert_contains "Total" "$OUT" "total row"
+assert_contains "56ms" "$OUT" "total is the sum of component timings"
+
+test_start "benchmark_waterfall_no_timing_data"
+BENCH_PY_STEP=0 run_bench "$PATH_NO_HF" --waterfall
+assert_equals 0 "$RC" "zero timings exit 0"
+assert_contains "No timing data" "$OUT" "warns when nothing was measured"
+
+# ── --profile ───────────────────────────────────────────────────────
+test_start "benchmark_profile"
+run_bench "$PATH_NO_HF" -p
+assert_equals 0 "$RC" "--profile exits 0"
+assert_contains "Zsh profiler (zprof)" "$OUT" "zprof header"
+assert_contains "compinit" "$OUT" "zprof table is shown"
+
+# ── --compare ───────────────────────────────────────────────────────
+test_start "benchmark_compare_empty_history"
+rm -rf "$BENCH_DIR"
+run_bench "$PATH_NO_HF" -c
+assert_equals 0 "$RC" "--compare exits 0 without history"
+assert_contains "No benchmark history found." "$OUT" "empty history message"
+
+test_start "benchmark_compare_with_history"
+mkdir -p "$BENCH_DIR"
+printf '{"results":[{"mean":0.123,"min":0.1,"max":0.2}]}\n' >"$BENCH_DIR/20260101_120000.json"
+printf '{"results":[{"mean":0.123,"min":0.1,"max":0.2}]}\n' >"$BENCH_DIR/latest.json"
+run_bench "$PATH_NO_HF" --compare
+assert_equals 0 "$RC" "--compare exits 0 with history"
+assert_contains "20260101_120000" "$OUT" "history row printed"
+assert_contains "123ms" "$OUT" "mean converted to ms"
+if [[ "$OUT" == *"latest "*"ms"* ]]; then
+  ((TESTS_FAILED++)) || true
+  printf '%b\n' "  ${RED}✗${NC} $CURRENT_TEST: latest.json must be skipped in history"
+else
+  ((TESTS_PASSED++)) || true
+  printf '%b\n' "  ${GREEN}✓${NC} $CURRENT_TEST: latest.json skipped in history"
+fi
+
+# ── TTY / gum branches (UI_ENABLED=1, UI_COLOR=1) ────────────────────
+if "$REAL_PY" -c 'import pty, os; os.waitstatus_to_exitcode' 2>/dev/null; then
+  test_start "benchmark_tty_basic_timing"
+  run_bench_pty "$PATH_NO_HF"
+  assert_equals 0 "$RC" "tty basic timing exits 0"
+  assert_contains "Average startup time" "$OUT" "ui_ok average line"
+  assert_contains "dot benchmark --waterfall" "$OUT" "ui_info tips"
+
+  test_start "benchmark_tty_hyperfine_ratings"
+  run_bench_pty "$PATH_HF"
+  assert_contains "Excellent (<100ms)" "$OUT" "tty rating excellent"
+  assert_contains "Mean:" "$OUT" "ui_kv mean"
+  BENCH_MEAN_S=0.15 run_bench_pty "$PATH_HF"
+  assert_contains "Good (<200ms)" "$OUT" "tty rating good"
+  BENCH_MEAN_S=0.3 run_bench_pty "$PATH_HF"
+  assert_contains "Acceptable (<500ms)" "$OUT" "tty rating acceptable"
+  BENCH_MEAN_S=0.7 run_bench_pty "$PATH_HF"
+  assert_contains "Slow (>500ms)" "$OUT" "tty rating slow"
+
+  test_start "benchmark_tty_waterfall_colour"
+  run_bench_pty "$PATH_NO_HF" --waterfall
+  assert_equals 0 "$RC" "tty waterfall exits 0"
+  assert_contains "Startup Waterfall" "$OUT" "waterfall header on tty"
+  assert_contains "Total" "$OUT" "total row on tty"
+else
+  test_start "benchmark_tty_branches_skipped"
+  ((TESTS_PASSED++)) || true
+  printf '%b\n' "  ${YELLOW}⚠${NC} $CURRENT_TEST: python pty unavailable, skipped"
+fi
+
+echo "RESULTS:$TESTS_RUN:$TESTS_PASSED:$TESTS_FAILED"

--- a/tests/unit/dot-cli/test_ai_install_pkg_map.sh
+++ b/tests/unit/dot-cli/test_ai_install_pkg_map.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2015-2026 Sebastien Rousseau
+# shellcheck disable=SC1090,SC1091,SC2034
+#
+# Contract test for lib/dot/ai-install.sh's provider → mise package map.
+# `dot ai <tool>` offers a mise install only when _ai_mise_pkg returns a
+# package for that binary, so a typo in an arm silently turns into "not
+# installed and mise not available". Every arm is asserted here, along
+# with the deliberate blanks (providers with native installers) and the
+# unknown-binary default.
+#
+# The library is sourced, never executed: the native installers it also
+# defines reach the network and are not called.
+#
+# AUTO-GENERATED: false (hand-written)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+source "$SCRIPT_DIR/../../framework/assertions.sh"
+source "$SCRIPT_DIR/../../framework/coverage_helpers.sh"
+
+# Hand children a copy of the real stderr so their xtrace still reaches
+# the coverage runner even though the probes capture output.
+exec 21>&2
+export BASH_XTRACEFD=21
+
+AI_INSTALL="$REPO_ROOT/lib/dot/ai-install.sh"
+BASH_BIN="$(command -v bash)"
+
+trap cov_teardown_sandbox EXIT
+cov_setup_sandbox
+
+test_start "ai_install_library_sources_cleanly_and_is_re_source_guarded"
+_out="$("$BASH_BIN" -c '
+  set -euo pipefail
+  source "$1"
+  first="$_DOT_LIB_AI_INSTALL_LOADED"
+  source "$1"
+  echo "loaded=$first reguard=$_DOT_LIB_AI_INSTALL_LOADED"
+  declare -F _ai_mise_pkg >/dev/null && echo "map-defined"
+  declare -F install_claude_native >/dev/null && echo "installers-defined"
+' _ "$AI_INSTALL" 2>&1)"
+_rc=$?
+assert_equals 0 "$_rc" "sourcing twice exits 0"
+assert_contains "loaded=1 reguard=1" "$_out" "the re-source guard holds"
+assert_contains "map-defined" "$_out" "the package map is available to callers"
+assert_contains "installers-defined" "$_out" "the native installers are available to callers"
+
+# _pkg <binary> — the mapped package for one provider binary.
+_pkg() {
+  "$BASH_BIN" -c 'source "$1"; _ai_mise_pkg "$2"' _ "$AI_INSTALL" "$1" 2>/dev/null
+}
+
+test_start "ai_install_maps_every_mise_backed_provider"
+while IFS='=' read -r _bin _want; do
+  [[ -n "$_bin" ]] || continue
+  assert_equals "$_want" "$(_pkg "$_bin")" "$_bin maps to its mise package"
+done <<'MAP'
+codex=npm:@openai/codex
+copilot=npm:@github/copilot
+crush=npm:@charmland/crush
+aider=pipx:aider-chat
+opencode=npm:opencode-ai
+sgpt=pipx:shell-gpt
+ollama=aqua:ollama/ollama
+kiro-cli=kiro-cli
+autohand=npm:autohand-cli
+vibe=pipx:mistral-vibe
+qwen=npm:@qwen-code/qwen-code
+zai=npm:@guizmo-ai/zai-cli
+MAP
+
+test_start "ai_install_leaves_native_installer_providers_unmapped"
+for _bin in goose amp cursor-agent grok agy kimi claude; do
+  assert_equals "" "$(_pkg "$_bin")" "$_bin has no mise package (native installer or n/a)"
+done
+
+test_start "ai_install_returns_nothing_for_an_unknown_binary"
+assert_equals "" "$(_pkg totally-unknown-tool)" "unknown binaries fall through to the default arm"
+
+echo "RESULTS:$TESTS_RUN:$TESTS_PASSED:$TESTS_FAILED"

--- a/tests/unit/dot-cli/test_ai_install_pkg_map.sh
+++ b/tests/unit/dot-cli/test_ai_install_pkg_map.sh
@@ -37,13 +37,13 @@ _out="$("$BASH_BIN" -c '
   source "$1"
   first="$_DOT_LIB_AI_INSTALL_LOADED"
   source "$1"
-  echo "loaded=$first reguard=$_DOT_LIB_AI_INSTALL_LOADED"
+  echo "loaded=$first after=$_DOT_LIB_AI_INSTALL_LOADED"
   declare -F _ai_mise_pkg >/dev/null && echo "map-defined"
   declare -F install_claude_native >/dev/null && echo "installers-defined"
 ' _ "$AI_INSTALL" 2>&1)"
 _rc=$?
 assert_equals 0 "$_rc" "sourcing twice exits 0"
-assert_contains "loaded=1 reguard=1" "$_out" "the re-source guard holds"
+assert_contains "loaded=1 after=1" "$_out" "the re-source guard holds"
 assert_contains "map-defined" "$_out" "the package map is available to callers"
 assert_contains "installers-defined" "$_out" "the native installers are available to callers"
 

--- a/tests/unit/dot-cli/test_ai_status_install.sh
+++ b/tests/unit/dot-cli/test_ai_status_install.sh
@@ -1,0 +1,261 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2015-2026 Sebastien Rousseau
+# shellcheck disable=SC1090,SC1091,SC2034
+#
+# Behavioural coverage for the install / launcher / bridge branches of
+# scripts/dot/commands/ai.sh that test_ai_exhaustive.sh does not reach:
+# the "missing providers" flow behind `dot ai tools` (gum "Install all",
+# "Choose which to install", pick-nothing, no-gum tips), the launcher
+# tip without gum, the run log hook, the bridge's --help / bad --style /
+# kiro alias, the interactive-install prompts (gum confirm, plain read,
+# mise failure, no mise) and the deprecated verbs (local, ai-query,
+# tools install). Everything runs against sandboxed shims — no AI CLI,
+# mise, gum or network call ever leaves the sandbox.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+source "$SCRIPT_DIR/../../framework/assertions.sh"
+source "$SCRIPT_DIR/../../framework/coverage_helpers.sh"
+
+# Keep bash xtrace flowing to the coverage runner's trace stream even
+# when a probe below captures `2>&1`.
+exec 21>&2
+export BASH_XTRACEFD=21
+
+AI_SCRIPT="$REPO_ROOT/scripts/dot/commands/ai.sh"
+
+trap cov_teardown_sandbox EXIT
+cov_setup_sandbox
+
+MB="$DOTFILES_COV_TMPDIR/bin"
+REAL_BASH="$(command -v bash)"
+REAL_JQ="$(command -v jq || true)"
+ln -sf "$REAL_BASH" "$MB/bash"
+[[ -n "$REAL_JQ" ]] && ln -sf "$REAL_JQ" "$MB/jq"
+
+# Separate shim dirs so each scenario composes exactly the PATH it needs.
+TOOLS="$DOTFILES_COV_TMPDIR/tools" # AI CLIs
+MISE="$DOTFILES_COV_TMPDIR/mise"   # mise
+GUM="$DOTFILES_COV_TMPDIR/gum"     # gum
+mkdir -p "$TOOLS" "$MISE" "$GUM"
+CALLS="$DOTFILES_COV_TMPDIR/calls.log"
+
+# The sandbox bin dir ships its own `mise` shim, so "mise unavailable"
+# needs a PATH that mirrors it minus that one entry.
+NOMISE="$DOTFILES_COV_TMPDIR/nomise"
+mkdir -p "$NOMISE"
+for _b in "$MB"/*; do
+  [[ "$(basename "$_b")" == "mise" ]] && continue
+  ln -sf "$_b" "$NOMISE/$(basename "$_b")"
+done
+
+mk_tool() {
+  printf '#!/usr/bin/env bash\ncat >/dev/null 2>&1 || true\necho "%s-ran"\nexit 0\n' "$1" >"$TOOLS/$1"
+  chmod +x "$TOOLS/$1"
+}
+
+# mise: records every call; fails for the package named in MISE_FAIL_PKG.
+cat >"$MISE/mise" <<'SHIM'
+#!/usr/bin/env bash
+printf 'mise %s\n' "$*" >>"${AI_TEST_CALLS:?}"
+if [[ -n "${MISE_FAIL_PKG:-}" && "$*" == *"$MISE_FAIL_PKG"* ]]; then
+  echo "mise: install failed" >&2
+  exit 1
+fi
+exit 0
+SHIM
+chmod +x "$MISE/mise"
+
+# gum: answers by --header so each prompt can be steered from the test.
+#   GUM_MISSING   → answer to "Missing AI providers — install via mise?"
+#   GUM_PICK      → newline-separated answer to "Select providers to install"
+#   GUM_LAUNCH    → answer to "Select an AI CLI"
+#   GUM_CONFIRM   → exit code for `gum confirm`
+cat >"$GUM/gum" <<'SHIM'
+#!/usr/bin/env bash
+cmd="${1:-}"
+shift || true
+header=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --header) header="$2"; shift 2 ;;
+    --) shift; break ;;
+    *) shift ;;
+  esac
+done
+case "$cmd" in
+  choose)
+    cat >/dev/null
+    case "$header" in
+      *"Missing AI providers"*) [[ -n "${GUM_MISSING:-}" ]] && printf '%s\n' "$GUM_MISSING" ;;
+      *"Select providers"*) [[ -n "${GUM_PICK:-}" ]] && printf '%b\n' "$GUM_PICK" || exit 1 ;;
+      *"Select an AI CLI"*) [[ -n "${GUM_LAUNCH:-}" ]] && printf '%s\n' "$GUM_LAUNCH" ;;
+    esac
+    ;;
+  confirm) exit "${GUM_CONFIRM:-0}" ;;
+  spin) "$@"; exit $? ;;
+  style | format | join) printf '%s\n' "$*" ;;
+  *) : ;;
+esac
+exit 0
+SHIM
+chmod +x "$GUM/gum"
+
+# Run-log hook picked up by _ai_log_run.
+mkdir -p "$HOME/.local/bin"
+cat >"$HOME/.local/bin/dot-ai-log" <<'SHIM'
+#!/usr/bin/env bash
+printf 'ai-log %s\n' "$*" >>"${AI_TEST_CALLS:?}"
+SHIM
+chmod +x "$HOME/.local/bin/dot-ai-log"
+
+export AI_TEST_CALLS="$CALLS"
+BASE_PATH="$MB:/usr/bin:/bin"
+CACHE="$HOME/.cache/dotfiles/ai/status.tsv"
+
+# run_ai <PATH> <args…> — sets OUT / RC; status cache is cleared first so
+# every scenario probes the tools visible on its own PATH.
+run_ai() {
+  local p="$1"
+  shift
+  rm -f "$CACHE"
+  : >"$CALLS"
+  set +e
+  OUT="$(PATH="$p" bash "$AI_SCRIPT" "$@" 2>&1 </dev/null)"
+  RC=$?
+  set -e
+}
+
+# ── `dot ai tools`: missing providers, gum "Install all" ────────────
+test_start "ai_tools_install_all_via_gum"
+MISE_FAIL_PKG="pipx:aider-chat" GUM_MISSING="Install all" \
+  run_ai "$GUM:$MISE:$BASE_PATH" ai tools
+assert_equals 0 "$RC" "install-all flow exits 0"
+assert_contains "Run 'dot ai' again to see updated status" "$OUT" "install-all completes"
+assert_contains "Codex CLI" "$OUT" "codex listed"
+assert_file_contains "$CALLS" "mise use -g npm:@openai/codex@latest" "codex installed through mise"
+assert_file_contains "$CALLS" "mise use -g pipx:aider-chat@latest" "aider attempted through mise"
+assert_contains "install failed (continuing)" "$OUT" "failed mise install is reported and skipped"
+assert_contains "No AI CLIs installed" "$OUT" "nothing installed warning"
+assert_file_not_exists "$CACHE" "status cache invalidated after installs"
+
+# ── `dot ai tools`: gum "Choose which to install" with a selection ──
+test_start "ai_tools_choose_which_via_gum"
+GUM_MISSING="Choose which to install" GUM_PICK='Codex CLI\nOpenCode' \
+  run_ai "$GUM:$MISE:$BASE_PATH" ai tools
+assert_equals 0 "$RC" "choose-which flow exits 0"
+assert_file_contains "$CALLS" "npm:@openai/codex@latest" "picked codex installed"
+assert_file_contains "$CALLS" "npm:opencode-ai@latest" "picked opencode installed"
+if grep -q 'aider' "$CALLS"; then
+  ((TESTS_FAILED++)) || true
+  printf '%b\n' "  ${RED}✗${NC} $CURRENT_TEST: unpicked provider must not be installed"
+else
+  ((TESTS_PASSED++)) || true
+  printf '%b\n' "  ${GREEN}✓${NC} $CURRENT_TEST: unpicked provider not installed"
+fi
+
+# ── `dot ai tools`: gum "Choose which" but nothing picked ──────────
+test_start "ai_tools_choose_nothing_via_gum"
+GUM_MISSING="Choose which to install" GUM_PICK="" \
+  run_ai "$GUM:$MISE:$BASE_PATH" ai tools
+assert_equals 0 "$RC" "empty pick exits 0"
+if grep -q 'mise use' "$CALLS"; then
+  ((TESTS_FAILED++)) || true
+  printf '%b\n' "  ${RED}✗${NC} $CURRENT_TEST: nothing should be installed"
+else
+  ((TESTS_PASSED++)) || true
+  printf '%b\n' "  ${GREEN}✓${NC} $CURRENT_TEST: nothing installed"
+fi
+
+# ── `dot ai tools`: mise present, no gum → tips only ───────────────
+test_start "ai_tools_missing_without_gum"
+run_ai "$MISE:$BASE_PATH" ai tools
+assert_equals 0 "$RC" "no-gum tips exit 0"
+assert_contains "Install missing providers: mise install" "$OUT" "mise tip"
+assert_contains "Or individually: mise use -g <package>@latest" "$OUT" "per-package tip"
+
+# ── `dot ai tools`: something installed, no gum → launcher tip ─────
+mk_tool claude
+test_start "ai_tools_installed_without_gum"
+run_ai "$TOOLS:$BASE_PATH" ai tools
+assert_equals 0 "$RC" "launcher tip exits 0"
+assert_contains "Install gum for interactive launcher" "$OUT" "gum launcher tip"
+assert_file_exists "$CACHE" "status cache written"
+assert_file_contains "$CACHE" "claude" "cache lists the probed tool"
+
+# ── `dot ai tools install <tool>` verb ─────────────────────────────
+test_start "ai_tools_install_verb"
+run_ai "$TOOLS:$MISE:$BASE_PATH" ai tools install codex
+assert_file_contains "$CALLS" "npm:@openai/codex@latest" "tools install routes to cmd_ai_install"
+
+# ── Bridge: run log hook fires after a one-shot ────────────────────
+test_start "ai_bridge_logs_run"
+run_ai "$TOOLS:$BASE_PATH" ai claude "hello there"
+assert_equals 0 "$RC" "one-shot exits 0"
+assert_contains "claude-ran" "$OUT" "claude invoked"
+assert_file_contains "$CALLS" "ai-log claude" "run logged with provider"
+assert_file_contains "$CALLS" " 0 " "run logged with exit code 0"
+
+# ── Bridge: --help, bad --style, kiro alias, raw + style ───────────
+test_start "ai_bridge_help"
+run_ai "$TOOLS:$BASE_PATH" codex --help
+assert_equals 0 "$RC" "bridge --help exits 0"
+assert_contains "Usage: dot ai" "$OUT" "bridge usage shown"
+assert_contains "Available styles:" "$OUT" "styles listed"
+
+test_start "ai_bridge_missing_style"
+run_ai "$TOOLS:$BASE_PATH" ai claude --style no-such-style "hi"
+assert_equals 1 "$RC" "unknown style exits 1"
+assert_contains "Pattern not found" "$OUT" "unknown style reported"
+
+mk_tool kiro-cli
+test_start "ai_bridge_kiro_alias"
+run_ai "$TOOLS:$BASE_PATH" kiro "hi"
+assert_equals 0 "$RC" "kiro alias exits 0"
+assert_contains "kiro-cli-ran" "$OUT" "kiro resolves to kiro-cli"
+
+test_start "ai_bridge_raw_with_style"
+DOT_AI_RAW=1 run_ai "$TOOLS:$BASE_PATH" ai claude --style architect "hi"
+assert_equals 0 "$RC" "raw styled one-shot exits 0"
+assert_contains "claude-ran" "$OUT" "claude invoked in raw mode"
+
+# ── Bridge: tool missing → install prompts ─────────────────────────
+test_start "ai_bridge_missing_tool_plain_prompt_declines"
+run_ai "$MISE:$BASE_PATH" ai codex "hi"
+assert_equals 1 "$RC" "declined install exits 1"
+assert_contains "Install codex via mise (npm:@openai/codex)? [y/N]" "$OUT" "plain prompt shown"
+assert_contains "install with: mise use -g npm:@openai/codex@latest" "$OUT" "install hint"
+
+test_start "ai_bridge_missing_tool_gum_confirm_installs"
+run_ai "$GUM:$MISE:$BASE_PATH" ai codex "hi"
+assert_file_contains "$CALLS" "mise use -g npm:@openai/codex@latest" "gum confirm triggers mise install"
+
+test_start "ai_bridge_missing_tool_install_fails"
+MISE_FAIL_PKG="npm:@openai/codex" run_ai "$GUM:$MISE:$BASE_PATH" ai codex "hi"
+assert_equals 1 "$RC" "failed install exits 1"
+assert_contains "installation failed" "$OUT" "failure reported"
+
+test_start "ai_bridge_missing_tool_no_mise"
+run_ai "$NOMISE:/usr/bin:/bin" ai codex "hi"
+assert_equals 1 "$RC" "no mise exits 1"
+assert_contains "not installed and mise not available" "$OUT" "no-mise message"
+
+test_start "ai_bridge_missing_tool_without_package"
+run_ai "$MISE:$BASE_PATH" ai goose "hi"
+assert_equals 1 "$RC" "tool without a mise package exits 1"
+assert_contains "not installed and mise not available" "$OUT" "falls to the generic message"
+
+# ── Deprecated verbs ───────────────────────────────────────────────
+test_start "ai_deprecated_local_without_proxy"
+run_ai "$BASE_PATH" ai local
+assert_equals 1 "$RC" "ai local without dot-ai-proxy exits 1"
+assert_contains "deprecated" "$OUT" "deprecation hint"
+
+test_start "ai_deprecated_ai_query"
+run_ai "$TOOLS:$BASE_PATH" ai-query "2+2"
+assert_contains "use: dot ai ask" "$OUT" "ai-query deprecation hint"
+
+echo "RESULTS:$TESTS_RUN:$TESTS_PASSED:$TESTS_FAILED"

--- a/tests/unit/dot-cli/test_dot_commands_agents_render.sh
+++ b/tests/unit/dot-cli/test_dot_commands_agents_render.sh
@@ -153,6 +153,19 @@ _rc=$?
 assert_equals 0 "$_rc" "a freshly rendered tree is in sync"
 assert_contains "in sync with CLAUDE.md" "$_out" "sync is reported"
 
+test_start "agents_check_is_insensitive_to_blank_line_differences"
+# `render` writes one more blank line after its header block than
+# CLAUDE.md carries, so the two extracted bodies ALWAYS differ by a
+# blank line — the whole verdict rests on that being ignored. Adding
+# more blank lines must not manufacture drift either. (macOS 14's diff
+# drops --ignore-blank-lines under -q, which made every freshly
+# rendered tree look drifted there.)
+printf '\n\n' >>"$_root/AGENTS.md"
+_out="$(_agents "$_bin" check)"
+_rc=$?
+assert_equals 0 "$_rc" "extra blank lines are not drift"
+assert_contains "in sync with CLAUDE.md" "$_out" "still reported as in sync"
+
 test_start "agents_check_detects_drift"
 printf '\n- A rule added only to CLAUDE.md.\n' >>"$_root/CLAUDE.md"
 _out="$(_agents "$_bin" check)"

--- a/tests/unit/dot-cli/test_dot_commands_agents_render.sh
+++ b/tests/unit/dot-cli/test_dot_commands_agents_render.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2015-2026 Sebastien Rousseau
+# shellcheck disable=SC1090,SC1091,SC2034
+#
+# Behaviour tests for `dot agents` (scripts/dot/commands/agents.sh):
+# list, check (missing CLAUDE.md, missing AGENTS.md, in sync, drifted),
+# render (all eleven harness targets, and that a render makes check
+# pass), help and the unknown-subcommand error.
+#
+# Every case runs against a throwaway "repo" whose root the command
+# discovers through a `chezmoi source-path` shim, so `render` writes
+# AGENTS.md, .cursor/, .codex/ and friends into the sandbox — never
+# into this checkout. The repo-root guard is exercised too: a
+# candidate without .chezmoidata.toml must be rejected.
+#
+# AUTO-GENERATED: false (hand-written)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+source "$SCRIPT_DIR/../../framework/assertions.sh"
+source "$SCRIPT_DIR/../../framework/coverage_helpers.sh"
+
+# Hand children a copy of the real stderr so their xtrace still reaches
+# the coverage runner even though the probes capture output with 2>&1.
+exec 21>&2
+export BASH_XTRACEFD=21
+
+DOT_BIN="$REPO_ROOT/bin/dot"
+BASH_BIN="$(command -v bash)"
+
+trap cov_teardown_sandbox EXIT
+cov_setup_sandbox
+
+CLAUDE_BODY='## Conventions
+
+- Two-space indent.
+- Conventional commits.
+'
+
+# _repo <name> [--no-data] [--no-claude] — a fake repo root; prints it.
+_repo() {
+  local name="$1"
+  local root="$DOTFILES_COV_TMPDIR/repos/$name"
+  shift
+  mkdir -p "$root"
+  local with_data=1 with_claude=1
+  local opt
+  for opt in "$@"; do
+    case "$opt" in
+      --no-data) with_data=0 ;;
+      --no-claude) with_claude=0 ;;
+    esac
+  done
+  ((with_data)) && printf 'dotfiles_version = "1.0.0"\n' >"$root/.chezmoidata.toml"
+  if ((with_claude)); then
+    printf '# CLAUDE.md — Project guide\n\n%s' "$CLAUDE_BODY" >"$root/CLAUDE.md"
+  fi
+  printf '%s\n' "$root"
+}
+
+# _shim_root <root> — a bin dir whose `chezmoi source-path` answers
+# <root>; prints the bin dir.
+_shim_root() {
+  local root="$1"
+  local dir
+  dir="$DOTFILES_COV_TMPDIR/shims/$(basename "$root")"
+  mkdir -p "$dir"
+  cat >"$dir/chezmoi" <<EOF
+#!/usr/bin/env bash
+[[ "\${1:-}" == "source-path" ]] && echo "$root"
+exit 0
+EOF
+  chmod +x "$dir/chezmoi"
+  printf '%s\n' "$dir"
+}
+
+_agents() { # <bin-dir> [args…]
+  local dir="$1"
+  shift
+  PATH="$dir:$PATH" "$BASH_BIN" "$DOT_BIN" agents "$@" 2>&1
+}
+
+# ── list ─────────────────────────────────────────────────────────────
+test_start "agents_list_shows_every_harness_and_its_render_state"
+_root="$(_repo list)"
+_bin="$(_shim_root "$_root")"
+_out="$(_agents "$_bin" list)"
+_rc=$?
+assert_equals 0 "$_rc" "list exits 0"
+assert_contains "Agent harness targets" "$_out" "header printed"
+assert_contains "$_root/AGENTS.md" "$_out" "agents-md target resolved under the fixture root"
+assert_contains "not yet rendered" "$_out" "unrendered targets are flagged"
+for _h in agents-md cursor codex windsurf zed roo cline aider continue jules; do
+  assert_contains "$_h" "$_out" "harness $_h listed"
+done
+
+test_start "agents_defaults_to_list"
+_out="$(_agents "$_bin")"
+assert_equals 0 "$?" "no subcommand exits 0"
+assert_contains "Agent harness targets" "$_out" "bare invocation lists targets"
+
+# ── check ────────────────────────────────────────────────────────────
+test_start "agents_check_requires_claude_md"
+_root="$(_repo nocanon --no-claude)"
+_bin="$(_shim_root "$_root")"
+_out="$(_agents "$_bin" check)"
+_rc=$?
+assert_equals 2 "$_rc" "missing CLAUDE.md exits 2"
+assert_contains "not found at $_root/CLAUDE.md" "$_out" "the expected path is named"
+
+test_start "agents_check_reports_a_missing_agents_md"
+_root="$(_repo unrendered)"
+_bin="$(_shim_root "$_root")"
+_out="$(_agents "$_bin" check)"
+_rc=$?
+assert_equals 1 "$_rc" "missing AGENTS.md exits 1"
+assert_contains "run 'dot agents render'" "$_out" "the fix is suggested"
+
+# ── render ───────────────────────────────────────────────────────────
+test_start "agents_render_writes_every_harness_file"
+_root="$(_repo rendered)"
+_bin="$(_shim_root "$_root")"
+_out="$(_agents "$_bin" render)"
+_rc=$?
+assert_equals 0 "$_rc" "render exits 0"
+for _f in AGENTS.md .cursor/rules/dotfiles.mdc .codex/config.toml \
+  .windsurf/rules.md .zed/agent-config.toml .roo/rules.md .clinerules \
+  .aider.conf.yml .continuerc.json .jules/system.md .agy/AGY.md; do
+  assert_file_exists "$_root/$_f" "render wrote $_f"
+done
+assert_contains "rendered → $_root/AGENTS.md" "$_out" "AGENTS.md render reported"
+
+test_start "agents_render_propagates_the_claude_body"
+# NOTE: render pipes the body through
+# `sed '1s/^# CLAUDE\.md.*/# AGENTS.md — AI Assistant Guidelines/'`,
+# but `_agents_body` has already dropped that H1, so the substitution
+# never fires and the rendered file carries no title of its own — the
+# committed AGENTS.md shows the same shape. Pinned as current
+# behaviour; changing it would re-render every harness file.
+assert_output_not_contains "# AGENTS.md — AI Assistant Guidelines" cat "$_root/AGENTS.md"
+assert_file_contains "$_root/AGENTS.md" "## Conventions" "the first body heading survives"
+assert_file_contains "$_root/AGENTS.md" "Conventional commits." "the CLAUDE.md body is carried over"
+assert_file_contains "$_root/AGENTS.md" "Canonical source: CLAUDE.md" "the do-not-edit header is present"
+assert_file_contains "$_root/.windsurf/rules.md" "Conventional commits." "the same body reaches per-harness files"
+assert_file_contains "$_root/.zed/agent-config.toml" 'agent_context = "AGENTS.md"' "Zed gets a pointer, not a copy"
+assert_file_contains "$_root/.aider.conf.yml" "AGENTS.md" "Aider config points at the bundle"
+assert_file_contains "$_root/.continuerc.json" "systemMessage" "Continue pointer written as JSON"
+
+test_start "agents_check_passes_immediately_after_a_render"
+_out="$(_agents "$_bin" check)"
+_rc=$?
+assert_equals 0 "$_rc" "a freshly rendered tree is in sync"
+assert_contains "in sync with CLAUDE.md" "$_out" "sync is reported"
+
+test_start "agents_check_detects_drift"
+printf '\n- A rule added only to CLAUDE.md.\n' >>"$_root/CLAUDE.md"
+_out="$(_agents "$_bin" check)"
+_rc=$?
+assert_equals 1 "$_rc" "drift exits 1"
+assert_contains "drifted from CLAUDE.md" "$_out" "drift is reported"
+_out="$(_agents "$_bin" render)"
+_out="$(_agents "$_bin" check)"
+assert_equals 0 "$?" "re-rendering clears the drift"
+
+test_start "agents_list_marks_rendered_targets"
+_out="$(_agents "$_bin" list)"
+assert_contains "rendered" "$_out" "rendered state is shown after a render"
+
+# ── guard, help and unknown subcommands ──────────────────────────────
+test_start "agents_refuses_a_root_without_chezmoidata"
+_root="$(_repo foreign --no-data)"
+_bin="$(_shim_root "$_root")"
+_out="$(cd "$_root" && PATH="$_bin:$PATH" "$BASH_BIN" "$DOT_BIN" agents check 2>&1)"
+_rc=$?
+assert_not_equals 0 "$_rc" "a checkout that is not the dotfiles repo is refused"
+assert_file_not_exists "$_root/AGENTS.md" "and nothing is written into it"
+
+test_start "agents_help"
+_root="$(_repo helpdir)"
+_bin="$(_shim_root "$_root")"
+# `dot agents -h`/`--help` is intercepted by the CLI's own help
+# registry; `dot agents help` reaches the command's usage text.
+_out="$(_agents "$_bin" help)"
+_rc=$?
+assert_equals 0 "$_rc" "help exits 0"
+assert_contains "Usage: dot agents <subcommand>" "$_out" "usage printed"
+assert_contains "render   Regenerate AGENTS.md" "$_out" "render documented"
+
+test_start "agents_unknown_subcommand_fails"
+_out="$(_agents "$_bin" bogus)"
+_rc=$?
+assert_equals 1 "$_rc" "unknown subcommand exits 1"
+assert_contains "Unknown subcommand" "$_out" "the error names the problem"
+assert_contains "dot agents --help" "$_out" "and points at the help"
+
+echo "RESULTS:$TESTS_RUN:$TESTS_PASSED:$TESTS_FAILED"

--- a/tests/unit/dot-cli/test_dot_commands_manual_formats.sh
+++ b/tests/unit/dot-cli/test_dot_commands_manual_formats.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2015-2026 Sebastien Rousseau
+# shellcheck disable=SC1090,SC1091,SC2034
+#
+# Behaviour tests for scripts/dot/commands/manual.sh: format selection,
+# the cache-then-fetch path, download failures, --offline and --local
+# sources, `download` mode, and the per-format open behaviour (pager
+# for text, tarball extraction for markdown, URL for html).
+#
+# `curl`, the opener and $PAGER are PATH shims that record what they
+# received, and DOTFILES_MANUAL_URL points at a fake host, so no
+# request leaves the machine and nothing opens a window. Cache,
+# offline and download directories all live in the sandbox.
+#
+# AUTO-GENERATED: false (hand-written)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+source "$SCRIPT_DIR/../../framework/assertions.sh"
+source "$SCRIPT_DIR/../../framework/coverage_helpers.sh"
+
+# Hand children a copy of the real stderr so their xtrace still reaches
+# the coverage runner even though the probes capture output with 2>&1.
+exec 21>&2
+export BASH_XTRACEFD=21
+
+MANUAL="$REPO_ROOT/scripts/dot/commands/manual.sh"
+BASH_BIN="$(command -v bash)"
+
+trap cov_teardown_sandbox EXIT
+cov_setup_sandbox
+
+LOG="$DOTFILES_COV_TMPDIR/manual.log"
+: >"$LOG"
+
+SHIMS="$DOTFILES_COV_TMPDIR/manual-shims"
+mkdir -p "$SHIMS"
+
+# curl shim: writes a body to -o <path> unless CURL_SHIM_FAIL is set.
+cat >"$SHIMS/curl" <<EOF
+#!/usr/bin/env bash
+printf 'curl %s\n' "\$*" >>"$LOG"
+[[ -n "\${CURL_SHIM_FAIL:-}" ]] && exit 22
+out=""
+prev=""
+for a in "\$@"; do
+  [[ "\$prev" == "-o" ]] && out="\$a"
+  prev="\$a"
+done
+[[ -n "\$out" ]] && printf 'fetched-manual-body\n' >"\$out"
+exit 0
+EOF
+# Opener + pager shims.
+cat >"$SHIMS/xdg-open" <<EOF
+#!/usr/bin/env bash
+printf 'xdg-open %s\n' "\$*" >>"$LOG"
+EOF
+cat >"$SHIMS/fake-pager" <<EOF
+#!/usr/bin/env bash
+printf 'pager %s\n' "\$*" >>"$LOG"
+EOF
+cat >"$SHIMS/uname" <<'EOF'
+#!/usr/bin/env bash
+echo "${MANUAL_TEST_UNAME:-Linux}"
+EOF
+chmod +x "$SHIMS/curl" "$SHIMS/xdg-open" "$SHIMS/fake-pager" "$SHIMS/uname"
+
+MANUAL_URL="https://manual.test/dotfiles"
+
+_manual() { # [args…]
+  DOTFILES_MANUAL_URL="$MANUAL_URL" PAGER="$SHIMS/fake-pager" \
+    PATH="$SHIMS:$PATH" "$BASH_BIN" "$MANUAL" "$@" 2>&1
+}
+
+CACHE="$XDG_CACHE_HOME/dotfiles/manual"
+OFFLINE="$XDG_DATA_HOME/dotfiles/manual"
+
+test_start "manual_help_lists_the_usage_block"
+_out="$(_manual --help)"
+_rc=$?
+assert_equals 0 "$_rc" "--help exits 0"
+assert_contains "dot manual pdf" "$_out" "the pdf form is documented"
+assert_contains "dot manual download <fmt>" "$_out" "the download form is documented"
+
+test_start "manual_fetches_a_format_once_and_then_serves_it_from_cache"
+: >"$LOG"
+_out="$(_manual pdf)"
+_rc=$?
+assert_equals 0 "$_rc" "first pdf open exits 0"
+assert_file_exists "$CACHE/dotfiles.pdf" "the pdf was cached"
+assert_file_contains "$LOG" "$MANUAL_URL/dotfiles.pdf" "the format-specific URL was fetched"
+assert_file_contains "$LOG" "xdg-open $CACHE/dotfiles.pdf" "the cached file was opened"
+: >"$LOG"
+_out="$(_manual pdf)"
+assert_equals 0 "$?" "second pdf open exits 0"
+assert_output_not_contains "curl " cat "$LOG"
+
+test_start "manual_reports_a_failed_download"
+: >"$LOG"
+_out="$(CURL_SHIM_FAIL=1 _manual epub)"
+_rc=$?
+assert_equals 1 "$_rc" "a failed fetch exits 1"
+assert_contains "failed to download $MANUAL_URL/dotfiles.epub" "$_out" "the URL is named in the error"
+assert_file_not_exists "$CACHE/dotfiles.epub" "nothing is left in the cache"
+
+test_start "manual_text_format_goes_to_the_pager"
+: >"$LOG"
+_out="$(_manual text)"
+_rc=$?
+assert_equals 0 "$_rc" "text open exits 0"
+assert_file_contains "$LOG" "pager $CACHE/dotfiles.txt" "the pager received the cached text manual"
+
+test_start "manual_html_opens_the_site_rather_than_a_file"
+: >"$LOG"
+_out="$(_manual html)"
+assert_equals 0 "$?" "html open exits 0"
+assert_file_contains "$LOG" "xdg-open $MANUAL_URL/" "the manual site URL is opened"
+: >"$LOG"
+_out="$(_manual html-multi)"
+assert_file_contains "$LOG" "xdg-open $MANUAL_URL/html/" "html-multi opens the multi-page URL"
+
+test_start "manual_markdown_extracts_the_tarball"
+_srcdir="$DOTFILES_COV_TMPDIR/md-src"
+mkdir -p "$_srcdir"
+printf '# Manual\n' >"$_srcdir/index.md"
+mkdir -p "$CACHE"
+tar -czf "$CACHE/dotfiles-md.tar.gz" -C "$_srcdir" index.md
+: >"$LOG"
+_out="$(_manual markdown)"
+_rc=$?
+assert_equals 0 "$_rc" "markdown open exits 0"
+assert_contains "Markdown source extracted to:" "$_out" "the extraction directory is reported"
+
+test_start "manual_offline_source"
+mkdir -p "$OFFLINE"
+printf 'offline-manual\n' >"$OFFLINE/dotfiles.pdf"
+: >"$LOG"
+_out="$(_manual pdf --offline)"
+_rc=$?
+assert_equals 0 "$_rc" "offline open exits 0"
+assert_file_contains "$LOG" "xdg-open $OFFLINE/dotfiles.pdf" "the offline copy was opened"
+assert_output_not_contains "curl " cat "$LOG"
+
+_out="$(_manual epub --offline)"
+_rc=$?
+assert_equals 1 "$_rc" "a missing offline copy exits 1"
+assert_contains "offline copy not found at $OFFLINE/dotfiles.epub" "$_out" "the expected path is named"
+
+test_start "manual_local_build_is_reported_when_absent"
+_out="$(_manual pdf --local)"
+_rc=$?
+assert_equals 1 "$_rc" "a missing local build exits 1"
+assert_contains "local build not found" "$_out" "the missing build is reported"
+assert_contains "build-manual.sh" "$_out" "the way to produce it is suggested"
+
+test_start "manual_download_mode_copies_into_the_working_directory"
+_dl="$DOTFILES_COV_TMPDIR/downloads"
+mkdir -p "$_dl"
+: >"$LOG"
+_out="$(cd "$_dl" && DOTFILES_MANUAL_URL="$MANUAL_URL" PATH="$SHIMS:$PATH" \
+  "$BASH_BIN" "$MANUAL" download pdf 2>&1)"
+_rc=$?
+assert_equals 0 "$_rc" "download exits 0"
+assert_file_exists "$_dl/dotfiles.pdf" "the manual landed in the working directory"
+assert_contains "saved: ./dotfiles.pdf" "$_out" "the destination is reported"
+
+test_start "manual_custom_url_override"
+: >"$LOG"
+_out="$(DOTFILES_MANUAL_URL="$MANUAL_URL" PATH="$SHIMS:$PATH" \
+  "$BASH_BIN" "$MANUAL" epub --url=https://mirror.test/manual 2>&1)"
+assert_file_contains "$LOG" "https://mirror.test/manual/dotfiles.epub" "--url= replaces the manual host"
+
+test_start "manual_open_falls_back_to_a_message_on_other_platforms"
+: >"$LOG"
+_out="$(MANUAL_TEST_UNAME=FreeBSD _manual pdf)"
+_rc=$?
+assert_equals 0 "$_rc" "an unsupported platform still exits 0"
+assert_contains "saved to: $CACHE/dotfiles.pdf" "$_out" "the path is printed instead of opened"
+
+test_start "manual_reports_when_no_opener_is_available"
+_bare="$DOTFILES_COV_TMPDIR/no-opener"
+mkdir -p "$_bare"
+for _t in bash cat printf echo sed find wc mkdir dirname basename tr uname date stat cp curl tar head; do
+  _p="$(command -v "$_t" 2>/dev/null || true)"
+  [[ -n "$_p" ]] && ln -sf "$_p" "$_bare/$_t"
+done
+ln -sf "$SHIMS/curl" "$_bare/curl"
+# Keep the uname shim: without it the real `uname` reports Darwin here
+# and manual.sh calls /usr/bin/open by absolute path, which would open a
+# window on the machine running the tests.
+ln -sf "$SHIMS/uname" "$_bare/uname"
+_out="$(MANUAL_TEST_UNAME=Linux DOTFILES_MANUAL_URL="$MANUAL_URL" PATH="$_bare" \
+  "$BASH_BIN" "$MANUAL" pdf 2>&1)"
+_rc=$?
+assert_equals 1 "$_rc" "no opener exits 1"
+assert_contains "no opener found" "$_out" "the missing openers are named"
+
+echo "RESULTS:$TESTS_RUN:$TESTS_PASSED:$TESTS_FAILED"

--- a/tests/unit/dot-cli/test_dot_commands_patterns_behavior.sh
+++ b/tests/unit/dot-cli/test_dot_commands_patterns_behavior.sh
@@ -27,6 +27,22 @@ BASH_BIN="$(command -v bash)"
 trap cov_teardown_sandbox EXIT
 cov_setup_sandbox
 
+# Substring refutation on an already-captured string. The framework's
+# assert_output_not_contains re-runs its arguments through `eval`, so
+# feeding captured output back in breaks on any shell metacharacter the
+# program happened to print.
+_refute_contains() { # <needle> <haystack> <msg>
+  if [[ "$2" != *"$1"* ]]; then
+    ((TESTS_PASSED++)) || true
+    printf '%b\n' "  ${GREEN}✓${NC} $CURRENT_TEST: $3"
+    return 0
+  fi
+  ((TESTS_FAILED++)) || true
+  printf '%b\n' "  ${RED}✗${NC} $CURRENT_TEST: $3"
+  printf '%b\n' "    Should not contain: '$1'"
+  return 1
+}
+
 PATTERN_DIR="$XDG_CONFIG_HOME/ai/patterns"
 LOG="$DOTFILES_COV_TMPDIR/patterns.log"
 : >"$LOG"
@@ -59,7 +75,7 @@ printf '# Hardener\n' >"$PATTERN_DIR/hardener.md"
 _out="$(_run list)"
 assert_contains "architect" "$_out" "first pattern listed"
 assert_contains "hardener" "$_out" "second pattern listed"
-assert_output_not_contains ".md" printf '%s' "$_out"
+_refute_contains ".md" "$_out" "the .md suffix is stripped from listed names"
 
 test_start "patterns_defaults_to_list"
 _out="$(_run)"
@@ -91,7 +107,7 @@ assert_file_contains "$LOG" "$PATTERN_DIR/architect.md" "glow received the patte
 test_start "patterns_view_reports_an_unknown_pattern"
 _out="$(_run view nope)"
 assert_contains "Pattern not found" "$_out" "missing pattern reported"
-assert_output_not_contains "Pattern: nope" printf '%s' "$_out"
+_refute_contains "Pattern: nope" "$_out" "no pattern body is rendered"
 
 test_start "patterns_view_without_a_name_fails_with_usage"
 _out="$(_run view)"

--- a/tests/unit/dot-cli/test_dot_commands_patterns_behavior.sh
+++ b/tests/unit/dot-cli/test_dot_commands_patterns_behavior.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2015-2026 Sebastien Rousseau
+# shellcheck disable=SC1090,SC1091,SC2034
+#
+# Behaviour tests for scripts/dot/commands/patterns.sh — the AI
+# steering-pattern manager: list, view (with and without `glow`), edit
+# (through a recording $EDITOR), the missing-name errors, the
+# not-found path and the usage fallback. Patterns live in the sandbox
+# XDG_CONFIG_HOME, so no real ~/.config is touched and no editor opens.
+#
+# AUTO-GENERATED: false (hand-written)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+source "$SCRIPT_DIR/../../framework/assertions.sh"
+source "$SCRIPT_DIR/../../framework/coverage_helpers.sh"
+
+# Hand children a copy of the real stderr so their xtrace still reaches
+# the coverage runner even though the probes capture output with 2>&1.
+exec 21>&2
+export BASH_XTRACEFD=21
+
+PATTERNS="$REPO_ROOT/scripts/dot/commands/patterns.sh"
+BASH_BIN="$(command -v bash)"
+
+trap cov_teardown_sandbox EXIT
+cov_setup_sandbox
+
+PATTERN_DIR="$XDG_CONFIG_HOME/ai/patterns"
+LOG="$DOTFILES_COV_TMPDIR/patterns.log"
+: >"$LOG"
+
+# A PATH with no `glow` at all. The host's may carry a mise shim for it,
+# which would take the glow branch (and fail on an untrusted config)
+# where this test wants the plain `cat` fallback.
+NOGLOW="$DOTFILES_COV_TMPDIR/noglow"
+mkdir -p "$NOGLOW"
+for _t in bash cat ls sed mkdir printf echo tr head tail wc date uname \
+  hostname tput dirname basename grep awk sort id stat find; do
+  _p="$(command -v "$_t" 2>/dev/null || true)"
+  [[ -n "$_p" ]] && ln -sf "$_p" "$NOGLOW/$_t"
+done
+
+_run() { # [args…] — runs with a glow-free PATH
+  PATH="$NOGLOW" "$BASH_BIN" "$PATTERNS" "$@" 2>&1
+}
+
+test_start "patterns_list_creates_the_directory_and_lists_names_without_the_extension"
+assert_dir_not_exists "$PATTERN_DIR" "pattern dir absent before the first run"
+_out="$(_run list)"
+_rc=$?
+assert_equals 0 "$_rc" "list on an empty config exits 0"
+assert_dir_exists "$PATTERN_DIR" "list created the pattern directory"
+assert_contains "AI Steering Patterns" "$_out" "header printed"
+
+printf '# Architect\n\nThink in systems.\n' >"$PATTERN_DIR/architect.md"
+printf '# Hardener\n' >"$PATTERN_DIR/hardener.md"
+_out="$(_run list)"
+assert_contains "architect" "$_out" "first pattern listed"
+assert_contains "hardener" "$_out" "second pattern listed"
+assert_output_not_contains ".md" printf '%s' "$_out"
+
+test_start "patterns_defaults_to_list"
+_out="$(_run)"
+assert_equals 0 "$?" "no argument exits 0"
+assert_contains "architect" "$_out" "bare invocation lists patterns"
+
+test_start "patterns_view_prints_the_body_with_cat_when_glow_is_missing"
+_out="$(_run view architect)"
+_rc=$?
+assert_equals 0 "$_rc" "view exits 0"
+assert_contains "Pattern: architect" "$_out" "header names the pattern"
+assert_contains "Think in systems." "$_out" "body printed"
+
+test_start "patterns_view_prefers_glow_when_available"
+_glow="$DOTFILES_COV_TMPDIR/glow-bin"
+mkdir -p "$_glow"
+cat >"$_glow/glow" <<EOF
+#!/usr/bin/env bash
+printf 'glow %s\n' "\$*" >>"$LOG"
+echo "rendered-by-glow"
+EOF
+chmod +x "$_glow/glow"
+_out="$(PATH="$_glow:$NOGLOW" "$BASH_BIN" "$PATTERNS" view architect 2>&1)"
+_rc=$?
+assert_equals 0 "$_rc" "view via glow exits 0"
+assert_contains "rendered-by-glow" "$_out" "glow rendered the file"
+assert_file_contains "$LOG" "$PATTERN_DIR/architect.md" "glow received the pattern path"
+
+test_start "patterns_view_reports_an_unknown_pattern"
+_out="$(_run view nope)"
+assert_contains "Pattern not found" "$_out" "missing pattern reported"
+assert_output_not_contains "Pattern: nope" printf '%s' "$_out"
+
+test_start "patterns_view_without_a_name_fails_with_usage"
+_out="$(_run view)"
+_rc=$?
+assert_equals 1 "$_rc" "view without a name exits 1"
+assert_contains "Usage: dot patterns view <name>" "$_out" "usage printed"
+
+test_start "patterns_edit_opens_the_file_in_EDITOR"
+_editor="$DOTFILES_COV_TMPDIR/editor-bin"
+mkdir -p "$_editor"
+cat >"$_editor/fake-editor" <<EOF
+#!/usr/bin/env bash
+printf 'editor %s\n' "\$*" >>"$LOG"
+EOF
+chmod +x "$_editor/fake-editor"
+: >"$LOG"
+_out="$(EDITOR="$_editor/fake-editor" _run edit architect)"
+_rc=$?
+assert_equals 0 "$_rc" "edit exits 0"
+assert_file_contains "$LOG" "editor $PATTERN_DIR/architect.md" "the editor received the pattern path"
+
+test_start "patterns_edit_without_a_name_fails_with_usage"
+_out="$(EDITOR="$_editor/fake-editor" _run edit)"
+_rc=$?
+assert_equals 1 "$_rc" "edit without a name exits 1"
+assert_contains "Usage: dot patterns edit <name>" "$_out" "usage printed"
+
+test_start "patterns_unknown_subcommand_prints_usage_and_fails"
+_out="$(_run bogus)"
+_rc=$?
+assert_equals 1 "$_rc" "unknown subcommand exits 1"
+assert_contains "Usage: dot patterns [list|view|edit] [name]" "$_out" "usage printed"
+
+echo "RESULTS:$TESTS_RUN:$TESTS_PASSED:$TESTS_FAILED"

--- a/tests/unit/dot-cli/test_dot_commands_tools_guards.sh
+++ b/tests/unit/dot-cli/test_dot_commands_tools_guards.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2015-2026 Sebastien Rousseau
+# shellcheck disable=SC1090,SC1091,SC2034
+#
+# Guard-path tests for scripts/dot/commands/tools.sh:
+#
+#   tools install  — the "Nix is not installed" refusal.
+#   new            — usage, template-name and project-name validation
+#                    (path traversal), unknown template, existing
+#                    destination, and a successful render.
+#   packages       — the language package-manager report, including the
+#                    pipx fallback when `pipx list` fails (a broken
+#                    interpreter in real life).
+#
+# The command file is run directly (it dispatches on "$1" at the
+# bottom) with PATH shims for nix/pipx/npm and a sandbox working
+# directory, so nothing is installed and no project is written outside
+# the sandbox.
+#
+# AUTO-GENERATED: false (hand-written)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+source "$SCRIPT_DIR/../../framework/assertions.sh"
+source "$SCRIPT_DIR/../../framework/coverage_helpers.sh"
+
+# Hand children a copy of the real stderr so their xtrace still reaches
+# the coverage runner even though the probes capture output with 2>&1.
+exec 21>&2
+export BASH_XTRACEFD=21
+
+TOOLS="$REPO_ROOT/scripts/dot/commands/tools.sh"
+BASH_BIN="$(command -v bash)"
+
+trap cov_teardown_sandbox EXIT
+cov_setup_sandbox
+
+WORK="$DOTFILES_COV_TMPDIR/work"
+mkdir -p "$WORK"
+
+_tools() { # [args…] — run from the sandbox working directory
+  (cd "$WORK" && "$BASH_BIN" "$TOOLS" "$@" 2>&1)
+}
+
+# ── tools install without nix ────────────────────────────────────────
+test_start "tools_install_refuses_without_nix"
+_nonix="$DOTFILES_COV_TMPDIR/nonix"
+mkdir -p "$_nonix"
+for _t in bash cat printf echo sed tr uname date dirname basename \
+  head tail wc mkdir cp rm grep awk sort stat find tput python3 git; do
+  _p="$(command -v "$_t" 2>/dev/null || true)"
+  [[ -n "$_p" ]] && ln -sf "$_p" "$_nonix/$_t"
+done
+_out="$(cd "$WORK" && PATH="$_nonix" "$BASH_BIN" "$TOOLS" tools install 2>&1)"
+_rc=$?
+assert_equals 1 "$_rc" "install without nix exits 1"
+assert_contains "not installed" "$_out" "the missing prerequisite is named"
+assert_contains "https://nixos.org/download/" "$_out" "the verified installer is linked"
+assert_contains "use Homebrew/apt for individual tools" "$_out" "an alternative is suggested"
+
+# ── dot new guards ───────────────────────────────────────────────────
+test_start "new_without_arguments_prints_usage"
+_out="$(_tools new)"
+_rc=$?
+assert_equals 1 "$_rc" "no arguments exits 1"
+assert_contains "Usage: dot new <lang> <name>" "$_out" "usage printed"
+assert_contains "Available templates:" "$_out" "templates listed"
+
+_out="$(_tools new python)"
+assert_equals 1 "$?" "a missing project name exits 1"
+
+test_start "new_rejects_a_traversing_template_name"
+_out="$(_tools new "../../etc" proj)"
+_rc=$?
+assert_not_equals 0 "$_rc" "a traversing template name is refused"
+assert_contains "Invalid template name" "$_out" "the template name is rejected by name"
+
+test_start "new_rejects_a_traversing_project_name"
+_out="$(_tools new python "../escape")"
+_rc=$?
+assert_not_equals 0 "$_rc" "a traversing project name is refused"
+assert_contains "Invalid project name" "$_out" "the project name is rejected by name"
+assert_file_not_exists "$DOTFILES_COV_TMPDIR/escape" "nothing is created outside the working directory"
+
+test_start "new_reports_an_unknown_template"
+_out="$(_tools new nosuchlang proj)"
+_rc=$?
+assert_equals 1 "$_rc" "an unknown template exits 1"
+assert_contains "Unknown template: nosuchlang" "$_out" "the template is named"
+assert_contains "Available templates:" "$_out" "the known templates are listed"
+
+test_start "new_refuses_to_overwrite_an_existing_destination"
+mkdir -p "$WORK/taken"
+_out="$(_tools new python taken)"
+_rc=$?
+assert_not_equals 0 "$_rc" "an existing destination is refused"
+assert_contains "Destination exists" "$_out" "the collision is reported"
+
+# ── packages ─────────────────────────────────────────────────────────
+test_start "packages_reports_language_package_managers"
+_pm="$DOTFILES_COV_TMPDIR/pm"
+mkdir -p "$_pm"
+for _t in bash cat printf echo sed tr uname date dirname basename \
+  head tail wc mkdir grep awk sort stat find tput; do
+  _p="$(command -v "$_t" 2>/dev/null || true)"
+  [[ -n "$_p" ]] && ln -sf "$_p" "$_pm/$_t"
+done
+cat >"$_pm/pipx" <<'SHIM'
+#!/usr/bin/env bash
+case "${1:-}" in
+  --version) echo "1.4.3" ;;
+  list)
+    if [[ -n "${PIPX_SHIM_BROKEN:-}" ]]; then
+      echo "pipx: broken interpreter" >&2
+      exit 1
+    fi
+    [[ -n "${PIPX_SHIM_EMPTY:-}" ]] && exit 0
+    printf 'black 24.1.0\nruff 0.3.0\n'
+    ;;
+esac
+exit 0
+SHIM
+chmod +x "$_pm/pipx"
+_out="$(cd "$WORK" && PATH="$_pm" "$BASH_BIN" "$TOOLS" packages 2>&1)"
+_rc=$?
+assert_equals 0 "$_rc" "packages exits 0"
+assert_contains "Package Managers" "$_out" "the system section header is printed"
+assert_contains "Language Package Managers" "$_out" "the language section header is printed"
+assert_contains "pipx: 1.4.3" "$_out" "the pipx version is reported"
+assert_contains "Installed: 2" "$_out" "both installed pipx packages are counted"
+
+test_start "packages_counts_an_empty_pipx_list_as_zero"
+_out="$(cd "$WORK" && PATH="$_pm" PIPX_SHIM_EMPTY=1 "$BASH_BIN" "$TOOLS" packages 2>&1)"
+assert_equals 0 "$?" "an empty pipx list exits 0"
+assert_contains "Installed: 0" "$_out" "no packages counts as zero, not one"
+
+test_start "packages_falls_back_when_pipx_list_fails"
+_out="$(cd "$WORK" && PATH="$_pm" PIPX_SHIM_BROKEN=1 "$BASH_BIN" "$TOOLS" packages 2>&1)"
+_rc=$?
+assert_equals 0 "$_rc" "a failing pipx list does not abort the report"
+assert_contains "Installed: N/A" "$_out" "the count degrades to N/A"
+assert_contains "Language Package Managers" "$_out" "the rest of the report still renders"
+
+test_start "tools_unknown_subcommand_fails"
+_out="$(_tools totally-unknown)"
+_rc=$?
+assert_equals 1 "$_rc" "an unknown subcommand exits 1"
+assert_contains "Unknown tools command" "$_out" "the error names the problem"
+
+echo "RESULTS:$TESTS_RUN:$TESTS_PASSED:$TESTS_FAILED"

--- a/tests/unit/dot-cli/test_dot_fleet_namespace_enforce_apply.sh
+++ b/tests/unit/dot-cli/test_dot_fleet_namespace_enforce_apply.sh
@@ -1,0 +1,461 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2015-2026 Sebastien Rousseau
+# shellcheck disable=SC1090,SC1091,SC2034
+#
+# Behavioural coverage for `dot fleet namespace|enforce|apply` and the
+# top-level dispatcher in scripts/dot/commands/fleet.sh. The command's
+# config writes (.chezmoidata.toml, agent-profiles.json) land in a
+# private fake source tree; SSH fan-out is replaced by PATH shims for
+# ssh / ssh-keygen / mv / sed so every failure branch is reachable
+# without touching the host, the real repo, or the network.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+source "$SCRIPT_DIR/../../framework/assertions.sh"
+source "$SCRIPT_DIR/../../framework/coverage_helpers.sh"
+
+# Keep child xtrace flowing to the coverage runner's trace stream even
+# when a probe captures `2>&1` or discards stderr.
+exec 21>&2
+export BASH_XTRACEFD=21
+
+trap cov_teardown_sandbox EXIT
+cov_setup_sandbox
+TMP="$DOTFILES_COV_TMPDIR"
+[[ -n "$TMP" && -d "$TMP" ]] || {
+  echo "sandbox tmpdir missing; refusing to run" >&2
+  exit 1
+}
+
+# ── Fake source tree ────────────────────────────────────────────────
+# lib/ scripts/ bin/ are symlinks into the real repo so the traced
+# BASH_SOURCE paths resolve to the real files; defaults/ is a private
+# copy so the command's config reads/writes never leave the sandbox.
+# Under the coverage runner the tree must outlive sandbox teardown
+# (the aggregator resolves symlinks after every test has finished);
+# COV_TRACE_DIR is wiped by the runner at the start of each sweep.
+if [[ -n "${COV_TRACE_DIR:-}" && -d "${COV_TRACE_DIR:-}" ]]; then
+  FAKE="$(mktemp -d "$COV_TRACE_DIR/fleet-fake.XXXXXX")"
+else
+  FAKE="$TMP/repo"
+fi
+mkdir -p "$FAKE/defaults/dot_config/dotfiles"
+ln -s "$REPO_ROOT/lib" "$FAKE/lib"
+ln -s "$REPO_ROOT/scripts" "$FAKE/scripts"
+ln -s "$REPO_ROOT/bin" "$FAKE/bin"
+cp "$REPO_ROOT/package.json" "$FAKE/package.json"
+echo defaults >"$FAKE/.chezmoiroot"
+FLEET="$FAKE/scripts/dot/commands/fleet.sh"
+DATA="$FAKE/defaults/.chezmoidata.toml"
+PROFILES="$FAKE/defaults/dot_config/dotfiles/agent-profiles.json"
+EVENTS="$XDG_STATE_HOME/dotfiles/fleet/events.jsonl"
+
+# ── PATH ────────────────────────────────────────────────────────────
+# $MINI holds only the coreutils the script needs; $SHIMS is a second
+# front-of-PATH dir for per-test overrides (ssh, ssh-keygen, mv, sed).
+MINI="$TMP/mini"
+SHIMS="$TMP/shims"
+mkdir -p "$MINI" "$SHIMS"
+for t in bash sh dirname basename sed head tail hostname date mkdir awk wc tr \
+  uname grep realpath readlink sort uniq cat mktemp mv rm cp cut env tput \
+  stty ls find diff touch chmod jq; do
+  p="$(command -v "$t" 2>/dev/null || true)"
+  [[ -n "$p" ]] && ln -sf "$p" "$MINI/$t"
+done
+PATH_NO_SSH="$TMP/bin:$MINI"
+export PATH="$SHIMS:$PATH_NO_SSH"
+
+# ssh shim: never opens a socket; records the target and exits 0.
+SSH_LOG="$TMP/ssh.log"
+cat >"$SHIMS/ssh" <<'SHIM'
+#!/usr/bin/env bash
+target=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -o) shift 2 ;;
+    -*) shift ;;
+    *)
+      target="$1"
+      shift
+      break
+      ;;
+  esac
+done
+printf '%s %s\n' "$target" "$*" >>"${FAKE_SSH_LOG:?}"
+exit 0
+SHIM
+chmod +x "$SHIMS/ssh"
+export FAKE_SSH_LOG="$SSH_LOG"
+
+# ssh-keygen shim: `-F host` succeeds unless FAKE_UNKNOWN_HOST matches.
+cat >"$SHIMS/ssh-keygen" <<'SHIM'
+#!/usr/bin/env bash
+host=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -F)
+      host="$2"
+      shift 2
+      ;;
+    *) shift ;;
+  esac
+done
+[[ -n "${FAKE_UNKNOWN_HOST:-}" && "$host" == "$FAKE_UNKNOWN_HOST" ]] && exit 1
+exit 0
+SHIM
+chmod +x "$SHIMS/ssh-keygen"
+
+write_data() {
+  cat >"$DATA"
+}
+
+# assert_not_contains <needle> <haystack> [msg] — string-level negative.
+assert_not_contains() {
+  local needle="$1" actual="$2" msg="${3:-string should not contain substring}"
+  if [[ "$actual" != *"$needle"* ]]; then
+    ((TESTS_PASSED++)) || true
+    printf '%b\n' "  ${GREEN}✓${NC} $CURRENT_TEST: $msg"
+  else
+    ((TESTS_FAILED++)) || true
+    printf '%b\n' "  ${RED}✗${NC} $CURRENT_TEST: $msg"
+    printf '%b\n' "    Should not contain: '$needle'"
+  fi
+}
+
+fleet() {
+  bash "$FLEET" fleet "$@"
+}
+
+# ── namespace ───────────────────────────────────────────────────────
+write_data <<'TOML'
+node_id = "node-a"
+namespace = "team"
+
+[namespaces.default]
+[namespaces.team]
+[namespaces.lab]
+TOML
+
+test_start "fleet_namespace_show_lists_available_namespaces"
+out="$(fleet namespace show 2>&1)"
+rc=$?
+assert_equals 0 "$rc" "namespace show exits 0"
+assert_contains "team" "$out" "active namespace shown"
+assert_contains "[active]" "$out" "active marker rendered"
+assert_contains "lab" "$out" "inactive namespace listed"
+
+test_start "fleet_namespace_default_subcommand_and_alias"
+out="$(fleet namespace 2>&1)"
+assert_contains "Fleet Namespace" "$out" "bare namespace shows"
+out="$(fleet ns 2>&1)"
+assert_contains "Fleet Namespace" "$out" "ns alias routes to namespace"
+
+test_start "fleet_namespace_set_rewrites_data_file"
+out="$(fleet namespace set lab 2>&1)"
+rc=$?
+assert_equals 0 "$rc" "namespace set exits 0"
+assert_contains "Set to 'lab'" "$out" "confirmation message"
+assert_file_contains "$DATA" 'namespace = "lab"' "data file rewritten atomically"
+assert_file_contains "$EVENTS" '"event":"namespace_set"' "event emitted"
+assert_file_contains "$EVENTS" '"namespace":"lab"' "event carries the new namespace"
+
+test_start "fleet_namespace_set_requires_name"
+out="$(fleet namespace set 2>&1)"
+rc=$?
+assert_equals 1 "$rc" "missing name exits 1"
+assert_contains "Usage: dot fleet namespace set" "$out" "usage printed"
+
+test_start "fleet_namespace_set_rejects_unsafe_name"
+out="$(fleet namespace set 'bad;name' 2>&1)"
+rc=$?
+assert_equals 1 "$rc" "unsafe name exits 1"
+assert_contains "Invalid namespace" "$out" "validation message"
+assert_file_contains "$DATA" 'namespace = "lab"' "data file untouched"
+
+test_start "fleet_namespace_set_without_existing_key"
+write_data <<'TOML'
+node_id = "node-a"
+TOML
+out="$(fleet namespace set fresh 2>&1)"
+rc=$?
+assert_equals 0 "$rc" "set without a namespace line still succeeds"
+assert_contains "Set to 'fresh'" "$out" "confirmation message"
+assert_equals "" "$(grep '^namespace' "$DATA")" "no namespace line is invented"
+
+write_data <<'TOML'
+namespace = "team"
+TOML
+
+test_start "fleet_namespace_set_reports_mv_failure"
+cat >"$SHIMS/mv" <<'SHIM'
+#!/usr/bin/env bash
+exit 1
+SHIM
+chmod +x "$SHIMS/mv"
+out="$(fleet namespace set broken 2>&1)"
+rc=$?
+rm -f "$SHIMS/mv"
+assert_equals 1 "$rc" "mv failure exits 1"
+assert_contains "Failed to commit namespace update" "$out" "commit failure reported"
+assert_file_contains "$DATA" 'namespace = "team"' "data file left intact"
+assert_equals "" "$(ls "$FAKE/defaults"/.chezmoidata.toml.* 2>/dev/null)" "tempfile cleaned up"
+
+test_start "fleet_namespace_set_reports_sed_failure"
+cat >"$SHIMS/sed" <<'SHIM'
+#!/usr/bin/env bash
+case "$*" in
+  *'s/^namespace = '*) exit 1 ;;
+esac
+exec "${FAKE_REAL_SED:?}" "$@"
+SHIM
+chmod +x "$SHIMS/sed"
+out="$(FAKE_REAL_SED="$MINI/sed" fleet namespace set broken 2>&1)"
+rc=$?
+rm -f "$SHIMS/sed"
+assert_equals 1 "$rc" "sed failure exits 1"
+assert_contains "Failed to render namespace update" "$out" "render failure reported"
+assert_file_contains "$DATA" 'namespace = "team"' "data file left intact"
+
+test_start "fleet_namespace_unknown_subcommand"
+out="$(fleet namespace bogus 2>&1)"
+rc=$?
+assert_equals 1 "$rc" "unknown namespace subcommand exits 1"
+assert_contains "Usage: dot fleet namespace" "$out" "usage printed"
+
+# ── enforce ─────────────────────────────────────────────────────────
+test_start "fleet_enforce_status_without_profiles"
+out="$(fleet enforce 2>&1)"
+rc=$?
+assert_equals 1 "$rc" "missing profiles exits 1"
+assert_contains "agent-profiles.json not found" "$out" "explains the missing file"
+
+cat >"$PROFILES" <<'JSON'
+{
+  "rbac": {
+    "enforcement": "advisory",
+    "defaultRole": "developer",
+    "roles": {
+      "developer": {"allowedProfiles": ["ask", "plan"]},
+      "operator": {"allowedProfiles": ["apply"]}
+    }
+  }
+}
+JSON
+
+test_start "fleet_enforce_status_renders_roles"
+out="$(fleet enforce status 2>&1)"
+rc=$?
+assert_equals 0 "$rc" "enforce status exits 0"
+assert_contains "advisory" "$out" "mode shown"
+assert_contains "developer" "$out" "default role shown"
+assert_contains "ask, plan" "$out" "role profiles joined"
+assert_contains "operator" "$out" "every role listed"
+
+test_start "fleet_enforce_set_strict"
+out="$(fleet enforce set strict 2>&1)"
+rc=$?
+assert_equals 0 "$rc" "enforce set exits 0"
+assert_contains "set to 'strict'" "$out" "confirmation"
+assert_equals "strict" "$(jq -r .rbac.enforcement "$PROFILES")" "profiles file updated"
+assert_file_contains "$EVENTS" '"event":"enforcement_set"' "event emitted"
+
+test_start "fleet_enforce_set_requires_mode"
+out="$(fleet enforce set 2>&1)"
+rc=$?
+assert_equals 1 "$rc" "missing mode exits 1"
+assert_contains "Usage: dot fleet enforce set" "$out" "usage printed"
+
+test_start "fleet_enforce_set_rejects_unknown_mode"
+out="$(fleet enforce set lenient 2>&1)"
+rc=$?
+assert_equals 1 "$rc" "unknown mode exits 1"
+assert_contains "Invalid enforcement mode: lenient" "$out" "validation message"
+assert_equals "strict" "$(jq -r .rbac.enforcement "$PROFILES")" "profiles file untouched"
+
+test_start "fleet_enforce_set_without_profiles"
+mv "$PROFILES" "$PROFILES.bak"
+out="$(fleet enforce set advisory 2>&1)"
+rc=$?
+mv "$PROFILES.bak" "$PROFILES"
+assert_equals 1 "$rc" "missing profiles exits 1"
+assert_contains "agent-profiles.json not found" "$out" "explains the missing file"
+
+test_start "fleet_enforce_unknown_subcommand"
+out="$(fleet enforce bogus 2>&1)"
+rc=$?
+assert_equals 1 "$rc" "unknown enforce subcommand exits 1"
+assert_contains "Usage: dot fleet enforce" "$out" "usage printed"
+
+# ── apply ───────────────────────────────────────────────────────────
+HOSTS="$TMP/fleet.toml"
+cat >"$HOSTS" <<'TOML'
+[hosts.alpha]
+ssh = "user@alpha.test"
+profile = "workstation"
+
+[hosts.beta]
+ssh = "user@beta.test:2222"
+profile = "minimal"
+TOML
+export DOTFILES_FLEET_HOSTS="$HOSTS"
+
+test_start "fleet_apply_help"
+out="$(fleet apply --help 2>&1)"
+rc=$?
+assert_equals 0 "$rc" "--help exits 0"
+assert_contains "Usage: dot fleet apply" "$out" "usage header"
+assert_contains "$HOSTS" "$out" "help names the active hosts file"
+
+test_start "fleet_apply_rejects_unknown_flag"
+out="$(fleet apply --bogus 2>&1)"
+rc=$?
+assert_equals 1 "$rc" "unknown flag exits 1"
+assert_contains "Unknown arg" "$out" "flag echoed"
+
+test_start "fleet_apply_without_hosts_file"
+out="$(DOTFILES_FLEET_HOSTS="$TMP/nope.toml" fleet apply 2>&1)"
+rc=$?
+assert_equals 1 "$rc" "missing hosts file exits 1"
+assert_contains "no hosts file at $TMP/nope.toml" "$out" "path reported"
+assert_contains "Hint" "$out" "hint printed"
+
+test_start "fleet_apply_with_empty_hosts_file"
+: >"$TMP/empty.toml"
+out="$(DOTFILES_FLEET_HOSTS="$TMP/empty.toml" fleet apply 2>&1)"
+rc=$?
+assert_equals 1 "$rc" "empty hosts file exits 1"
+assert_contains "hosts file is empty" "$out" "explains"
+
+test_start "fleet_apply_unknown_host_filter"
+out="$(fleet apply --host gamma 2>&1)"
+rc=$?
+assert_equals 1 "$rc" "unknown host exits 1"
+assert_contains "host not found: gamma" "$out" "host named"
+
+test_start "fleet_apply_dry_run_lists_hosts"
+out="$(fleet apply --dry-run --cmd "uptime" --jobs 2 2>&1)"
+rc=$?
+assert_equals 0 "$rc" "dry-run exits 0"
+assert_contains "alpha" "$out" "first host listed"
+assert_contains "user@beta.test:2222  profile=minimal  cmd=uptime" "$out" "host line carries ssh target, profile and command"
+assert_contains "no SSH connections opened" "$out" "dry-run confirmation"
+assert_contains "Parallel" "$out" "parallelism reported"
+assert_file_not_exists "$SSH_LOG" "dry-run never invokes ssh"
+
+test_start "fleet_apply_short_flags"
+out="$(fleet apply -n -j 1 2>&1)"
+rc=$?
+assert_equals 0 "$rc" "-n / -j accepted"
+assert_contains "dot sync && dot doctor --quiet" "$out" "default command shown"
+
+test_start "fleet_apply_without_ssh_binary"
+out="$(PATH="$PATH_NO_SSH" fleet apply 2>&1)"
+rc=$?
+assert_equals 127 "$rc" "missing ssh exits 127"
+assert_contains "not installed" "$out" "explains"
+
+test_start "fleet_apply_rejects_invalid_ssh_target"
+cat >"$TMP/bad.toml" <<'TOML'
+[hosts.evil]
+ssh = "user@evil';rm -rf /;'.com"
+profile = "x"
+TOML
+out="$(DOTFILES_FLEET_HOSTS="$TMP/bad.toml" fleet apply --cmd true 2>&1)"
+rc=$?
+assert_equals 1 "$rc" "invalid target exits 1"
+assert_contains "invalid ssh target" "$out" "rejection message"
+assert_file_not_exists "$SSH_LOG" "no ssh call for a rejected target"
+
+test_start "fleet_apply_verify_hosts_requires_known_hosts"
+rm -f "$HOME/.ssh/known_hosts"
+out="$(fleet apply --verify-hosts --cmd true 2>&1)"
+rc=$?
+assert_equals 1 "$rc" "missing known_hosts exits 1"
+assert_contains "populate before --verify-hosts" "$out" "explains"
+
+mkdir -p "$HOME/.ssh"
+: >"$HOME/.ssh/known_hosts"
+
+test_start "fleet_apply_verify_hosts_aborts_on_unknown_host"
+out="$(FAKE_UNKNOWN_HOST=beta.test fleet apply --verify-hosts --cmd true 2>&1)"
+rc=$?
+assert_equals 1 "$rc" "unknown host aborts"
+assert_contains "no known_hosts entry for beta.test" "$out" "host named (user@ and :port stripped)"
+assert_contains "1 host(s) missing from known_hosts" "$out" "count reported"
+assert_file_not_exists "$SSH_LOG" "no ssh call when verification fails"
+
+test_start "fleet_apply_verify_hosts_then_fans_out"
+out="$(fleet apply --verify-hosts --jobs 1 --cmd "echo hi" 2>&1)"
+rc=$?
+assert_equals 0 "$rc" "verified apply exits 0"
+assert_contains "all hosts found in known_hosts" "$out" "verification confirmation"
+assert_contains "2 ok / 0 failed / 2 total" "$out" "summary line"
+assert_file_contains "$SSH_LOG" "user@alpha.test echo hi" "alpha received the command"
+assert_file_contains "$SSH_LOG" "user@beta.test:2222 echo hi" "beta received the command"
+assert_file_contains "$EVENTS" '"event":"apply"' "apply events emitted"
+assert_file_contains "$EVENTS" '"host":"beta"' "event carries the host"
+
+test_start "fleet_apply_reports_failed_hosts"
+cat >"$SHIMS/ssh" <<'SHIM'
+#!/usr/bin/env bash
+# Failing variant: every connection "breaks" with a diagnostic on stderr.
+echo "shim: connection refused" >&2
+exit 255
+SHIM
+chmod +x "$SHIMS/ssh"
+out="$(fleet apply --cmd "uptime" 2>&1)"
+rc=$?
+assert_equals 1 "$rc" "any failed host makes apply exit 1"
+assert_contains "0 ok / 2 failed / 2 total" "$out" "summary counts failures"
+assert_contains "connection refused" "$out" "first stderr line surfaced per host"
+assert_file_contains "$EVENTS" '"status":"fail 255"' "event records the ssh exit code"
+cat >"$SHIMS/ssh" <<'SHIM'
+#!/usr/bin/env bash
+target=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -o) shift 2 ;;
+    -*) shift ;;
+    *)
+      target="$1"
+      shift
+      break
+      ;;
+  esac
+done
+printf '%s %s\n' "$target" "$*" >>"${FAKE_SSH_LOG:?}"
+exit 0
+SHIM
+chmod +x "$SHIMS/ssh"
+
+test_start "fleet_apply_push_alias"
+rm -f "$SSH_LOG"
+out="$(fleet push --host alpha --cmd "uptime" 2>&1)"
+rc=$?
+assert_equals 0 "$rc" "push alias exits 0"
+assert_contains "1 ok / 0 failed / 1 total" "$out" "single host summary"
+assert_file_contains "$SSH_LOG" "user@alpha.test uptime" "only alpha contacted"
+
+# ── dispatcher ──────────────────────────────────────────────────────
+test_start "fleet_default_subcommand_with_flag"
+out="$(fleet --json 2>&1)"
+rc=$?
+assert_equals 0 "$rc" "flag-only argv exits 0"
+assert_contains '{"node_id"' "$out" "--json without subcommand runs status --json"
+
+test_start "fleet_unknown_subcommand_prints_usage"
+out="$(fleet bogus 2>&1)"
+rc=$?
+assert_equals 0 "$rc" "usage listing exits 0"
+assert_contains "Fleet Commands" "$out" "usage header"
+assert_contains "enforce" "$out" "enforce listed"
+assert_contains "apply" "$out" "apply listed"
+
+test_start "fleet_dispatch_without_fleet_prefix"
+out="$(bash "$FLEET" --json 2>&1)"
+rc=$?
+assert_equals 0 "$rc" "direct invocation exits 0"
+assert_contains '{"node_id"' "$out" "prefix-less argv still dispatches"
+
+echo "RESULTS:$TESTS_RUN:$TESTS_PASSED:$TESTS_FAILED"

--- a/tests/unit/dot-cli/test_dot_fleet_status_drift.sh
+++ b/tests/unit/dot-cli/test_dot_fleet_status_drift.sh
@@ -265,7 +265,7 @@ rc=$?
 assert_equals 0 "$rc" "history exits 0"
 assert_contains "2026-01-01T00:00:00Z" "$out" "clean entry time shown"
 assert_contains "drifted (2 files)" "$out" "drifted entry shows file count"
-assert_contains "?" "$out" "unparseable line falls back to ? instead of aborting"
+assert_contains "?" "$out" "unparsable line falls back to ? instead of aborting"
 
 test_start "fleet_drift_history_honours_count"
 out="$(fleet drift history 1 2>&1)"

--- a/tests/unit/dot-cli/test_dot_fleet_status_drift.sh
+++ b/tests/unit/dot-cli/test_dot_fleet_status_drift.sh
@@ -1,0 +1,339 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2015-2026 Sebastien Rousseau
+# shellcheck disable=SC1090,SC1091,SC2034
+#
+# Behavioural coverage for `dot fleet status|drift|events` in
+# scripts/dot/commands/fleet.sh. Every branch is driven through inputs:
+# a writable fake source tree (code symlinked, .chezmoidata.toml owned
+# by the test), a scripted `chezmoi status` shim, a curl spy for the
+# event-forwarding endpoint, and PATH variants without chezmoi / jq.
+# Nothing touches the real repo, $HOME, or the network.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+source "$SCRIPT_DIR/../../framework/assertions.sh"
+source "$SCRIPT_DIR/../../framework/coverage_helpers.sh"
+
+# Keep child xtrace flowing to the coverage runner's trace stream even
+# when a probe captures `2>&1` or discards stderr.
+exec 21>&2
+export BASH_XTRACEFD=21
+
+trap cov_teardown_sandbox EXIT
+cov_setup_sandbox
+TMP="$DOTFILES_COV_TMPDIR"
+[[ -n "$TMP" && -d "$TMP" ]] || {
+  echo "sandbox tmpdir missing; refusing to run" >&2
+  exit 1
+}
+
+# ── Fake source tree ────────────────────────────────────────────────
+# lib/ scripts/ bin/ are symlinks into the real repo so the traced
+# BASH_SOURCE paths resolve to the real files; defaults/ is a private
+# copy so the command's config reads/writes never leave the sandbox.
+# Under the coverage runner the fake tree must outlive this test's
+# sandbox teardown: the aggregator resolves the symlinked BASH_SOURCE
+# paths only after every test has finished. COV_TRACE_DIR is wiped by
+# the runner at the start of each sweep, so nothing accumulates.
+if [[ -n "${COV_TRACE_DIR:-}" && -d "${COV_TRACE_DIR:-}" ]]; then
+  FAKE="$(mktemp -d "$COV_TRACE_DIR/fleet-fake.XXXXXX")"
+else
+  FAKE="$TMP/repo"
+fi
+mkdir -p "$FAKE/defaults"
+ln -s "$REPO_ROOT/lib" "$FAKE/lib"
+ln -s "$REPO_ROOT/scripts" "$FAKE/scripts"
+ln -s "$REPO_ROOT/bin" "$FAKE/bin"
+cp "$REPO_ROOT/package.json" "$FAKE/package.json"
+echo defaults >"$FAKE/.chezmoiroot"
+FLEET="$FAKE/scripts/dot/commands/fleet.sh"
+DATA="$FAKE/defaults/.chezmoidata.toml"
+
+STATE_DIR="$XDG_STATE_HOME/dotfiles/fleet"
+EVENTS="$STATE_DIR/events.jsonl"
+HISTORY="$STATE_DIR/drift-history.jsonl"
+
+# ── PATH variants ───────────────────────────────────────────────────
+# $MINI holds only the coreutils the script needs, so a PATH built
+# from it can omit chezmoi / jq deterministically.
+MINI="$TMP/mini"
+WITHJQ="$TMP/withjq"
+mkdir -p "$MINI" "$WITHJQ"
+for t in bash sh dirname basename sed head tail hostname date mkdir awk wc tr \
+  uname grep realpath readlink sort uniq cat mktemp mv rm cp cut env tput \
+  stty ls find diff touch chmod; do
+  p="$(command -v "$t" 2>/dev/null || true)"
+  [[ -n "$p" ]] && ln -sf "$p" "$MINI/$t"
+done
+ln -sf "$(command -v jq)" "$WITHJQ/jq"
+PATH_FULL="$TMP/bin:$WITHJQ:$MINI"
+PATH_NO_CHEZMOI="$WITHJQ:$MINI"
+PATH_NO_JQ="$TMP/bin:$MINI"
+export PATH="$PATH_FULL"
+
+# chezmoi shim: `status` replays $FAKE_CHEZMOI_STATUS when set.
+cat >"$TMP/bin/chezmoi" <<'SHIM'
+#!/usr/bin/env bash
+case "${1:-}" in
+  status) [[ -n "${FAKE_CHEZMOI_STATUS:-}" ]] && cat "$FAKE_CHEZMOI_STATUS" ;;
+  --version | version) echo "chezmoi version 2.47.1" ;;
+  *) : ;;
+esac
+exit 0
+SHIM
+chmod +x "$TMP/bin/chezmoi"
+
+# curl spy: records argv so the event-forwarding branch is observable.
+CURL_LOG="$TMP/curl.log"
+cat >"$TMP/bin/curl" <<'SHIM'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"${CURL_SPY_LOG:?}"
+exit 0
+SHIM
+chmod +x "$TMP/bin/curl"
+export CURL_SPY_LOG="$CURL_LOG"
+
+write_data() {
+  cat >"$DATA"
+}
+
+# assert_not_contains <needle> <haystack> [msg] — string-level negative.
+assert_not_contains() {
+  local needle="$1" actual="$2" msg="${3:-string should not contain substring}"
+  if [[ "$actual" != *"$needle"* ]]; then
+    ((TESTS_PASSED++)) || true
+    printf '%b\n' "  ${GREEN}✓${NC} $CURRENT_TEST: $msg"
+  else
+    ((TESTS_FAILED++)) || true
+    printf '%b\n' "  ${RED}✗${NC} $CURRENT_TEST: $msg"
+    printf '%b\n' "    Should not contain: '$needle'"
+  fi
+}
+
+fleet() {
+  bash "$FLEET" fleet "$@"
+}
+
+# ── status ──────────────────────────────────────────────────────────
+write_data <<'TOML'
+node_id = "node-a"
+namespace = "team"
+TOML
+
+test_start "fleet_status_json_reports_configured_identity"
+out="$(fleet status --json 2>&1)"
+rc=$?
+assert_equals 0 "$rc" "status --json exits 0"
+assert_contains '"node_id":"node-a"' "$out" "json carries node_id from data file"
+assert_contains '"namespace":"team"' "$out" "json carries namespace from data file"
+assert_contains '"drift":"clean"' "$out" "no chezmoi output means clean"
+
+test_start "fleet_status_short_flag_is_json"
+out="$(fleet status -j 2>&1)"
+assert_contains '{"node_id"' "$out" "-j selects json mode"
+
+test_start "fleet_status_human_reports_drift_and_last_apply"
+printf ' M .zshrc\n' >"$TMP/drift.txt"
+mkdir -p "$XDG_STATE_HOME/dotfiles"
+printf '[2026-01-02T03:04:05Z] apply completed\n' >"$XDG_STATE_HOME/dotfiles/dot.log"
+out="$(FAKE_CHEZMOI_STATUS="$TMP/drift.txt" fleet status 2>&1)"
+rc=$?
+assert_equals 0 "$rc" "human status exits 0"
+assert_contains "drifted" "$out" "chezmoi status output flips drift to drifted"
+assert_contains "Last Apply" "$out" "state log timestamp is surfaced"
+assert_contains "2026-01-02T03:04:05Z" "$out" "timestamp parsed from the log line"
+assert_file_exists "$EVENTS" "status emits a fleet event"
+assert_file_contains "$EVENTS" '"event":"status"' "event records the subcommand"
+assert_file_contains "$EVENTS" '"drift":"drifted"' "event carries the drift kv"
+
+test_start "fleet_status_human_clean_without_state_log"
+rm -f "$XDG_STATE_HOME/dotfiles/dot.log"
+out="$(fleet status 2>&1)"
+assert_contains "clean" "$out" "clean drift line rendered"
+assert_not_contains "Last Apply" "$out" "no Last Apply line without a state log"
+
+test_start "fleet_status_falls_back_to_hostname_and_default_namespace"
+write_data <<'TOML'
+profile = "laptop"
+TOML
+out="$(fleet status --json 2>&1)"
+assert_contains "\"node_id\":\"$(hostname -s)\"" "$out" "node_id falls back to hostname -s"
+assert_contains '"namespace":"default"' "$out" "namespace falls back to default"
+
+test_start "fleet_status_forwards_event_to_https_endpoint"
+write_data <<'TOML'
+node_id = "node-b"
+endpoint = "https://fleet.example.invalid/hook"
+TOML
+: >"$CURL_LOG"
+fleet status >/dev/null 2>&1
+assert_file_contains "$CURL_LOG" "https://fleet.example.invalid/hook" "curl POSTs to the configured endpoint"
+assert_file_contains "$CURL_LOG" '"node_id":"node-b"' "payload is sent as the request body"
+
+test_start "fleet_status_ignores_non_https_endpoint"
+write_data <<'TOML'
+endpoint = "http://plain.example.invalid/hook"
+TOML
+: >"$CURL_LOG"
+fleet status >/dev/null 2>&1
+assert_equals "" "$(cat "$CURL_LOG")" "plain-http endpoint is never called"
+
+test_start "fleet_status_survives_unwritable_state_dir"
+touch "$TMP/not-a-dir-file"
+out="$(XDG_STATE_HOME="$TMP/not-a-dir-file" fleet status --json 2>&1)"
+rc=$?
+assert_equals 0 "$rc" "mkdir failure for the state dir is non-fatal"
+assert_contains '{"node_id"' "$out" "status still renders"
+
+# ── _fleet_enabled (no CLI surface; sourced in a subshell) ──────────
+test_start "fleet_enabled_reads_enabled_flag"
+write_data <<'TOML'
+enabled = true
+TOML
+out="$(
+  cd "$TMP" && set +e
+  source "$FLEET" fleet status --json >/dev/null 2>&1
+  if _fleet_enabled; then echo enabled; else echo disabled; fi
+)"
+assert_equals "enabled" "$out" "enabled = true is detected"
+write_data <<'TOML'
+enabled = false
+TOML
+out="$(
+  cd "$TMP" && set +e
+  source "$FLEET" fleet status --json >/dev/null 2>&1
+  if _fleet_enabled; then echo enabled; else echo disabled; fi
+)"
+assert_equals "disabled" "$out" "anything else is disabled"
+
+# ── drift check ─────────────────────────────────────────────────────
+write_data <<'TOML'
+node_id = "node-a"
+TOML
+rm -rf "$STATE_DIR"
+
+test_start "fleet_drift_check_clean"
+out="$(fleet drift check 2>&1)"
+rc=$?
+assert_equals 0 "$rc" "clean drift exits 0"
+assert_contains "No drift detected" "$out" "clean message"
+assert_file_contains "$HISTORY" '"status":"clean"' "clean entry appended to history"
+assert_file_contains "$EVENTS" '"event":"drift_check"' "drift_check event emitted"
+
+test_start "fleet_drift_check_reports_changed_files"
+printf 'MM .zshrc\n M .bashrc\nA  .vimrc\nD  .gone\n' >"$TMP/drift4.txt"
+out="$(FAKE_CHEZMOI_STATUS="$TMP/drift4.txt" fleet drift check 2>&1)"
+rc=$?
+assert_equals 0 "$rc" "drifted check still exits 0"
+assert_contains "Configuration drift detected" "$out" "drift banner"
+assert_contains ".zshrc" "$out" "MM file listed"
+assert_contains ".gone" "$out" "other change types listed via info"
+assert_file_contains "$HISTORY" '"status":"drifted"' "drifted entry appended"
+assert_file_contains "$HISTORY" '.vimrc' "file names captured in history"
+assert_file_contains "$EVENTS" '"count":"4"' "event carries the drift count"
+
+test_start "fleet_drift_default_subcommand_is_check"
+out="$(fleet drift 2>&1)"
+assert_contains "Fleet Drift Report" "$out" "bare drift runs check"
+out="$(fleet drift --verbose 2>&1)"
+assert_contains "Fleet Drift Report" "$out" "flag-only argv runs check"
+
+test_start "fleet_drift_check_without_chezmoi_fails"
+out="$(PATH="$PATH_NO_CHEZMOI" fleet drift check 2>&1)"
+rc=$?
+assert_equals 1 "$rc" "missing chezmoi exits 1"
+assert_contains "not installed" "$out" "explains what is missing"
+
+# ── drift history ───────────────────────────────────────────────────
+test_start "fleet_drift_history_empty"
+rm -f "$HISTORY"
+out="$(fleet drift history 2>&1)"
+rc=$?
+assert_equals 0 "$rc" "empty history exits 0"
+assert_contains "No drift history recorded yet" "$out" "empty-history message"
+
+test_start "fleet_drift_history_renders_entries"
+mkdir -p "$STATE_DIR"
+cat >"$HISTORY" <<'JSONL'
+{"time":"2026-01-01T00:00:00Z","status":"clean","files":[]}
+{"time":"2026-01-02T00:00:00Z","status":"drifted","files":[".zshrc",".bashrc"]}
+not json at all
+JSONL
+out="$(fleet drift history 2>&1)"
+rc=$?
+assert_equals 0 "$rc" "history exits 0"
+assert_contains "2026-01-01T00:00:00Z" "$out" "clean entry time shown"
+assert_contains "drifted (2 files)" "$out" "drifted entry shows file count"
+assert_contains "?" "$out" "unparseable line falls back to ? instead of aborting"
+
+test_start "fleet_drift_history_honours_count"
+out="$(fleet drift history 1 2>&1)"
+assert_not_contains "2026-01-01T00:00:00Z" "$out" "only the last entry is shown"
+
+# ── drift predict ───────────────────────────────────────────────────
+test_start "fleet_drift_predict_without_history"
+rm -f "$HISTORY"
+out="$(fleet drift predict 2>&1)"
+rc=$?
+assert_equals 0 "$rc" "predict without history exits 0"
+assert_contains "Not enough history" "$out" "explains the missing history"
+
+test_start "fleet_drift_predict_flags_frequent_files"
+mkdir -p "$STATE_DIR"
+: >"$HISTORY"
+for _ in 1 2 3 4 5 6; do
+  echo '{"time":"t","status":"drifted","files":[".zshrc"]}' >>"$HISTORY"
+done
+echo '{"time":"t","status":"drifted","files":[".rare"]}' >>"$HISTORY"
+out="$(fleet drift predict 2>&1)"
+rc=$?
+assert_equals 0 "$rc" "predict exits 0"
+assert_contains "Likely to drift" "$out" "frequent file flagged"
+assert_contains ".zshrc (drifted 6 times recently)" "$out" "count reported"
+assert_not_contains ".rare (drifted" "$out" "below-threshold file not flagged"
+assert_contains "7 checks recorded" "$out" "total checks reported"
+
+test_start "fleet_drift_unknown_subcommand"
+out="$(fleet drift bogus 2>&1)"
+rc=$?
+assert_equals 1 "$rc" "unknown drift subcommand exits 1"
+assert_contains "Usage: dot fleet drift" "$out" "usage printed"
+
+# ── events ──────────────────────────────────────────────────────────
+test_start "fleet_events_without_log"
+rm -f "$EVENTS"
+out="$(fleet events 2>&1)"
+rc=$?
+assert_equals 0 "$rc" "no events exits 0"
+assert_contains "No fleet events recorded yet" "$out" "empty message"
+assert_contains "events.jsonl" "$out" "points at the events file"
+
+mkdir -p "$STATE_DIR"
+cat >"$EVENTS" <<'JSONL'
+{"time":"2026-01-01T00:00:00Z","event":"status","status":"ok","node_id":"n1","namespace":"default","trace_id":"t"}
+{"time":"2026-01-02T00:00:00Z","event":"drift_check","status":"clean","node_id":"n1","namespace":"default","trace_id":"t"}
+{"time":"2026-01-03T00:00:00Z","event":"apply","status":"fail 7","node_id":"n2","namespace":"default","trace_id":"t"}
+JSONL
+
+test_start "fleet_events_with_jq"
+out="$(fleet events 2>&1)"
+rc=$?
+assert_equals 0 "$rc" "events exits 0"
+assert_contains "Fleet Events (last 20)" "$out" "default count in header"
+assert_contains "drift_check" "$out" "clean event rendered"
+assert_contains "apply" "$out" "failed event rendered"
+assert_contains "(n2)" "$out" "node id shown per event"
+
+test_start "fleet_events_count_argument"
+out="$(fleet events 1 2>&1)"
+assert_contains "Fleet Events (last 1)" "$out" "count reflected in header"
+assert_not_contains "drift_check" "$out" "older events trimmed by count"
+
+test_start "fleet_events_without_jq_prints_raw"
+out="$(PATH="$PATH_NO_JQ" fleet events 2 2>&1)"
+rc=$?
+assert_equals 0 "$rc" "raw fallback exits 0"
+assert_contains '{"time":"2026-01-03T00:00:00Z"' "$out" "raw jsonl lines printed"
+
+echo "RESULTS:$TESTS_RUN:$TESTS_PASSED:$TESTS_FAILED"

--- a/tests/unit/functions/test_case_functions_branches.sh
+++ b/tests/unit/functions/test_case_functions_branches.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2015-2026 Sebastien Rousseau
+# shellcheck disable=SC1090,SC1091,SC2034,SC2016
+# Behavioural coverage for the rename helpers kebabcase / titlecase /
+# uppercase: the rename branch, the already-converted skip branch and
+# the mv-failure branch (driven by a PATH-shadowed `mv` that refuses).
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+source "$SCRIPT_DIR/../../framework/assertions.sh"
+source "$SCRIPT_DIR/../../framework/coverage_helpers.sh"
+
+# Keep bash xtrace flowing to the coverage runner's trace stream even
+# when a probe below captures 2>&1.
+exec 21>&2
+export BASH_XTRACEFD=21
+
+FUNCS_DIR="$REPO_ROOT/defaults/.chezmoitemplates/functions/text"
+
+trap cov_teardown_sandbox EXIT
+cov_setup_sandbox
+
+fail_bin="$DOTFILES_COV_TMPDIR/failing-mv"
+mkdir -p "$fail_bin"
+cat >"$fail_bin/mv" <<'EOF'
+#!/usr/bin/env bash
+echo "mv-shim refusing: $*" >&2
+exit 1
+EOF
+chmod +x "$fail_bin/mv"
+
+# run_fn <function-file> <fn> <args...> — child bash, cwd = sandbox.
+run_fn() {
+  local file="$1" fn="$2"
+  shift 2
+  bash -c 'source "$1"; shift; "$@"' _ "$file" "$fn" "$@"
+}
+
+work="$DOTFILES_COV_TMPDIR/work"
+mkdir -p "$work"
+
+# ── kebabcase ────────────────────────────────────────────────────
+test_start "kebabcase_renames_mixed_name"
+touch "$work/My File.txt"
+out="$(run_fn "$FUNCS_DIR/kebabcase.sh" kebabcase "$work/My File.txt" 2>&1)"
+assert_equals 0 "$?" "rename exits 0"
+assert_contains "Renamed '$work/My File.txt' to '$work/my-file.txt'" "$out" "reports the rename"
+assert_file_exists "$work/my-file.txt" "kebab-case file created"
+assert_file_not_exists "$work/My File.txt" "original name gone"
+
+test_start "kebabcase_skips_already_kebab"
+out="$(run_fn "$FUNCS_DIR/kebabcase.sh" kebabcase "$work/my-file.txt" 2>&1)"
+assert_contains "already in kebab-case" "$out" "skip message printed"
+
+test_start "kebabcase_reports_mv_failure"
+touch "$work/Kebab Fail.txt"
+out="$(PATH="$fail_bin:$PATH" run_fn "$FUNCS_DIR/kebabcase.sh" kebabcase "$work/Kebab Fail.txt" 2>&1)"
+assert_contains "[ERROR] Failed to rename '$work/Kebab Fail.txt'" "$out" "mv failure surfaced"
+assert_file_exists "$work/Kebab Fail.txt" "file untouched when mv fails"
+
+test_start "kebabcase_missing_path_and_no_args"
+out="$(run_fn "$FUNCS_DIR/kebabcase.sh" kebabcase "$work/nope" 2>&1)"
+assert_contains "does not exist" "$out" "missing path reported"
+out="$(run_fn "$FUNCS_DIR/kebabcase.sh" kebabcase 2>&1)"
+assert_equals 1 "$?" "no-arg exits 1"
+
+# ── titlecase ────────────────────────────────────────────────────
+test_start "titlecase_renames_upper_name"
+touch "$work/MYFILE.TXT"
+out="$(run_fn "$FUNCS_DIR/titlecase.sh" titlecase "$work/MYFILE.TXT" 2>&1)"
+assert_equals 0 "$?" "rename exits 0"
+assert_file_exists "$work/Myfile.txt" "title-case file created"
+assert_contains "Renamed" "$out" "reports the rename"
+
+test_start "titlecase_skips_already_titlecase"
+out="$(run_fn "$FUNCS_DIR/titlecase.sh" titlecase "$work/Myfile.txt" 2>&1)"
+assert_contains "already in title case" "$out" "skip message printed"
+
+test_start "titlecase_reports_mv_failure"
+touch "$work/TITLEFAIL.TXT"
+out="$(PATH="$fail_bin:$PATH" run_fn "$FUNCS_DIR/titlecase.sh" titlecase "$work/TITLEFAIL.TXT" 2>&1)"
+assert_contains "[ERROR] Failed to rename '$work/TITLEFAIL.TXT'" "$out" "mv failure surfaced"
+
+test_start "titlecase_missing_path_and_no_args"
+out="$(run_fn "$FUNCS_DIR/titlecase.sh" titlecase "$work/nope" 2>&1)"
+assert_contains "does not exist" "$out" "missing path reported"
+out="$(run_fn "$FUNCS_DIR/titlecase.sh" titlecase 2>&1)"
+assert_equals 1 "$?" "no-arg exits 1"
+
+# ── uppercase ────────────────────────────────────────────────────
+test_start "uppercase_renames_lower_name"
+touch "$work/lower.txt"
+out="$(run_fn "$FUNCS_DIR/uppercase.sh" uppercase "$work/lower.txt" 2>&1)"
+assert_equals 0 "$?" "rename exits 0"
+assert_file_exists "$work/LOWER.TXT" "uppercase file created"
+assert_contains "Renamed" "$out" "reports the rename"
+
+test_start "uppercase_skips_already_upper"
+out="$(run_fn "$FUNCS_DIR/uppercase.sh" uppercase "$work/LOWER.TXT" 2>&1)"
+assert_contains "already in uppercase" "$out" "skip message printed"
+
+test_start "uppercase_reports_mv_failure"
+touch "$work/upperfail.txt"
+out="$(PATH="$fail_bin:$PATH" run_fn "$FUNCS_DIR/uppercase.sh" uppercase "$work/upperfail.txt" 2>&1)"
+assert_contains "[ERROR] Failed to rename '$work/upperfail.txt'" "$out" "mv failure surfaced"
+
+test_start "uppercase_missing_path_and_no_args"
+out="$(run_fn "$FUNCS_DIR/uppercase.sh" uppercase "$work/nope" 2>&1)"
+assert_contains "does not exist" "$out" "missing path reported"
+out="$(run_fn "$FUNCS_DIR/uppercase.sh" uppercase 2>&1)"
+assert_equals 1 "$?" "no-arg exits 1"
+
+echo "RESULTS:$TESTS_RUN:$TESTS_PASSED:$TESTS_FAILED"

--- a/tests/unit/functions/test_extract_branches.sh
+++ b/tests/unit/functions/test_extract_branches.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2015-2026 Sebastien Rousseau
+# shellcheck disable=SC1090,SC1091,SC2034,SC2016
+# Behavioural coverage for functions/files/extract.sh: every archive
+# suffix dispatches to its extractor. Real tar/gzip/bzip2 archives are
+# built inside the sandbox; extractors that are not guaranteed on a CI
+# host (unzip, unrar, uncompress, 7z) are PATH-shadowed shims.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+source "$SCRIPT_DIR/../../framework/assertions.sh"
+source "$SCRIPT_DIR/../../framework/coverage_helpers.sh"
+
+# Keep bash xtrace flowing to the coverage runner's trace stream even
+# when a probe below captures 2>&1.
+exec 21>&2
+export BASH_XTRACEFD=21
+
+FUNC_FILE="$REPO_ROOT/defaults/.chezmoitemplates/functions/files/extract.sh"
+
+trap cov_teardown_sandbox EXIT
+cov_setup_sandbox
+
+shim_dir="$DOTFILES_COV_TMPDIR/extract-shims"
+mkdir -p "$shim_dir"
+for tool in unzip unrar uncompress 7z; do
+  cat >"$shim_dir/$tool" <<EOF
+#!/usr/bin/env bash
+echo "shim-$tool \$*"
+EOF
+  chmod +x "$shim_dir/$tool"
+done
+export PATH="$shim_dir:$PATH"
+
+# run_extract <workdir> <archive> — source the function file in a child
+# bash inside <workdir> and call extract on <archive>.
+run_extract() {
+  (cd "$1" && bash -c 'source "$1"; shift; extract "$@"' _ "$FUNC_FILE" "$2")
+}
+
+work="$DOTFILES_COV_TMPDIR/archives"
+mkdir -p "$work"
+echo "payload" >"$work/hello.txt"
+(
+  cd "$work" || exit 1
+  tar cjf a.tar.bz2 hello.txt
+  tar czf a.tar.gz hello.txt
+  tar cjf a.tbz2 hello.txt
+  tar czf a.tgz hello.txt
+  tar cf a.tar hello.txt
+  cp hello.txt b.txt && bzip2 b.txt
+  cp hello.txt c.txt && gzip c.txt
+  : >a.zip
+  : >a.rar
+  : >a.Z
+  : >a.7z
+  : >a.unknown
+)
+
+for archive in a.tar.bz2 a.tar.gz a.tbz2 a.tgz a.tar; do
+  test_start "extract_${archive//./_}_via_tar"
+  case_dir="$DOTFILES_COV_TMPDIR/case-$archive"
+  mkdir -p "$case_dir"
+  cp "$work/$archive" "$case_dir/"
+  out="$(run_extract "$case_dir" "$archive" 2>&1)"
+  rc=$?
+  assert_equals 0 "$rc" "extract $archive exits 0"
+  assert_contains "[INFO] Extracting '$archive'" "$out" "reports the archive"
+  assert_file_exists "$case_dir/hello.txt" "member extracted from $archive"
+done
+
+test_start "extract_bz2_via_bunzip2"
+case_dir="$DOTFILES_COV_TMPDIR/case-bz2"
+mkdir -p "$case_dir"
+cp "$work/b.txt.bz2" "$case_dir/"
+out="$(run_extract "$case_dir" b.txt.bz2 2>&1)"
+assert_equals 0 "$?" "bunzip2 path exits 0"
+assert_file_exists "$case_dir/b.txt" "bz2 payload restored"
+
+test_start "extract_gz_via_gunzip"
+case_dir="$DOTFILES_COV_TMPDIR/case-gz"
+mkdir -p "$case_dir"
+cp "$work/c.txt.gz" "$case_dir/"
+out="$(run_extract "$case_dir" c.txt.gz 2>&1)"
+assert_equals 0 "$?" "gunzip path exits 0"
+assert_file_exists "$case_dir/c.txt" "gz payload restored"
+
+for pair in "a.zip:unzip" "a.rar:unrar" "a.Z:uncompress" "a.7z:7z"; do
+  archive="${pair%%:*}"
+  tool="${pair##*:}"
+  test_start "extract_${archive//./_}_dispatches_to_${tool}"
+  out="$(run_extract "$work" "$archive" 2>&1)"
+  rc=$?
+  assert_equals 0 "$rc" "$tool shim path exits 0"
+  assert_contains "shim-$tool" "$out" "$archive is handed to $tool"
+done
+
+test_start "extract_unknown_suffix_rejected"
+out="$(run_extract "$work" a.unknown 2>&1)"
+rc=$?
+assert_equals 1 "$rc" "unknown suffix exits 1"
+assert_contains "cannot be extracted" "$out" "explains the rejection"
+
+test_start "extract_missing_file_rejected"
+out="$(run_extract "$work" nope.tar.gz 2>&1)"
+rc=$?
+assert_equals 1 "$rc" "missing file exits 1"
+assert_contains "is not a valid file" "$out" "explains the rejection"
+
+test_start "extract_requires_exactly_one_argument"
+out="$(bash -c 'source "$1"; extract a b' _ "$FUNC_FILE" 2>&1)"
+rc=$?
+assert_equals 1 "$rc" "two arguments exit 1"
+assert_contains "Please provide one argument" "$out" "usage error printed"
+
+test_start "extract_help"
+out="$(bash -c 'source "$1"; extract --help' _ "$FUNC_FILE" 2>&1)"
+rc=$?
+assert_equals 0 "$rc" "--help exits 0"
+assert_contains "extract: Archive Extractor" "$out" "help banner printed"
+
+test_start "extract_guard_keeps_existing_definition"
+out="$(bash -c 'extract() { echo "pre-existing $*"; }; source "$1"; extract x' _ "$FUNC_FILE" 2>&1)"
+assert_contains "pre-existing x" "$out" "declare -f guard skips redefinition"
+
+echo "RESULTS:$TESTS_RUN:$TESTS_PASSED:$TESTS_FAILED"

--- a/tests/unit/functions/test_func_curl_api_behavior.sh
+++ b/tests/unit/functions/test_func_curl_api_behavior.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2015-2026 Sebastien Rousseau
+# shellcheck disable=SC1090,SC1091,SC2034,SC2016
+#
+# Behaviour tests for the two HTTP function templates:
+#
+#   curltime   — timing view: help, the missing-URL guard and the curl
+#                invocation itself (format string, silent mode, output
+#                discarded).
+#   apilatency — latency sampler: help/version, argument validation
+#                (missing URL, bad scheme, non-numeric count and
+#                interval), the sampling loop and the main dispatcher.
+#
+# `curl` and `sleep` are PATH shims, so no request ever leaves the
+# machine and the loop finishes immediately.
+#
+# AUTO-GENERATED: false (hand-written)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+source "$SCRIPT_DIR/../../framework/assertions.sh"
+source "$SCRIPT_DIR/../../framework/coverage_helpers.sh"
+
+# Hand children a copy of the real stderr so their xtrace still reaches
+# the coverage runner even though the probes capture output with 2>&1.
+exec 21>&2
+export BASH_XTRACEFD=21
+
+FUNCS="$REPO_ROOT/defaults/.chezmoitemplates/functions"
+CURLTIME="$FUNCS/curl/curltime.sh"
+APILATENCY="$FUNCS/api/apilatency.sh"
+BASH_BIN="$(command -v bash)"
+
+trap cov_teardown_sandbox EXIT
+cov_setup_sandbox
+
+LOG="$DOTFILES_COV_TMPDIR/http.log"
+: >"$LOG"
+
+SHIMS="$DOTFILES_COV_TMPDIR/http-shims"
+mkdir -p "$SHIMS"
+cat >"$SHIMS/curl" <<EOF
+#!/usr/bin/env bash
+printf 'curl %s\n' "\$*" >>"$LOG"
+# The -w format is what curltime renders; apilatency asks for
+# %{time_total} alone.
+echo "0.123"
+EOF
+cat >"$SHIMS/sleep" <<EOF
+#!/usr/bin/env bash
+printf 'sleep %s\n' "\$*" >>"$LOG"
+EOF
+chmod +x "$SHIMS/curl" "$SHIMS/sleep"
+
+_call() { # <function-file> <fn> [args…]
+  PATH="$SHIMS:$PATH" "$BASH_BIN" -c 'source "$1"; shift; "$@"' _ "$@" 2>&1
+}
+
+# ── curltime ─────────────────────────────────────────────────────────
+test_start "curltime_help"
+_out="$(_call "$CURLTIME" curltime --help)"
+_rc=$?
+assert_equals 0 "$_rc" "--help exits 0"
+assert_contains "curltime: Curl Timing Viewer" "$_out" "help banner printed"
+assert_contains "curltime [url]" "$_out" "usage line printed"
+
+test_start "curltime_requires_a_url"
+_out="$(_call "$CURLTIME" curltime)"
+_rc=$?
+assert_equals 1 "$_rc" "no URL exits 1"
+assert_contains "No URL provided" "$_out" "error explains what is missing"
+
+test_start "curltime_asks_curl_for_the_timing_breakdown"
+: >"$LOG"
+_out="$(_call "$CURLTIME" curltime https://example.test)"
+_rc=$?
+assert_equals 0 "$_rc" "a URL exits 0"
+_args="$(cat "$LOG")"
+assert_contains "https://example.test" "$_args" "the URL is passed through"
+assert_contains "time_namelookup" "$_args" "DNS timing requested"
+assert_contains "time_total" "$_args" "total timing requested"
+assert_contains "-o /dev/null" "$_args" "response body discarded"
+assert_contains "--connect-timeout 10" "$_args" "connect timeout applied"
+
+# ── apilatency ───────────────────────────────────────────────────────
+test_start "apilatency_help_and_version"
+_out="$(_call "$APILATENCY" apilatency --help)"
+_rc=$?
+assert_equals 0 "$_rc" "--help exits 0"
+assert_contains "Usage: apilatency URL [COUNT] [INTERVAL]" "$_out" "usage printed"
+_out="$(_call "$APILATENCY" apilatency -v)"
+assert_equals 0 "$?" "-v exits 0"
+assert_contains "apilatency version" "$_out" "version reported"
+
+test_start "apilatency_requires_a_url"
+_out="$(_call "$APILATENCY" apilatency)"
+_rc=$?
+assert_equals 1 "$_rc" "no argument exits 1"
+assert_contains "Missing required URL argument" "$_out" "error explains what is missing"
+assert_contains "Usage: apilatency" "$_out" "usage is printed alongside the error"
+
+test_start "apilatency_validates_url_count_and_interval"
+_out="$(_call "$APILATENCY" apilatency ftp://example.test)"
+assert_equals 1 "$?" "a non-http scheme exits 1"
+assert_contains "Invalid URL format" "$_out" "scheme requirement explained"
+
+_out="$(_call "$APILATENCY" apilatency https://example.test three)"
+assert_equals 1 "$?" "a non-numeric count exits 1"
+assert_contains "COUNT must be a positive integer" "$_out" "count requirement explained"
+
+_out="$(_call "$APILATENCY" apilatency https://example.test 2 soon)"
+assert_equals 1 "$?" "a non-numeric interval exits 1"
+assert_contains "INTERVAL must be a positive number" "$_out" "interval requirement explained"
+
+test_start "apilatency_samples_the_endpoint_count_times"
+: >"$LOG"
+_out="$(_call "$APILATENCY" apilatency https://example.test 3 0)"
+_rc=$?
+assert_equals 0 "$_rc" "a sampling run exits 0"
+assert_contains "Monitoring API latency for https://example.test" "$_out" "target echoed"
+assert_contains "Total Requests: 3" "$_out" "request count echoed"
+assert_contains "Time,Response_Time" "$_out" "CSV header printed"
+assert_contains "0.123" "$_out" "each sample carries curl's time_total"
+assert_contains "Latency monitoring completed." "$_out" "completion line printed"
+assert_equals 3 "$(grep -c '^curl ' "$LOG")" "curl called once per request"
+assert_equals 3 "$(grep -c '^sleep 0' "$LOG")" "the interval is honoured between requests"
+
+test_start "apilatency_defaults_the_interval_and_accepts_fractions"
+: >"$LOG"
+_out="$(_call "$APILATENCY" apilatency https://example.test 1 0.5)"
+assert_equals 0 "$?" "a fractional interval is accepted"
+assert_file_contains "$LOG" "sleep 0.5" "the fractional interval reaches sleep"
+
+echo "RESULTS:$TESTS_RUN:$TESTS_PASSED:$TESTS_FAILED"

--- a/tests/unit/functions/test_keygen_behavior.sh
+++ b/tests/unit/functions/test_keygen_behavior.sh
@@ -1,0 +1,250 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2015-2026 Sebastien Rousseau
+# shellcheck disable=SC1090,SC1091,SC2034
+#
+# Behaviour tests for defaults/.chezmoitemplates/functions/security/keygen.sh.
+# Every branch is driven through arguments, stdin (interactive mode)
+# and a tightly controlled PATH: `ssh-keygen` and `ssh-add` are shims
+# that write fake key files, `uname` is shimmed for the Linux arm,
+# and the clipboard tools (cb / pbcopy / xclip / wl-copy / clip.exe)
+# are shims that record what they received. No real key material,
+# agent or clipboard is touched.
+#
+# AUTO-GENERATED: false (hand-written)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+source "$SCRIPT_DIR/../../framework/assertions.sh"
+source "$SCRIPT_DIR/../../framework/coverage_helpers.sh"
+
+# Route child xtrace to the runner's trace stream even when a probe
+# captures 2>&1 (fd 19: fd 9 is taken by lock handling elsewhere).
+exec 21>&2
+export BASH_XTRACEFD=21
+
+FUNC_FILE="$REPO_ROOT/defaults/.chezmoitemplates/functions/security/keygen.sh"
+BASH_BIN="$(command -v bash)"
+
+trap cov_teardown_sandbox EXIT
+cov_setup_sandbox
+
+# ── Controlled PATH ───────────────────────────────────────────────────
+# Only what keygen itself needs. The clipboard probes in
+# copy_to_clipboard must NOT see the host's pbcopy/xclip, so the
+# clipboard shim of each case lives in its own directory.
+_kbin="$DOTFILES_COV_TMPDIR/kbin"
+mkdir -p "$_kbin"
+for _t in bash mkdir chmod uname dirname cat; do
+  _p="$(command -v "$_t" 2>/dev/null || true)"
+  [[ -n "$_p" ]] && ln -sf "$_p" "$_kbin/$_t"
+done
+
+cat >"$_kbin/ssh-keygen" <<'SHIM'
+#!/usr/bin/env bash
+# Fake ssh-keygen: `-l -f pub` prints a fingerprint; otherwise writes a
+# private/public pair at the -f path and records the argv.
+printf 'ssh-keygen %s\n' "$*" >>"${KEYGEN_SHIM_LOG:?}"
+if [[ "$1" == "-l" ]]; then
+  echo "256 SHA256:shim-fingerprint comment (SHIM)"
+  exit 0
+fi
+path=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -f) path="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+echo "shim-private-key" >"$path"
+echo "ssh-shim AAAA shim@example.com" >"$path.pub"
+SHIM
+cat >"$_kbin/ssh-add" <<'SHIM'
+#!/usr/bin/env bash
+printf 'ssh-add %s\n' "$*" >>"${KEYGEN_SHIM_LOG:?}"
+exit "${SSH_ADD_RC:-0}"
+SHIM
+chmod +x "$_kbin/ssh-keygen" "$_kbin/ssh-add"
+export KEYGEN_SHIM_LOG="$DOTFILES_COV_TMPDIR/keygen-shim.log"
+
+# Clipboard shims: each records stdin into $CLIP_OUT.
+_clip_dir() { # <tool> → dir holding only that clipboard shim
+  local d="$DOTFILES_COV_TMPDIR/clip-$1"
+  mkdir -p "$d"
+  printf '#!/usr/bin/env bash\ncat >"${CLIP_OUT:?}"\n' >"$d/$1"
+  chmod +x "$d/$1"
+  printf '%s\n' "$d"
+}
+export CLIP_OUT="$DOTFILES_COV_TMPDIR/clip.txt"
+
+# Linux arm: `uname -s` must say Linux.
+_linux="$DOTFILES_COV_TMPDIR/linux"
+mkdir -p "$_linux"
+printf '#!/usr/bin/env bash\necho Linux\n' >"$_linux/uname"
+chmod +x "$_linux/uname"
+
+# Run keygen from a fresh bash with the function file sourced. PATH is
+# set INSIDE the child so the sourced prelude and keygen both see it.
+_keygen() { # <extra-path> [args...]  (stdin passes through)
+  local extra="$1"
+  shift
+  "$BASH_BIN" -c 'export PATH="$1"; source "$2"; shift 2; keygen "$@"' _ \
+    "${extra:+$extra:}$_kbin" "$FUNC_FILE" "$@" 2>&1
+}
+
+_fresh_home() { # <name>
+  export HOME="$DOTFILES_COV_TMPDIR/homes/$1"
+  mkdir -p "$HOME"
+}
+
+test_start "help_prints_usage"
+_out="$(_keygen "" --help)"
+_rc=$?
+assert_equals 0 "$_rc" "--help exits 0"
+assert_contains "SSH Key Generator (keygen)" "$_out" "help banner printed"
+
+test_start "single_argument_is_a_usage_error"
+_fresh_home usage
+_out="$(_keygen "" onlyname)"
+_rc=$?
+assert_equals 1 "$_rc" "one positional exits 1"
+assert_contains "Usage: keygen" "$_out" "usage error printed"
+
+test_start "ssh_dir_creation_failure_exits_1"
+_fresh_home sshfile
+: >"$HOME/.ssh" # a FILE named .ssh makes mkdir -p fail
+_out="$(_keygen "" k user@example.com)"
+_rc=$?
+assert_equals 1 "$_rc" "unwritable ~/.ssh exits 1"
+assert_contains "Failed to create ~/.ssh" "$_out" "mkdir failure reported"
+
+test_start "input_validation_rejects_bad_name_email_type_bits"
+_fresh_home validate
+_out="$(_keygen "" 'bad name!' user@example.com)"
+assert_equals 1 $? "bad name exits 1"
+assert_contains "Invalid name format" "$_out" "bad name reported"
+_out="$(_keygen "" goodname not-an-email)"
+assert_equals 1 $? "bad email exits 1"
+assert_contains "Invalid email format" "$_out" "bad email reported"
+_out="$(_keygen "" goodname user@example.com rsa abc)"
+assert_equals 1 $? "non-numeric rsa bits exits 1"
+assert_contains "RSA key length must be a number" "$_out" "non-numeric bits reported"
+_out="$(_keygen "" goodname user@example.com rsa 1024)"
+assert_equals 1 $? "short rsa bits exits 1"
+assert_contains "between 2048 and 8192" "$_out" "rsa range reported"
+_out="$(_keygen "" goodname user@example.com ecdsa 999)"
+assert_equals 1 $? "bad ecdsa bits exits 1"
+assert_contains "256, 384, or 521" "$_out" "ecdsa sizes reported"
+_out="$(_keygen "" goodname user@example.com dsa)"
+assert_equals 1 $? "unknown type exits 1"
+assert_contains "Invalid key type: dsa" "$_out" "unknown type reported"
+
+test_start "ed25519_key_generated_and_copied_via_pbcopy"
+_fresh_home ed
+: >"$KEYGEN_SHIM_LOG"
+: >"$CLIP_OUT"
+_out="$(_keygen "$(_clip_dir pbcopy)" mykey me@example.com)"
+_rc=$?
+assert_equals 0 "$_rc" "ed25519 generation exits 0"
+assert_file_exists "$HOME/.ssh/id_ed25519_mykey" "private key written"
+assert_file_exists "$HOME/.ssh/id_ed25519_mykey.pub" "public key written"
+assert_contains "ssh-keygen -t ed25519 -f $HOME/.ssh/id_ed25519_mykey -C me@example.com" "$(cat "$KEYGEN_SHIM_LOG")" "ssh-keygen invoked with ed25519"
+assert_contains "SSH key successfully generated" "$_out" "success message printed"
+assert_contains "SHA256:shim-fingerprint" "$_out" "fingerprint printed"
+assert_contains "copied to clipboard (macOS)" "$_out" "pbcopy branch reported"
+assert_contains "ssh-shim AAAA" "$(cat "$CLIP_OUT")" "public key reached the clipboard shim"
+assert_equals "700" "$(stat -f '%Lp' "$HOME/.ssh" 2>/dev/null || stat -c '%a' "$HOME/.ssh")" "the .ssh directory is mode 0700"
+assert_equals "600" "$(stat -f '%Lp' "$HOME/.ssh/id_ed25519_mykey" 2>/dev/null || stat -c '%a' "$HOME/.ssh/id_ed25519_mykey")" "private key is 0600"
+
+test_start "existing_key_is_not_regenerated"
+: >"$KEYGEN_SHIM_LOG"
+_out="$(_keygen "$(_clip_dir pbcopy)" mykey me@example.com)"
+_rc=$?
+assert_equals 0 "$_rc" "existing key exits 0"
+assert_contains "Key already exists" "$_out" "skip warning printed"
+assert_equals "" "$(cat "$KEYGEN_SHIM_LOG")" "ssh-keygen not invoked"
+
+test_start "rsa_key_on_linux_with_agent_down_warns_and_uses_xclip"
+_fresh_home rsa
+: >"$KEYGEN_SHIM_LOG"
+_out="$(SSH_ADD_RC=1 _keygen "$_linux:$(_clip_dir xclip)" rsakey me@example.com rsa 4096)"
+_rc=$?
+assert_equals 0 "$_rc" "rsa generation exits 0"
+assert_contains "ssh-keygen -t rsa -b 4096 -f $HOME/.ssh/id_rsa_rsakey" "$(cat "$KEYGEN_SHIM_LOG")" "ssh-keygen invoked with rsa bits"
+assert_contains "ssh-add $HOME/.ssh/id_rsa_rsakey" "$(cat "$KEYGEN_SHIM_LOG")" "plain ssh-add used on Linux"
+assert_contains "SSH agent not running. Start it and run 'ssh-add $HOME" "$_out" "agent warning printed"
+assert_contains "copied to clipboard (Linux)" "$_out" "xclip branch reported"
+
+test_start "ecdsa_defaults_to_256_bits_with_cb_clipboard"
+_fresh_home ecdsa
+: >"$KEYGEN_SHIM_LOG"
+_out="$(_keygen "$(_clip_dir cb)" eckey me@example.com ecdsa)"
+_rc=$?
+assert_equals 0 "$_rc" "ecdsa generation exits 0"
+assert_contains "ssh-keygen -t ecdsa -b 256 -f" "$(cat "$KEYGEN_SHIM_LOG")" "default ecdsa bits applied"
+assert_contains "Public key copied to clipboard." "$_out" "cb branch reported"
+
+test_start "macos_agent_down_warns_with_keychain_hint"
+_fresh_home agentmac
+_out="$(SSH_ADD_RC=1 _keygen "$(_clip_dir wl-copy)" mackey me@example.com)"
+_rc=$?
+assert_equals 0 "$_rc" "generation still exits 0"
+assert_contains "ssh-add --apple-use-keychain" "$_out" "keychain hint printed"
+assert_contains "copied to clipboard (Wayland)" "$_out" "wl-copy branch reported"
+
+test_start "clip_exe_and_no_clipboard_branches"
+_fresh_home clipexe
+_out="$(_keygen "$(_clip_dir clip.exe)" winkey me@example.com)"
+assert_equals 0 $? "clip.exe generation exits 0"
+assert_contains "copied to clipboard (Windows)" "$_out" "clip.exe branch reported"
+_fresh_home noclip
+_out="$(_keygen "" bare me@example.com)"
+assert_equals 0 $? "no-clipboard generation exits 0"
+assert_contains "Clipboard tool not available" "$_out" "missing clipboard warned"
+
+test_start "interactive_mode_reads_rsa_answers_from_stdin"
+_fresh_home irsa
+: >"$KEYGEN_SHIM_LOG"
+_out="$(printf 'ikey\nme@example.com\nrsa\n2048\n' | _keygen "")"
+_rc=$?
+assert_equals 0 "$_rc" "interactive rsa exits 0"
+assert_contains "Enter RSA key length" "$_out" "rsa length prompt shown"
+assert_contains "ssh-keygen -t rsa -b 2048 -f $HOME/.ssh/id_rsa_ikey" "$(cat "$KEYGEN_SHIM_LOG")" "stdin answers applied"
+
+test_start "interactive_mode_reads_ecdsa_and_default_type"
+_fresh_home iecdsa
+: >"$KEYGEN_SHIM_LOG"
+_out="$(printf 'ekey\nme@example.com\necdsa\n384\n' | _keygen "")"
+assert_equals 0 $? "interactive ecdsa exits 0"
+assert_contains "Enter ECDSA key length" "$_out" "ecdsa length prompt shown"
+assert_contains "ssh-keygen -t ecdsa -b 384 -f" "$(cat "$KEYGEN_SHIM_LOG")" "ecdsa bits applied"
+: >"$KEYGEN_SHIM_LOG"
+_out="$(printf 'dkey\nme@example.com\n\n' | _keygen "")"
+assert_equals 0 $? "interactive default type exits 0"
+assert_contains "ssh-keygen -t ed25519 -f $HOME/.ssh/id_ed25519_dkey" "$(cat "$KEYGEN_SHIM_LOG")" "empty type defaults to ed25519"
+
+test_start "interactive_mode_rejects_unknown_type"
+_fresh_home ibad
+_out="$(printf 'bkey\nme@example.com\nfoo\n' | _keygen "")"
+_rc=$?
+assert_equals 1 "$_rc" "interactive bad type exits 1"
+assert_contains "Invalid key type: foo" "$_out" "bad type reported"
+
+# Fallback loggers: source keygen through a symlink whose directory has
+# no ../utils/logging.sh so the inline log_* definitions are used.
+test_start "fallback_loggers_used_when_logging_sh_is_absent"
+_iso="$DOTFILES_COV_TMPDIR/iso/security"
+mkdir -p "$_iso"
+ln -s "$FUNC_FILE" "$_iso/keygen.sh"
+_fresh_home fallback
+_out="$("$BASH_BIN" -c 'export PATH="$1"; source "$2"; shift 2; keygen "$@"' _ \
+  "$_kbin" "$_iso/keygen.sh" fbkey me@example.com 2>&1)"
+assert_equals 0 $? "fallback-logger generation exits 0"
+assert_contains "[INFO] SSH key successfully generated!" "$_out" "fallback log_info format used"
+assert_contains "[WARNING] Clipboard tool not available" "$_out" "fallback log_warning format used"
+_out="$("$BASH_BIN" -c 'export PATH="$1"; source "$2"; shift 2; keygen "$@"' _ \
+  "$_kbin" "$_iso/keygen.sh" 'bad name' me@example.com 2>&1)"
+assert_equals 1 $? "fallback-logger validation exits 1"
+assert_contains "[ERROR] Invalid name format" "$_out" "fallback log_error format used"
+
+echo "RESULTS:$TESTS_RUN:$TESTS_PASSED:$TESTS_FAILED"

--- a/tests/unit/functions/test_keygen_behavior.sh
+++ b/tests/unit/functions/test_keygen_behavior.sh
@@ -29,6 +29,25 @@ BASH_BIN="$(command -v bash)"
 trap cov_teardown_sandbox EXIT
 cov_setup_sandbox
 
+# Permission bits, portably. GNU `stat -f` is "filesystem status" and
+# SUCCEEDS, so a `-f`-first probe never falls through to `-c` on Linux
+# and returns a block of filesystem info instead of a mode. BSD stat
+# rejects `-c` outright, so probing `-c` first is the safe order.
+_mode() { # <path>
+  stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1" 2>/dev/null
+}
+
+# The Linux arm must NOT suggest the macOS-only keychain flag.
+_refute_keychain() { # <output>
+  if [[ "$1" != *"--apple-use-keychain"* ]]; then
+    ((TESTS_PASSED++)) || true
+    printf '%b\n' "  ${GREEN}✓${NC} $CURRENT_TEST: no macOS keychain flag on Linux"
+  else
+    ((TESTS_FAILED++)) || true
+    printf '%b\n' "  ${RED}✗${NC} $CURRENT_TEST: keychain flag leaked into the Linux hint"
+  fi
+}
+
 # ── Controlled PATH ───────────────────────────────────────────────────
 # Only what keygen itself needs. The clipboard probes in
 # copy_to_clipboard must NOT see the host's pbcopy/xclip, so the
@@ -77,11 +96,17 @@ _clip_dir() { # <tool> → dir holding only that clipboard shim
 }
 export CLIP_OUT="$DOTFILES_COV_TMPDIR/clip.txt"
 
-# Linux arm: `uname -s` must say Linux.
+# Platform arms: keygen branches on `uname -s`, so each case pins it
+# rather than inheriting the host's (the agent-hint assertions below
+# differ between macOS and Linux).
 _linux="$DOTFILES_COV_TMPDIR/linux"
 mkdir -p "$_linux"
 printf '#!/usr/bin/env bash\necho Linux\n' >"$_linux/uname"
 chmod +x "$_linux/uname"
+_darwin="$DOTFILES_COV_TMPDIR/darwin"
+mkdir -p "$_darwin"
+printf '#!/usr/bin/env bash\necho Darwin\n' >"$_darwin/uname"
+chmod +x "$_darwin/uname"
 
 # Run keygen from a fresh bash with the function file sourced. PATH is
 # set INSIDE the child so the sourced prelude and keygen both see it.
@@ -153,8 +178,8 @@ assert_contains "SSH key successfully generated" "$_out" "success message printe
 assert_contains "SHA256:shim-fingerprint" "$_out" "fingerprint printed"
 assert_contains "copied to clipboard (macOS)" "$_out" "pbcopy branch reported"
 assert_contains "ssh-shim AAAA" "$(cat "$CLIP_OUT")" "public key reached the clipboard shim"
-assert_equals "700" "$(stat -f '%Lp' "$HOME/.ssh" 2>/dev/null || stat -c '%a' "$HOME/.ssh")" "the .ssh directory is mode 0700"
-assert_equals "600" "$(stat -f '%Lp' "$HOME/.ssh/id_ed25519_mykey" 2>/dev/null || stat -c '%a' "$HOME/.ssh/id_ed25519_mykey")" "private key is 0600"
+assert_equals "700" "$(_mode "$HOME/.ssh")" "the .ssh directory is mode 0700"
+assert_equals "600" "$(_mode "$HOME/.ssh/id_ed25519_mykey")" "private key is 0600"
 
 test_start "existing_key_is_not_regenerated"
 : >"$KEYGEN_SHIM_LOG"
@@ -186,11 +211,19 @@ assert_contains "Public key copied to clipboard." "$_out" "cb branch reported"
 
 test_start "macos_agent_down_warns_with_keychain_hint"
 _fresh_home agentmac
-_out="$(SSH_ADD_RC=1 _keygen "$(_clip_dir wl-copy)" mackey me@example.com)"
+_out="$(SSH_ADD_RC=1 _keygen "$_darwin:$(_clip_dir wl-copy)" mackey me@example.com)"
 _rc=$?
 assert_equals 0 "$_rc" "generation still exits 0"
 assert_contains "ssh-add --apple-use-keychain" "$_out" "keychain hint printed"
 assert_contains "copied to clipboard (Wayland)" "$_out" "wl-copy branch reported"
+
+test_start "linux_agent_down_warns_without_the_keychain_flag"
+_fresh_home agentlinux
+_out="$(SSH_ADD_RC=1 _keygen "$_linux:$(_clip_dir wl-copy)" linuxkey me@example.com)"
+_rc=$?
+assert_equals 0 "$_rc" "generation still exits 0"
+assert_contains "SSH agent not running" "$_out" "agent warning printed"
+_refute_keychain "$_out"
 
 test_start "clip_exe_and_no_clipboard_branches"
 _fresh_home clipexe

--- a/tests/unit/functions/test_lazy_loaders_branches.sh
+++ b/tests/unit/functions/test_lazy_loaders_branches.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2015-2026 Sebastien Rousseau
+# shellcheck disable=SC1090,SC1091,SC2034,SC2016
+# Behavioural coverage for functions/misc/lazy_loaders.sh.
+#
+# Each loader is only defined when its tool is installed, and the first
+# call must (a) drop the trigger aliases, (b) load the real tool and
+# (c) re-run the command that triggered it — exactly once. The
+# "exactly once" half is what the `unalias` fix restored: while the
+# aliases survived the first load, every later call went back through
+# the loader (and `lazy_rbenv` re-entered itself without bound because
+# `$(rbenv init -)` is alias-expanded at runtime).
+#
+# Fake nvm/sdkman installs and an rbenv shim live inside the sandbox
+# HOME; nothing here touches the host.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+source "$SCRIPT_DIR/../../framework/assertions.sh"
+source "$SCRIPT_DIR/../../framework/coverage_helpers.sh"
+
+# Hand children a copy of the real stderr so their bash xtrace still
+# reaches the coverage runner's trace file even though the probes
+# below capture the command's own output with 2>&1.
+exec 21>&2
+export BASH_XTRACEFD=21
+
+FUNC_FILE="$REPO_ROOT/defaults/.chezmoitemplates/functions/misc/lazy_loaders.sh"
+BASH_BIN="${BASH:-$(command -v bash)}"
+
+trap cov_teardown_sandbox EXIT
+cov_setup_sandbox
+
+# ── Fixtures: fake nvm / sdkman installs + an rbenv binary on PATH ──
+# The init files use the `function name {` form on purpose: the trigger
+# aliases are live while they are sourced, and bash alias-expands a
+# bare `name() {` header into a syntax error.
+mkdir -p "$HOME/.nvm" "$HOME/.sdkman/bin"
+counts="$DOTFILES_COV_TMPDIR/counts"
+mkdir -p "$counts"
+
+cat >"$HOME/.nvm/nvm.sh" <<EOF
+echo nvm >>"$counts/nvm.sourced"
+function nvm { echo "nvm-real \$*"; }
+function node { echo "node-real \$*"; }
+function npm { echo "npm-real \$*"; }
+EOF
+echo ': bash completion stub' >"$HOME/.nvm/bash_completion"
+
+cat >"$HOME/.sdkman/bin/sdkman-init.sh" <<EOF
+echo sdk >>"$counts/sdk.sourced"
+function sdk { echo "sdk-real \$*"; }
+function java { echo "java-real \$*"; }
+EOF
+
+cat >"$DOTFILES_COV_TMPDIR/bin/rbenv" <<EOF
+#!/usr/bin/env bash
+echo rbenv >>"$counts/rbenv.called"
+if [[ "\${1:-}" == "init" ]]; then
+  echo 'function rbenv { echo "rbenv-real \$*"; }; function ruby { echo "ruby-real \$*"; }'
+else
+  echo "rbenv-bin \$*"
+fi
+EOF
+chmod +x "$DOTFILES_COV_TMPDIR/bin/rbenv"
+
+# Driver: aliases only expand on lines parsed after the alias exists,
+# so every probe is its own line of a real script run by the same bash
+# the harness uses.
+driver="$DOTFILES_COV_TMPDIR/driver.sh"
+cat >"$driver" <<EOF
+shopt -s expand_aliases
+source "$FUNC_FILE"
+echo "--- aliases-before"
+alias nvm node npm yarn npx rbenv ruby gem bundle sdk java gradle mvn kotlin
+node --version
+node --second
+sdk version
+ruby -v
+echo "--- aliases-after"
+alias node 2>/dev/null || echo "node-alias-gone"
+alias ruby 2>/dev/null || echo "ruby-alias-gone"
+alias kotlin 2>/dev/null || echo "kotlin-alias-gone"
+EOF
+
+test_start "lazy_loaders_wires_aliases_for_installed_tools"
+out="$(run_with_timeout 30 "$BASH_BIN" "$driver" 2>&1)"
+rc=$?
+assert_equals 0 "$rc" "driver completes (no runaway recursion)"
+assert_contains "alias node='lazy_nvm node'" "$out" "node alias points at lazy_nvm"
+assert_contains "alias bundle='lazy_rbenv bundle'" "$out" "bundle alias points at lazy_rbenv"
+assert_contains "alias kotlin='lazy_sdk kotlin'" "$out" "kotlin alias points at lazy_sdk"
+
+test_start "lazy_nvm_sources_nvm_and_reruns_command"
+assert_contains "node-real --version" "$out" "nvm.sh functions replace the alias stub"
+
+test_start "lazy_rbenv_evals_init_and_reruns_command"
+assert_contains "ruby-real -v" "$out" "rbenv init - output is eval'd, then ruby runs"
+
+test_start "lazy_sdk_sources_init_and_reruns_command"
+assert_contains "sdk-real version" "$out" "sdkman-init.sh functions replace the alias stub"
+
+test_start "lazy_loaders_drop_their_trigger_aliases"
+assert_contains "node-alias-gone" "$out" "nvm aliases removed after loading"
+assert_contains "ruby-alias-gone" "$out" "rbenv aliases removed after loading"
+assert_contains "kotlin-alias-gone" "$out" "sdkman aliases removed after loading"
+
+test_start "lazy_nvm_loads_once_not_per_invocation"
+assert_contains "node-real --second" "$out" "second call still reaches the real node"
+assert_equals 1 "$(wc -l <"$counts/nvm.sourced" | tr -d ' ')" "nvm.sh sourced exactly once"
+
+test_start "lazy_rbenv_calls_rbenv_init_once"
+assert_equals 1 "$(wc -l <"$counts/rbenv.called" | tr -d ' ')" "rbenv invoked once (no re-entry)"
+
+test_start "lazy_loaders_absent_when_tools_missing"
+empty_home="$DOTFILES_COV_TMPDIR/empty-home"
+mkdir -p "$empty_home"
+out="$(HOME="$empty_home" PATH="/usr/bin:/bin" "$BASH_BIN" -c \
+  'source "$1"; declare -f lazy_nvm lazy_rbenv lazy_sdk >/dev/null && echo DEFINED || echo UNDEFINED' \
+  _ "$FUNC_FILE" 2>&1)"
+assert_contains "UNDEFINED" "$out" "no loader is defined without nvm/rbenv/sdkman"
+
+echo "RESULTS:$TESTS_RUN:$TESTS_PASSED:$TESTS_FAILED"

--- a/tests/unit/functions/test_misc_functions_branches.sh
+++ b/tests/unit/functions/test_misc_functions_branches.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2015-2026 Sebastien Rousseau
+# shellcheck disable=SC1090,SC1091,SC2034,SC2016
+# Behavioural coverage for small function templates whose remaining
+# branches depend on the host: goto (cd + listing), size (Linux
+# `stat -c` branch via a uname/stat shim) and utils/logging.sh (colour
+# escapes only when stdout is a TTY, exercised through a pseudo-tty).
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+source "$SCRIPT_DIR/../../framework/assertions.sh"
+source "$SCRIPT_DIR/../../framework/coverage_helpers.sh"
+
+# Keep bash xtrace flowing to the coverage runner's trace stream even
+# when a probe below captures 2>&1 or runs under a pty.
+exec 21>&2
+export BASH_XTRACEFD=21
+
+FUNCS_DIR="$REPO_ROOT/defaults/.chezmoitemplates/functions"
+PY3="$(command -v python3 || true)"
+REAL_STAT="$(command -v stat)"
+
+trap cov_teardown_sandbox EXIT
+cov_setup_sandbox
+
+# run_pty <cmd...> — run under a pseudo-terminal so [ -t 1 ] is true.
+run_pty() {
+  "$PY3" -c 'import pty, sys; sys.exit(pty.spawn(sys.argv[1:]) >> 8)' "$@" </dev/null
+}
+
+# ── goto ─────────────────────────────────────────────────────────
+target="$DOTFILES_COV_TMPDIR/goto-target"
+mkdir -p "$target"
+touch "$target/marker"
+
+test_start "goto_changes_directory_and_lists"
+out="$(bash -c 'source "$1"; goto "$2" >/dev/null 2>&1; pwd -L' _ "$FUNCS_DIR/nav/goto.sh" "$target" 2>&1)"
+assert_equals "$target" "$out" "cwd is the requested directory afterwards"
+
+test_start "goto_rejects_missing_directory"
+out="$(bash -c 'source "$1"; goto "$2"' _ "$FUNCS_DIR/nav/goto.sh" "$target/nope" 2>&1)"
+assert_equals 1 "$?" "missing directory exits 1"
+assert_contains "is not a valid directory" "$out" "error explains"
+
+test_start "goto_no_arg_and_help"
+out="$(bash -c 'source "$1"; goto ""' _ "$FUNCS_DIR/nav/goto.sh" 2>&1)"
+assert_contains "No directory provided" "$out" "empty arg rejected"
+out="$(bash -c 'source "$1"; goto --help' _ "$FUNCS_DIR/nav/goto.sh" 2>&1)"
+assert_contains "goto: Change Directory Helper" "$out" "help printed"
+
+# ── size ─────────────────────────────────────────────────────────
+size_bin="$DOTFILES_COV_TMPDIR/size-shims"
+mkdir -p "$size_bin"
+cat >"$size_bin/uname" <<'EOF'
+#!/usr/bin/env bash
+echo "${SIZE_TEST_UNAME:-Linux}"
+EOF
+cat >"$size_bin/stat" <<EOF
+#!/usr/bin/env bash
+# Deterministic byte counts for both stat dialects; anything else goes
+# to the real stat so error paths still fail naturally.
+case "\${1:-}" in
+  -c) [[ -e "\${3:-}" ]] && echo 42 ;;
+  -f) [[ -e "\${3:-}" ]] && echo 7 ;;
+  *) exec "$REAL_STAT" "\$@" ;;
+esac
+EOF
+chmod +x "$size_bin/uname" "$size_bin/stat"
+sample="$DOTFILES_COV_TMPDIR/sample.bin"
+echo "sample" >"$sample"
+
+test_start "size_linux_branch_uses_stat_c"
+out="$(PATH="$size_bin:$PATH" SIZE_TEST_UNAME=Linux bash -c 'source "$1"; size "$2"' _ "$FUNCS_DIR/files/size.sh" "$sample" 2>&1)"
+assert_equals 0 "$?" "size exits 0"
+assert_contains "Total size: 42 bytes" "$out" "Linux stat -c result reported"
+
+test_start "size_darwin_branch_uses_stat_f"
+out="$(PATH="$size_bin:$PATH" SIZE_TEST_UNAME=Darwin bash -c 'source "$1"; size "$2"' _ "$FUNCS_DIR/files/size.sh" "$sample" 2>&1)"
+assert_contains "Total size: 7 bytes" "$out" "Darwin stat -f result reported"
+
+test_start "size_missing_file_and_arg_count"
+out="$(PATH="$size_bin:$PATH" bash -c 'source "$1"; size "$2"' _ "$FUNCS_DIR/files/size.sh" "$sample.missing" 2>&1)"
+assert_equals 1 "$?" "missing file exits 1"
+assert_contains "Could not determine size" "$out" "missing file reported"
+out="$(bash -c 'source "$1"; size' _ "$FUNCS_DIR/files/size.sh" 2>&1)"
+assert_equals 1 "$?" "no-arg exits 1"
+
+# ── logging ──────────────────────────────────────────────────────
+LOG_FILE="$FUNCS_DIR/utils/logging.sh"
+log_probe='source "$1"; log_info i; log_success s; log_warning w; log_error e 2>&1'
+esc=$'\033'
+
+test_start "logging_colours_when_stdout_is_tty"
+if [[ -n "$PY3" ]]; then
+  out="$(NO_COLOR='' run_pty bash -c "$log_probe" _ "$LOG_FILE" 2>&1)"
+  assert_contains "${esc}[0;34m[INFO]${esc}[0m i" "$out" "blue INFO escape"
+  assert_contains "${esc}[0;32m[SUCCESS]" "$out" "green SUCCESS escape"
+  assert_contains "${esc}[0;33m[WARN]" "$out" "yellow WARN escape"
+  assert_contains "${esc}[0;31m[ERROR]" "$out" "red ERROR escape"
+else
+  echo "  SKIP: python3 not available for pty probe"
+fi
+
+test_start "logging_plain_when_not_a_tty"
+out="$(NO_COLOR='' bash -c "$log_probe" _ "$LOG_FILE" 2>&1)"
+assert_equals $'[INFO] i\n[SUCCESS] s\n[WARN] w\n[ERROR] e' "$out" "no escapes on a pipe"
+
+test_start "logging_respects_no_color_on_tty"
+if [[ -n "$PY3" ]]; then
+  out="$(NO_COLOR=1 run_pty bash -c "$log_probe" _ "$LOG_FILE" 2>&1)"
+  assert_contains "[INFO] i" "$out" "message still printed"
+  if [[ "$out" == *"$esc"* ]]; then
+    ((TESTS_FAILED++)) || true
+    printf '%b\n' "  ${RED}✗${NC} $CURRENT_TEST: escapes present despite NO_COLOR"
+  else
+    ((TESTS_PASSED++)) || true
+    printf '%b\n' "  ${GREEN}✓${NC} $CURRENT_TEST: NO_COLOR suppresses escapes"
+  fi
+else
+  echo "  SKIP: python3 not available for pty probe"
+fi
+
+echo "RESULTS:$TESTS_RUN:$TESTS_PASSED:$TESTS_FAILED"

--- a/tests/unit/ops/test_ops_bundle_branches.sh
+++ b/tests/unit/ops/test_ops_bundle_branches.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2015-2026 Sebastien Rousseau
+# shellcheck disable=SC1090,SC1091,SC2034
+#
+# Branch coverage for scripts/ops/bundle.sh: usage errors, the
+# XDG_RUNTIME_DIR fallback, the flock guard (free and contended), the
+# tar/zstd prerequisite check, a successful bundle and a failed tar.
+# `tar`, `zstd` and `flock` are PATH shims — no archive of the host is
+# ever produced.
+#
+# AUTO-GENERATED: false (hand-written)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+source "$SCRIPT_DIR/../../framework/assertions.sh"
+source "$SCRIPT_DIR/../../framework/coverage_helpers.sh"
+
+# Route child xtrace to the runner's trace stream even when a probe
+# captures 2>&1. bundle.sh does `exec 9>lockfile` when flock exists,
+# so fd 9 is NOT usable here — fd 19 keeps the trace intact.
+exec 21>&2
+export BASH_XTRACEFD=21
+
+SCRIPT_FILE="$REPO_ROOT/scripts/ops/bundle.sh"
+BASH_BIN="$(command -v bash)"
+
+trap cov_teardown_sandbox EXIT
+cov_setup_sandbox
+
+_link_real_tools() {
+  local dir="$1" t p
+  shift
+  for t in "$@"; do
+    p="$(command -v "$t" 2>/dev/null || true)"
+    [[ -n "$p" ]] && ln -sf "$p" "$dir/$t"
+  done
+}
+
+# Base tool set bundle.sh + ui.sh/log.sh need, without tar/zstd/flock.
+_base="$DOTFILES_COV_TMPDIR/base"
+mkdir -p "$_base"
+# `rm`/`tail` matter beyond the obvious: log.sh pipes through `tail`,
+# and bundle.sh's EXIT trap runs `rm -f` — a missing `rm` makes the
+# trap exit 127 and mask the script's real status.
+_link_real_tools "$_base" bash env dirname basename date mkdir stat cat sed awk grep \
+  head tail tr uname tput hostname printf rm ln cp mv sort wc du find id sleep touch chmod
+
+# tar shim: creates the -cf target (or fails when TAR_SHIM_FAIL=1);
+# zstd shim only needs to exist for the prerequisite probe.
+_arch="$DOTFILES_COV_TMPDIR/arch"
+mkdir -p "$_arch"
+cat >"$_arch/tar" <<'SHIM'
+#!/usr/bin/env bash
+printf 'tar %s\n' "$*" >>"${BUNDLE_SHIM_LOG:?}"
+[[ "${TAR_SHIM_FAIL:-0}" == "1" ]] && exit 1
+out=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -cf) out="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+echo "fake-zstd-archive" >"$out"
+SHIM
+printf '#!/usr/bin/env bash\nexit 0\n' >"$_arch/zstd"
+chmod +x "$_arch/tar" "$_arch/zstd"
+export BUNDLE_SHIM_LOG="$DOTFILES_COV_TMPDIR/bundle-shim.log"
+
+_bundle() { # <path> [args]
+  local path="$1"
+  shift
+  PATH="$path" "$BASH_BIN" "$SCRIPT_FILE" "$@" 2>&1
+}
+
+test_start "help_and_unknown_option"
+_out="$(_bundle "$_arch:$_base" --help)"
+assert_equals 0 $? "--help exits 0"
+assert_contains "Usage: bundle.sh [output-dir]" "$_out" "usage printed"
+_out="$(_bundle "$_arch:$_base" --bogus)"
+assert_equals 2 $? "unknown option exits 2"
+assert_contains "Unknown option: --bogus" "$_out" "option named"
+
+test_start "bundle_written_to_requested_dir_with_runtime_dir_fallback"
+: >"$BUNDLE_SHIM_LOG"
+_outdir="$DOTFILES_COV_TMPDIR/out"
+_out="$(XDG_RUNTIME_DIR=/nonexistent/runtime _bundle "$_arch:$_base" "$_outdir")"
+_rc=$?
+assert_equals 0 "$_rc" "bundle exits 0"
+assert_contains "Adding: $HOME/.dotfiles" "$_out" "existing path listed"
+assert_contains "Bundle created" "$_out" "success line printed"
+_file="$(find "$_outdir" -name 'dotfiles_offline_bundle_*.tar.zst' | head -1)"
+assert_not_empty "$_file" "archive file created"
+assert_contains "tar --zstd -cf $_file -P $HOME/.dotfiles" "$(cat "$BUNDLE_SHIM_LOG")" "tar invoked with zstd and existing paths only"
+assert_contains "tar --zstd -xf $_file -P" "$_out" "restore hint printed"
+
+test_start "flock_free_proceeds_and_contended_exits_0"
+_flock="$DOTFILES_COV_TMPDIR/flock"
+mkdir -p "$_flock"
+printf '#!/usr/bin/env bash\nexit "${FLOCK_SHIM_RC:-0}"\n' >"$_flock/flock"
+chmod +x "$_flock/flock"
+_out="$(XDG_RUNTIME_DIR="$DOTFILES_COV_TMPDIR" _bundle "$_flock:$_arch:$_base" "$DOTFILES_COV_TMPDIR/out2")"
+assert_equals 0 $? "free lock exits 0"
+assert_contains "Bundle created" "$_out" "bundle proceeds after flock"
+assert_file_exists "$DOTFILES_COV_TMPDIR/dotfiles-bundle.lock" "lock file opened in XDG_RUNTIME_DIR"
+_out="$(FLOCK_SHIM_RC=1 XDG_RUNTIME_DIR="$DOTFILES_COV_TMPDIR" _bundle "$_flock:$_arch:$_base" "$DOTFILES_COV_TMPDIR/out3")"
+assert_equals 0 $? "contended lock exits 0"
+assert_contains "Already running" "$_out" "already-running warning printed"
+assert_dir_not_exists "$DOTFILES_COV_TMPDIR/out3" "no output dir created when locked out"
+
+test_start "missing_zstd_exits_1"
+_taronly="$DOTFILES_COV_TMPDIR/taronly"
+mkdir -p "$_taronly"
+ln -sf "$_arch/tar" "$_taronly/tar"
+_out="$(_bundle "$_taronly:$_base" "$DOTFILES_COV_TMPDIR/out4")"
+_rc=$?
+assert_equals 1 "$_rc" "missing zstd exits 1"
+assert_contains "tar and zstd are required" "$_out" "prerequisite error printed"
+
+test_start "tar_failure_exits_1"
+_out="$(TAR_SHIM_FAIL=1 _bundle "$_arch:$_base" "$DOTFILES_COV_TMPDIR/out5")"
+_rc=$?
+assert_equals 1 "$_rc" "tar failure exits 1"
+assert_contains "Failed to create bundle" "$_out" "failure reported"
+
+echo "RESULTS:$TESTS_RUN:$TESTS_PASSED:$TESTS_FAILED"

--- a/tests/unit/ops/test_ops_heal_flows.sh
+++ b/tests/unit/ops/test_ops_heal_flows.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2015-2026 Sebastien Rousseau
+# shellcheck disable=SC1090,SC1091,SC2034
+#
+# End-to-end flows for scripts/ops/heal.sh: flag parsing, the
+# concurrency lock (flock present / absent, lock held), the
+# interactive confirmation, dry-run vs apply, and every summary line.
+# Every dependency heal checks for is a PATH shim, `mise` is a shim
+# (so nothing is downloaded), the lock lives in a sandbox
+# XDG_RUNTIME_DIR, and HOME is the cov sandbox — nothing on the host
+# is repaired.
+#
+# AUTO-GENERATED: false (hand-written)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+source "$SCRIPT_DIR/../../framework/assertions.sh"
+source "$SCRIPT_DIR/../../framework/coverage_helpers.sh"
+
+# Route child xtrace to the runner's trace stream even when a probe
+# captures 2>&1. heal.sh itself does `exec 9>lockfile`, so fd 9 is
+# NOT usable here — fd 19 keeps the trace intact past the lock.
+exec 21>&2
+export BASH_XTRACEFD=21
+
+HEAL_FILE="$REPO_ROOT/scripts/ops/heal.sh"
+BASH_BIN="$(command -v bash)"
+
+trap cov_teardown_sandbox EXIT
+cov_setup_sandbox
+
+# Shim every tool heal_missing_dependencies probes so the dependency
+# pass is deterministic (zero missing) regardless of the host.
+_deps="$DOTFILES_COV_TMPDIR/deps"
+mkdir -p "$_deps"
+for _t in zsh chezmoi starship rg bat fzf zoxide atuin yazi zellij nu pueue pueued wasmtime sops age hyperfine mise direnv; do
+  printf '#!/usr/bin/env bash\nexit 0\n' >"$_deps/$_t"
+  chmod +x "$_deps/$_t"
+done
+export PATH="$_deps:$PATH"
+
+# Lock directory under the sandbox so parallel test files never share
+# /tmp/dotfiles-heal.lock.
+export XDG_RUNTIME_DIR="$DOTFILES_COV_TMPDIR/run"
+mkdir -p "$XDG_RUNTIME_DIR"
+_lock_dir="$XDG_RUNTIME_DIR/dotfiles-heal.lock.d"
+
+_heal() { # [args]  (stdin passes through)
+  "$BASH_BIN" "$HEAL_FILE" "$@" 2>&1
+}
+
+_healthy_home() { # make HOME pass every heal check
+  touch "$HOME/.zshrc" "$HOME/.bashrc" "$HOME/.profile"
+  mkdir -p "$HOME/.config/shell" "$HOME/.config/nvim" "$HOME/.config/git"
+}
+
+_unhealthy_home() { # remove the critical files heal looks for
+  rm -f "$HOME/.zshrc" "$HOME/.bashrc" "$HOME/.profile"
+  rm -rf "$HOME/.config/shell" "$HOME/.config/nvim" "$HOME/.config/git"
+}
+
+test_start "help_prints_usage_and_exits_0"
+_out="$(_heal --help)"
+_rc=$?
+assert_equals 0 "$_rc" "--help exits 0"
+assert_contains "Dotfiles Heal - Auto-repair common issues" "$_out" "usage banner printed"
+
+test_start "unknown_option_prints_usage_and_exits_1"
+_out="$(_heal --bogus)"
+_rc=$?
+assert_equals 1 "$_rc" "unknown option exits 1"
+assert_contains "Unknown option: --bogus" "$_out" "option named"
+assert_contains "Usage:" "$_out" "usage printed after error"
+
+test_start "dry_run_counts_issues_without_fixing"
+_unhealthy_home
+_out="$(_heal --dry-run)"
+_rc=$?
+assert_equals 0 "$_rc" "dry-run exits 0"
+assert_contains "Dry-run mode (no changes will be made)" "$_out" "dry-run announced"
+assert_contains "issue(s). Run without --dry-run to apply fixes." "$_out" "issue count summarised"
+assert_file_not_exists "$HOME/.config/nvim" "dry-run created nothing"
+
+test_start "dry_run_healthy_home_reports_healthy"
+_healthy_home
+_out="$(_heal -n)"
+_rc=$?
+assert_equals 0 "$_rc" "dry-run exits 0"
+assert_contains "Healthy." "$_out" "healthy summary printed"
+
+test_start "force_apply_fixes_issues_and_logs_completion"
+_unhealthy_home
+rm -f "$XDG_STATE_HOME/dotfiles/heal.log"
+_out="$(_heal --force)"
+_rc=$?
+assert_equals 0 "$_rc" "forced heal exits 0"
+assert_contains "Done!" "$_out" "done summary printed"
+assert_contains "fix(es) for" "$_out" "fix count summarised"
+assert_dir_exists "$HOME/.config/nvim" "missing xdg dir was created"
+assert_contains "HEAL_COMPLETE:" "$(cat "$XDG_STATE_HOME/dotfiles/heal.log")" "completion persisted"
+
+test_start "interactive_decline_aborts"
+_healthy_home
+_out="$(printf 'n\n' | _heal)"
+_rc=$?
+assert_equals 0 "$_rc" "declined heal exits 0"
+assert_contains "This will auto-repair" "$_out" "confirmation shown"
+assert_contains "Aborted." "$_out" "abort acknowledged"
+
+test_start "interactive_accept_on_healthy_home_reports_healthy"
+_healthy_home
+_out="$(printf 'y\n' | _heal)"
+_rc=$?
+assert_equals 0 "$_rc" "accepted heal exits 0"
+assert_contains "Healthy." "$_out" "healthy summary printed after apply pass"
+
+test_start "issues_without_possible_fix_points_at_doctor"
+_healthy_home
+mkdir -p "$HOME/ro"
+ln -s /nonexistent/target "$HOME/ro/dead"
+chmod 555 "$HOME/ro"
+_out="$(DOTFILES_NONINTERACTIVE=1 _heal)"
+_rc=$?
+chmod 755 "$HOME/ro"
+rm -rf "$HOME/ro"
+assert_equals 0 "$_rc" "unfixable issue still exits 0"
+assert_contains "but no fixes could be applied" "$_out" "no-fix summary printed"
+assert_contains "dot doctor" "$_out" "doctor hint printed"
+
+test_start "flock_available_takes_the_lock_and_runs"
+_flock="$DOTFILES_COV_TMPDIR/flock-ok"
+mkdir -p "$_flock"
+printf '#!/usr/bin/env bash\nexit 0\n' >"$_flock/flock"
+chmod +x "$_flock/flock"
+_healthy_home
+_out="$(PATH="$_flock:$PATH" _heal -n)"
+_rc=$?
+assert_equals 0 "$_rc" "flock path exits 0"
+assert_contains "Healthy." "$_out" "run proceeds after flock"
+assert_file_exists "$XDG_RUNTIME_DIR/dotfiles-heal.lock" "lock file opened in XDG_RUNTIME_DIR"
+
+test_start "flock_contended_and_lock_dir_held_reports_already_running"
+_flockno="$DOTFILES_COV_TMPDIR/flock-no"
+mkdir -p "$_flockno"
+printf '#!/usr/bin/env bash\nexit 1\n' >"$_flockno/flock"
+chmod +x "$_flockno/flock"
+mkdir -p "$_lock_dir"
+_out="$(PATH="$_flockno:$PATH" _heal -n)"
+_rc=$?
+assert_equals 0 "$_rc" "contended lock exits 0"
+assert_contains "Already running" "$_out" "already-running warning printed"
+assert_output_not_contains "Dotfiles Heal" printf '%s' "$_out"
+rmdir "$_lock_dir"
+
+test_start "without_flock_held_lock_dir_reports_already_running"
+_noflock="$DOTFILES_COV_TMPDIR/noflock"
+mkdir -p "$_noflock"
+for _t in bash env dirname basename find readlink date mkdir rmdir rm cat sed awk grep head tail tr wc sort uname tput touch cp mv chmod stat printf; do
+  _p="$(command -v "$_t" 2>/dev/null || true)"
+  [[ -n "$_p" ]] && ln -sf "$_p" "$_noflock/$_t"
+done
+mkdir -p "$_lock_dir"
+_out="$(PATH="$_deps:$_noflock" _heal -n)"
+_rc=$?
+assert_equals 0 "$_rc" "held lock dir exits 0"
+assert_contains "Already running" "$_out" "already-running warning printed"
+rmdir "$_lock_dir"
+
+echo "RESULTS:$TESTS_RUN:$TESTS_PASSED:$TESTS_FAILED"

--- a/tests/unit/ops/test_ops_heal_flows.sh
+++ b/tests/unit/ops/test_ops_heal_flows.sh
@@ -30,6 +30,22 @@ BASH_BIN="$(command -v bash)"
 trap cov_teardown_sandbox EXIT
 cov_setup_sandbox
 
+# Substring refutation on an already-captured string. The framework's
+# assert_output_not_contains re-runs its arguments through `eval`, so
+# feeding captured output back in breaks on any shell metacharacter the
+# program happened to print.
+_refute_contains() { # <needle> <haystack> <msg>
+  if [[ "$2" != *"$1"* ]]; then
+    ((TESTS_PASSED++)) || true
+    printf '%b\n' "  ${GREEN}✓${NC} $CURRENT_TEST: $3"
+    return 0
+  fi
+  ((TESTS_FAILED++)) || true
+  printf '%b\n' "  ${RED}✗${NC} $CURRENT_TEST: $3"
+  printf '%b\n' "    Should not contain: '$1'"
+  return 1
+}
+
 # Shim every tool heal_missing_dependencies probes so the dependency
 # pass is deterministic (zero missing) regardless of the host.
 _deps="$DOTFILES_COV_TMPDIR/deps"
@@ -150,7 +166,7 @@ _out="$(PATH="$_flockno:$PATH" _heal -n)"
 _rc=$?
 assert_equals 0 "$_rc" "contended lock exits 0"
 assert_contains "Already running" "$_out" "already-running warning printed"
-assert_output_not_contains "Dotfiles Heal" printf '%s' "$_out"
+_refute_contains "Dotfiles Heal" "$_out" "the banner is suppressed"
 rmdir "$_lock_dir"
 
 test_start "without_flock_held_lock_dir_reports_already_running"

--- a/tests/unit/ops/test_ops_heal_system.sh
+++ b/tests/unit/ops/test_ops_heal_system.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2015-2026 Sebastien Rousseau
+# shellcheck disable=SC1090,SC1091,SC2034
+#
+# Behaviour tests for scripts/ops/heal-system.sh — the symlink,
+# critical-file and XDG-directory repair functions that heal.sh
+# sources. A tiny driver sources the module with the variables and
+# helpers heal.sh normally provides (DRY_RUN, FORCE, ISSUES_FOUND,
+# FIXES_APPLIED, CHEZMOI_APPLIED, log_dry, persist_log, _pkg_install)
+# and runs one function per case against a throwaway HOME.
+#
+# AUTO-GENERATED: false (hand-written)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+source "$SCRIPT_DIR/../../framework/assertions.sh"
+source "$SCRIPT_DIR/../../framework/coverage_helpers.sh"
+
+# Route child xtrace to the runner's trace stream even when a probe
+# captures 2>&1 (fd 19: fd 9 is taken by lock handling elsewhere).
+exec 21>&2
+export BASH_XTRACEFD=21
+
+HEAL_SYSTEM_FILE="$REPO_ROOT/scripts/ops/heal-system.sh"
+BASH_BIN="$(command -v bash)"
+
+trap cov_teardown_sandbox EXIT
+cov_setup_sandbox
+
+_driver="$DOTFILES_COV_TMPDIR/driver.sh"
+cat >"$_driver" <<'DRIVER'
+#!/usr/bin/env bash
+# Minimal stand-in for heal.sh's scope: same strict mode, same globals.
+set -euo pipefail
+source "${HEAL_SYSTEM_FILE:?}"
+log_dry() { printf 'DRY: %s\n' "$*"; }
+persist_log() { printf '%s\n' "$*" >>"${HEAL_LOG:?}"; }
+_pkg_install() {
+  shift 3
+  "$@" >/dev/null 2>&1
+}
+DRY_RUN="${DRY_RUN:-0}"
+FORCE="${FORCE:-0}"
+CHEZMOI_APPLIED="${CHEZMOI_APPLIED:-0}"
+ISSUES_FOUND=0
+FIXES_APPLIED=0
+rc=0
+"$1" || rc=$?
+printf 'ISSUES=%s FIXES=%s CHEZMOI_APPLIED=%s rc=%s\n' \
+  "$ISSUES_FOUND" "$FIXES_APPLIED" "$CHEZMOI_APPLIED" "$rc"
+DRIVER
+export HEAL_SYSTEM_FILE
+export HEAL_LOG="$DOTFILES_COV_TMPDIR/heal.log"
+
+_fresh_home() { # <name> → sets HOME to an empty per-case directory
+  HOME="$DOTFILES_COV_TMPDIR/homes/$1"
+  export HOME
+  mkdir -p "$HOME"
+}
+
+_run() { # <function> [ENV=val ...]  (stdin passes through)
+  local fn="$1"
+  shift
+  env "$@" "$BASH_BIN" "$_driver" "$fn" 2>&1
+}
+
+# ── heal_broken_symlinks ──────────────────────────────────────────────
+
+test_start "symlinks_clean_home_reports_ok"
+_fresh_home clean
+ln -s "$HOME" "$HOME/self-link"
+_out="$(_run heal_broken_symlinks)"
+assert_contains "✓" "$_out" "check mark printed"
+assert_contains "symlinks" "$_out" "symlinks line printed"
+assert_contains "ISSUES=0 FIXES=0" "$_out" "no issues counted"
+
+test_start "symlinks_dry_run_lists_broken_links_and_skips_known_lock_files"
+_fresh_home dry
+ln -s /nonexistent/target-a "$HOME/dead-a"
+mkdir -p "$HOME/google-chrome-backup"
+ln -s /nonexistent/lock "$HOME/google-chrome-backup/SingletonLock"
+ln -s /nonexistent/cookie "$HOME/SingletonCookie"
+_out="$(_run heal_broken_symlinks DRY_RUN=1)"
+assert_contains "DRY: remove broken symlink: $HOME/dead-a -> /nonexistent/target-a" "$_out" "broken link previewed"
+assert_output_not_contains "SingletonCookie" printf '%s' "$_out"
+assert_contains "ISSUES=1 FIXES=0" "$_out" "only the real broken link counted"
+# `-e`/`-f` are false for a dangling symlink, so assert on `-L`.
+assert_true "[[ -L '$HOME/dead-a' ]]" "dry-run leaves the broken link in place"
+
+test_start "symlinks_prompt_honours_no_then_yes"
+_fresh_home prompt
+: >"$HEAL_LOG"
+ln -s /nonexistent/one "$HOME/dead-1"
+ln -s /nonexistent/two "$HOME/dead-2"
+_out="$(printf 'n\ny\n' | _run heal_broken_symlinks)"
+# No prompt text is asserted here: bash prints a `read -p` prompt only
+# when stdin is a terminal, and this probe pipes the answers in. The
+# answers themselves are the observable behaviour — one link stays.
+assert_contains "ISSUES=2 FIXES=1" "$_out" "one of two removed"
+assert_contains "removed broken symlink" "$(cat "$HEAL_LOG")" "removal persisted to heal log"
+_left="$(find "$HOME" -maxdepth 1 -type l -name 'dead-*' | wc -l | tr -d ' ')"
+assert_equals 1 "$_left" "exactly one broken link remains"
+
+test_start "symlinks_lock_pattern_removed_without_prompt"
+_fresh_home lockpat
+ln -s /nonexistent/x "$HOME/app.SingletonLock.stale"
+_out="$(_run heal_broken_symlinks </dev/null)"
+assert_output_not_contains "Remove broken symlink" printf '%s' "$_out"
+assert_contains "removed $HOME/app.SingletonLock.stale" "$_out" "lock-pattern link removed"
+assert_contains "ISSUES=1 FIXES=1" "$_out" "fix counted"
+
+test_start "symlinks_force_reports_unremovable_link"
+_fresh_home ro
+mkdir -p "$HOME/ro"
+ln -s /nonexistent/y "$HOME/ro/dead"
+chmod 555 "$HOME/ro"
+_out="$(_run heal_broken_symlinks FORCE=1)"
+chmod 755 "$HOME/ro"
+assert_contains "could not remove $HOME/ro/dead" "$_out" "unremovable link reported"
+assert_contains "ISSUES=1 FIXES=0" "$_out" "no fix counted"
+
+test_start "symlinks_noninteractive_env_skips_prompt"
+_fresh_home nonint
+ln -s /nonexistent/z "$HOME/dead-z"
+_out="$(_run heal_broken_symlinks DOTFILES_NONINTERACTIVE=1 </dev/null)"
+assert_contains "removed $HOME/dead-z" "$_out" "link removed without prompt"
+
+# ── heal_missing_critical_files ───────────────────────────────────────
+
+test_start "critical_files_present_reports_ok"
+_fresh_home crit-ok
+touch "$HOME/.zshrc" "$HOME/.bashrc" "$HOME/.profile"
+_out="$(_run heal_missing_critical_files)"
+assert_contains "shell configs" "$_out" "shell configs line printed"
+assert_contains "ISSUES=0" "$_out" "no issues counted"
+
+test_start "critical_files_missing_without_chezmoi_returns_1"
+_fresh_home crit-nochezmoi
+_out="$(_run heal_missing_critical_files PATH=/usr/bin:/bin)"
+assert_contains "ISSUES=3 FIXES=0 CHEZMOI_APPLIED=0 rc=1" "$_out" "three missing, rc 1 without chezmoi"
+
+test_start "critical_files_missing_dry_run_previews_chezmoi"
+_fresh_home crit-dry
+_out="$(_run heal_missing_critical_files DRY_RUN=1)"
+assert_contains "DRY: regenerate missing files via chezmoi" "$_out" "dry-run preview printed"
+assert_contains "ISSUES=3 FIXES=0" "$_out" "issues counted, nothing applied"
+
+test_start "critical_files_already_applied_skips_chezmoi"
+_fresh_home crit-applied
+_out="$(_run heal_missing_critical_files CHEZMOI_APPLIED=1)"
+assert_contains "ISSUES=3 FIXES=0 CHEZMOI_APPLIED=1" "$_out" "no second apply"
+
+test_start "critical_files_chezmoi_apply_restores_and_counts"
+_fresh_home crit-apply
+: >"$HEAL_LOG"
+_chez="$DOTFILES_COV_TMPDIR/chez"
+mkdir -p "$_chez"
+cat >"$_chez/chezmoi" <<'SHIM'
+#!/usr/bin/env bash
+# Fake chezmoi: `apply` materialises one of the critical files.
+[[ "${1:-}" == "apply" ]] && touch "$HOME/.zshrc"
+exit 0
+SHIM
+chmod +x "$_chez/chezmoi"
+_out="$(_run heal_missing_critical_files PATH="$_chez:$PATH")"
+assert_contains "ISSUES=3 FIXES=1 CHEZMOI_APPLIED=1" "$_out" "one file restored and applied flag set"
+assert_contains "regenerated 1 critical file(s)" "$(cat "$HEAL_LOG")" "restore persisted to heal log"
+assert_file_exists "$HOME/.zshrc" "shim apply wrote .zshrc"
+
+# ── heal_missing_xdg_dirs ─────────────────────────────────────────────
+
+test_start "xdg_dirs_present_reports_ok"
+_fresh_home xdg-ok
+mkdir -p "$HOME/.config/shell" "$HOME/.config/nvim" "$HOME/.config/git"
+_out="$(_run heal_missing_xdg_dirs)"
+assert_contains "xdg directories" "$_out" "xdg line printed"
+assert_contains "ISSUES=0 FIXES=0" "$_out" "no issues counted"
+
+test_start "xdg_dirs_missing_dry_run_previews_creation"
+_fresh_home xdg-dry
+_out="$(_run heal_missing_xdg_dirs DRY_RUN=1)"
+assert_contains "DRY: create directory: $HOME/.config/nvim" "$_out" "creation previewed"
+assert_contains "ISSUES=3 FIXES=0" "$_out" "three missing, none created"
+assert_dir_not_exists "$HOME/.config/nvim" "dry-run creates nothing"
+
+test_start "xdg_dirs_missing_are_created"
+_fresh_home xdg-fix
+: >"$HEAL_LOG"
+_out="$(_run heal_missing_xdg_dirs)"
+assert_contains "ISSUES=3 FIXES=3" "$_out" "three created"
+assert_dir_exists "$HOME/.config/shell" "shell dir created"
+assert_dir_exists "$HOME/.config/git" "git dir created"
+assert_contains "created directory $HOME/.config/nvim" "$(cat "$HEAL_LOG")" "creation persisted to heal log"
+
+echo "RESULTS:$TESTS_RUN:$TESTS_PASSED:$TESTS_FAILED"

--- a/tests/unit/ops/test_ops_heal_system.sh
+++ b/tests/unit/ops/test_ops_heal_system.sh
@@ -28,6 +28,22 @@ BASH_BIN="$(command -v bash)"
 trap cov_teardown_sandbox EXIT
 cov_setup_sandbox
 
+# Substring refutation on an already-captured string. The framework's
+# assert_output_not_contains re-runs its arguments through `eval`, so
+# feeding captured output back in breaks on any shell metacharacter the
+# program happened to print.
+_refute_contains() { # <needle> <haystack> <msg>
+  if [[ "$2" != *"$1"* ]]; then
+    ((TESTS_PASSED++)) || true
+    printf '%b\n' "  ${GREEN}✓${NC} $CURRENT_TEST: $3"
+    return 0
+  fi
+  ((TESTS_FAILED++)) || true
+  printf '%b\n' "  ${RED}✗${NC} $CURRENT_TEST: $3"
+  printf '%b\n' "    Should not contain: '$1'"
+  return 1
+}
+
 _driver="$DOTFILES_COV_TMPDIR/driver.sh"
 cat >"$_driver" <<'DRIVER'
 #!/usr/bin/env bash
@@ -83,7 +99,7 @@ ln -s /nonexistent/lock "$HOME/google-chrome-backup/SingletonLock"
 ln -s /nonexistent/cookie "$HOME/SingletonCookie"
 _out="$(_run heal_broken_symlinks DRY_RUN=1)"
 assert_contains "DRY: remove broken symlink: $HOME/dead-a -> /nonexistent/target-a" "$_out" "broken link previewed"
-assert_output_not_contains "SingletonCookie" printf '%s' "$_out"
+_refute_contains "SingletonCookie" "$_out" "known lock files are skipped"
 assert_contains "ISSUES=1 FIXES=0" "$_out" "only the real broken link counted"
 # `-e`/`-f` are false for a dangling symlink, so assert on `-L`.
 assert_true "[[ -L '$HOME/dead-a' ]]" "dry-run leaves the broken link in place"
@@ -106,7 +122,7 @@ test_start "symlinks_lock_pattern_removed_without_prompt"
 _fresh_home lockpat
 ln -s /nonexistent/x "$HOME/app.SingletonLock.stale"
 _out="$(_run heal_broken_symlinks </dev/null)"
-assert_output_not_contains "Remove broken symlink" printf '%s' "$_out"
+_refute_contains "Remove broken symlink" "$_out" "lock-pattern links are removed without prompting"
 assert_contains "removed $HOME/app.SingletonLock.stale" "$_out" "lock-pattern link removed"
 assert_contains "ISSUES=1 FIXES=1" "$_out" "fix counted"
 

--- a/tests/unit/qa/test_check_version_consistency_fixtures.sh
+++ b/tests/unit/qa/test_check_version_consistency_fixtures.sh
@@ -28,11 +28,13 @@ trap cov_teardown_sandbox EXIT
 cov_setup_sandbox
 
 # Build a fixture tree where every live surface carries <version>.
-# Prints the path of the symlinked script inside the fixture.
+# Prints the fixture root; the checker runs against it through
+# REPO_ROOT rather than being copied or symlinked into the tree —
+# a symlinked copy also hides the run from the coverage aggregator,
+# which resolves trace paths after the sandbox is gone.
 _fixture() { # <name> <version>
   local root="$DOTFILES_COV_TMPDIR/fx-$1" v="$2"
   mkdir -p "$root/scripts/qa" "$root/defaults" "$root/bin" "$root/share/man/man1" "$root/lib/dot"
-  ln -s "$SCRIPT_FILE" "$root/scripts/qa/check-version-consistency.sh"
   printf 'dotfiles_version = "%s"\n' "$v" >"$root/defaults/.chezmoidata.toml"
   printf '{\n  "name": "dotfiles",\n  "version": "%s"\n}\n' "$v" >"$root/package.json"
   printf '#!/usr/bin/env bash\n# Dotfiles CLI Entry Point - v%s\nVERSION="%s"\n' "$v" "$v" >"$root/bin/dot"
@@ -47,7 +49,7 @@ _fixture() { # <name> <version>
 _check() { # <fixture-root> [args]
   local root="$1"
   shift
-  "$BASH_BIN" "$root/scripts/qa/check-version-consistency.sh" "$@" 2>&1
+  REPO_ROOT="$root" "$BASH_BIN" "$SCRIPT_FILE" "$@" 2>&1
 }
 
 test_start "help_and_unknown_flag"

--- a/tests/unit/qa/test_check_version_consistency_fixtures.sh
+++ b/tests/unit/qa/test_check_version_consistency_fixtures.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2015-2026 Sebastien Rousseau
+# shellcheck disable=SC1090,SC1091,SC2034
+#
+# Fixture-driven tests for scripts/qa/check-version-consistency.sh.
+# The script derives REPO_ROOT from its own location, so each case
+# symlinks it into a throwaway tree holding the eight version surfaces
+# and then drifts one of them: missing file, missing pattern, wrong
+# version (with and without --fix), unreadable canonical version.
+#
+# AUTO-GENERATED: false (hand-written)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+source "$SCRIPT_DIR/../../framework/assertions.sh"
+source "$SCRIPT_DIR/../../framework/coverage_helpers.sh"
+
+# Route child xtrace to the runner's trace stream even when a probe
+# captures 2>&1 (fd 19: fd 9 is taken by lock handling elsewhere).
+exec 21>&2
+export BASH_XTRACEFD=21
+
+SCRIPT_FILE="$REPO_ROOT/scripts/qa/check-version-consistency.sh"
+BASH_BIN="$(command -v bash)"
+
+trap cov_teardown_sandbox EXIT
+cov_setup_sandbox
+
+# Build a fixture tree where every live surface carries <version>.
+# Prints the path of the symlinked script inside the fixture.
+_fixture() { # <name> <version>
+  local root="$DOTFILES_COV_TMPDIR/fx-$1" v="$2"
+  mkdir -p "$root/scripts/qa" "$root/defaults" "$root/bin" "$root/share/man/man1" "$root/lib/dot"
+  ln -s "$SCRIPT_FILE" "$root/scripts/qa/check-version-consistency.sh"
+  printf 'dotfiles_version = "%s"\n' "$v" >"$root/defaults/.chezmoidata.toml"
+  printf '{\n  "name": "dotfiles",\n  "version": "%s"\n}\n' "$v" >"$root/package.json"
+  printf '#!/usr/bin/env bash\n# Dotfiles CLI Entry Point - v%s\nVERSION="%s"\n' "$v" "$v" >"$root/bin/dot"
+  printf '.TH DOT 1 "2026" "dotfiles v%s" "User Commands"\n' "$v" >"$root/share/man/man1/dot.1"
+  printf 'banner="D O T F I L E S [v%s]"\n' "$v" >"$root/lib/dot/bento.sh"
+  printf '# Dotfiles\n\n![Version](https://img.shields.io/badge/Version-v%s-blue)\n' "$v" >"$root/README.md"
+  printf 'Chezmoi-managed dotfiles. Version `%s`.\n' "$v" >"$root/CLAUDE.md"
+  printf 'Chezmoi-managed dotfiles. Version `%s`.\n' "$v" >"$root/AGENTS.md"
+  printf '%s\n' "$root"
+}
+
+_check() { # <fixture-root> [args]
+  local root="$1"
+  shift
+  "$BASH_BIN" "$root/scripts/qa/check-version-consistency.sh" "$@" 2>&1
+}
+
+test_start "help_and_unknown_flag"
+_root="$(_fixture help 1.2.3)"
+_out="$(_check "$_root" --help)"
+assert_equals 0 $? "--help exits 0"
+assert_contains "Verify that every" "$_out" "help text printed"
+_out="$(_check "$_root" --bogus)"
+assert_equals 2 $? "unknown flag exits 2"
+assert_contains "unknown flag: --bogus" "$_out" "unknown flag named"
+
+test_start "all_surfaces_match_exits_0"
+_root="$(_fixture match 1.2.3)"
+_out="$(_check "$_root")"
+_rc=$?
+assert_equals 0 "$_rc" "matching tree exits 0"
+assert_contains "canonical: 1.2.3" "$_out" "canonical version logged"
+assert_contains "all 8 live version surfaces match 1.2.3" "$_out" "success summary printed"
+
+test_start "quiet_suppresses_output_but_keeps_rc"
+_root="$(_fixture quiet 1.2.3)"
+_out="$(_check "$_root" --quiet)"
+_rc=$?
+assert_equals 0 "$_rc" "--quiet exits 0"
+assert_equals "" "$_out" "--quiet prints nothing"
+_out="$(_check "$_root" -q)"
+assert_equals 0 $? "-q exits 0"
+
+test_start "missing_canonical_version_exits_2"
+_root="$(_fixture nocanon 1.2.3)"
+printf 'other = "x"\n' >"$_root/defaults/.chezmoidata.toml"
+_out="$(_check "$_root")"
+_rc=$?
+assert_equals 2 "$_rc" "missing canonical exits 2"
+assert_contains "failed to read dotfiles_version" "$_out" "canonical error printed"
+
+test_start "missing_surface_file_is_drift"
+_root="$(_fixture missing 1.2.3)"
+rm -f "$_root/AGENTS.md"
+_out="$(_check "$_root")"
+_rc=$?
+assert_equals 1 "$_rc" "missing file exits 1"
+assert_contains "MISSING: AGENTS.md" "$_out" "missing file named"
+assert_contains "Tip: rerun with --fix" "$_out" "fix tip printed"
+
+test_start "missing_pattern_is_drift"
+_root="$(_fixture nopattern 1.2.3)"
+printf '# Dotfiles\n\nno badge here\n' >"$_root/README.md"
+_out="$(_check "$_root")"
+_rc=$?
+assert_equals 1 "$_rc" "missing pattern exits 1"
+assert_contains "PATTERN NOT FOUND: 'img.shields.io/badge/Version' in README.md" "$_out" "pattern named"
+
+test_start "drifted_surface_reported_then_fixed"
+_root="$(_fixture drift 1.2.3)"
+printf '#!/usr/bin/env bash\n# Dotfiles CLI Entry Point - v1.0.0\nVERSION="1.2.3"\n' >"$_root/bin/dot"
+_out="$(_check "$_root")"
+_rc=$?
+assert_equals 1 "$_rc" "drift exits 1"
+assert_contains "DRIFT in bin/dot" "$_out" "drifted file named"
+assert_contains "found:    # Dotfiles CLI Entry Point - v1.0.0" "$_out" "found line echoed"
+assert_contains "expected: contains '# Dotfiles CLI Entry Point - v1.2.3'" "$_out" "expected substring echoed"
+_out="$(_check "$_root" --fix)"
+_rc=$?
+assert_equals 1 "$_rc" "--fix run still exits 1 (verify on rerun)"
+assert_contains "fixed:  bin/dot  (v1.0.0 → v1.2.3)" "$_out" "fix logged"
+assert_contains "Auto-fixed where safe" "$_out" "fix summary printed"
+assert_file_contains "$_root/bin/dot" "Entry Point - v1.2.3" "header rewritten"
+assert_file_not_exists "$_root/bin/dot.bak" "sed backup removed"
+_out="$(_check "$_root")"
+assert_equals 0 $? "tree is consistent after --fix"
+
+test_start "fix_skips_lines_without_a_vX_Y_Z_token"
+_root="$(_fixture nofix 1.2.3)"
+printf '#!/usr/bin/env bash\n# Dotfiles CLI Entry Point - v1.2.3\nVERSION="9.9.9"\n' >"$_root/bin/dot"
+_out="$(_check "$_root" --fix)"
+_rc=$?
+assert_equals 1 "$_rc" "unfixable drift exits 1"
+assert_contains "DRIFT in bin/dot" "$_out" "drift reported"
+assert_output_not_contains "fixed:" printf '%s' "$_out"
+assert_file_contains "$_root/bin/dot" 'VERSION="9.9.9"' "unsafe line left untouched"
+
+echo "RESULTS:$TESTS_RUN:$TESTS_PASSED:$TESTS_FAILED"

--- a/tests/unit/qa/test_check_version_consistency_fixtures.sh
+++ b/tests/unit/qa/test_check_version_consistency_fixtures.sh
@@ -27,6 +27,22 @@ BASH_BIN="$(command -v bash)"
 trap cov_teardown_sandbox EXIT
 cov_setup_sandbox
 
+# Substring refutation on an already-captured string. The framework's
+# assert_output_not_contains re-runs its arguments through `eval`, so
+# feeding captured output back in breaks on any shell metacharacter the
+# program happened to print.
+_refute_contains() { # <needle> <haystack> <msg>
+  if [[ "$2" != *"$1"* ]]; then
+    ((TESTS_PASSED++)) || true
+    printf '%b\n' "  ${GREEN}✓${NC} $CURRENT_TEST: $3"
+    return 0
+  fi
+  ((TESTS_FAILED++)) || true
+  printf '%b\n' "  ${RED}✗${NC} $CURRENT_TEST: $3"
+  printf '%b\n' "    Should not contain: '$1'"
+  return 1
+}
+
 # Build a fixture tree where every live surface carries <version>.
 # Prints the fixture root; the checker runs against it through
 # REPO_ROOT rather than being copied or symlinked into the tree —
@@ -129,7 +145,7 @@ _out="$(_check "$_root" --fix)"
 _rc=$?
 assert_equals 1 "$_rc" "unfixable drift exits 1"
 assert_contains "DRIFT in bin/dot" "$_out" "drift reported"
-assert_output_not_contains "fixed:" printf '%s' "$_out"
+_refute_contains "fixed:" "$_out" "nothing is rewritten when the tree is in sync"
 assert_file_contains "$_root/bin/dot" 'VERSION="9.9.9"' "unsafe line left untouched"
 
 echo "RESULTS:$TESTS_RUN:$TESTS_PASSED:$TESTS_FAILED"

--- a/tests/unit/qa/test_scorecard_snapshot_branches.sh
+++ b/tests/unit/qa/test_scorecard_snapshot_branches.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2015-2026 Sebastien Rousseau
+# shellcheck disable=SC1090,SC1091,SC2034
+#
+# Branch coverage for scripts/qa/scorecard-snapshot.sh: missing
+# target, jq absent, Scorecard API unreachable, first-run injection
+# after "## Live score", in-place refresh between the markers, and
+# --check in sync / stale. `curl` is a shim returning a canned payload
+# (or failing), so nothing leaves the machine.
+#
+# AUTO-GENERATED: false (hand-written)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+source "$SCRIPT_DIR/../../framework/assertions.sh"
+source "$SCRIPT_DIR/../../framework/coverage_helpers.sh"
+
+# Route child xtrace to the runner's trace stream even when a probe
+# captures 2>&1 (fd 19: fd 9 is taken by lock handling elsewhere).
+exec 21>&2
+export BASH_XTRACEFD=21
+
+SCRIPT_FILE="$REPO_ROOT/scripts/qa/scorecard-snapshot.sh"
+BASH_BIN="$(command -v bash)"
+
+trap cov_teardown_sandbox EXIT
+cov_setup_sandbox
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq not available — skipping scorecard branch tests"
+  echo "RESULTS:0:0:0"
+  exit 0
+fi
+
+# curl shim: canned Scorecard payload, or failure when CURL_SHIM_FAIL=1.
+_curlbin="$DOTFILES_COV_TMPDIR/curlbin"
+mkdir -p "$_curlbin"
+cat >"$_curlbin/curl" <<'SHIM'
+#!/usr/bin/env bash
+[[ "${CURL_SHIM_FAIL:-0}" == "1" ]] && exit 22
+printf '%s\n' '{"score":7.5,"date":"2026-09-01","checks":[{"name":"Token-Permissions","score":10,"reason":"top level | ok"},{"name":"Binary-Artifacts","score":4,"reason":"binaries present"}]}'
+SHIM
+chmod +x "$_curlbin/curl"
+export PATH="$_curlbin:$PATH"
+
+_fixture() { # <name> → root with a fresh SCORECARD.md
+  local root="$DOTFILES_COV_TMPDIR/fx-$1"
+  mkdir -p "$root/docs/security"
+  printf '# Scorecard\n\nIntro paragraph.\n\n## Live score\n\n## Findings\n\nNarrative stays.\n' >"$root/docs/security/SCORECARD.md"
+  printf '%s\n' "$root"
+}
+
+_snap() { # <root> [args]
+  local root="$1"
+  shift
+  REPO_ROOT="$root" "$BASH_BIN" "$SCRIPT_FILE" "$@" 2>&1
+}
+
+test_start "missing_target_exits_2"
+_root="$DOTFILES_COV_TMPDIR/fx-notarget"
+mkdir -p "$_root"
+_out="$(_snap "$_root")"
+_rc=$?
+assert_equals 2 "$_rc" "missing SCORECARD.md exits 2"
+assert_contains "target not found: docs/security/SCORECARD.md" "$_out" "target path named"
+
+test_start "missing_jq_exits_2"
+_root="$(_fixture nojq)"
+_nojq="$DOTFILES_COV_TMPDIR/nojq"
+mkdir -p "$_nojq"
+ln -sf "$(command -v dirname)" "$_nojq/dirname"
+_out="$(REPO_ROOT="$_root" PATH="$_nojq" "$BASH_BIN" "$SCRIPT_FILE" 2>&1)"
+_rc=$?
+assert_equals 2 "$_rc" "no jq exits 2"
+assert_contains "jq required" "$_out" "jq requirement printed"
+
+test_start "api_unreachable_exits_2"
+_root="$(_fixture nocurl)"
+_out="$(CURL_SHIM_FAIL=1 _snap "$_root")"
+_rc=$?
+assert_equals 2 "$_rc" "curl failure exits 2"
+assert_contains "Scorecard API unreachable" "$_out" "API failure printed"
+
+test_start "first_run_injects_block_after_live_score_heading"
+_root="$(_fixture first)"
+_out="$(_snap "$_root")"
+_rc=$?
+assert_equals 0 "$_rc" "first write exits 0"
+assert_contains "Refreshed docs/security/SCORECARD.md (aggregate: 7.5 as of 2026-09-01)" "$_out" "refresh summary printed"
+_md="$_root/docs/security/SCORECARD.md"
+assert_file_contains "$_md" "<!-- BEGIN scorecard-snapshot" "begin marker written"
+assert_file_contains "$_md" "Aggregate score **7.5 / 10** at 2026-09-01." "aggregate line written"
+assert_file_contains "$_md" "| Binary-Artifacts | 4 | binaries present |" "checks sorted and tabled"
+assert_file_contains "$_md" "Narrative stays." "narrative preserved"
+_order="$(awk '/^## Live score$/{print "live"} /BEGIN scorecard-snapshot/{print "begin"} /^## Findings$/{print "findings"}' "$_md" | tr '\n' ' ')"
+assert_equals "live begin findings " "$_order" "block sits between the two headings"
+
+test_start "check_in_sync_exits_0_and_refresh_replaces_block_in_place"
+_out="$(_snap "$_root" --check)"
+_rc=$?
+assert_equals 0 "$_rc" "in-sync check exits 0"
+assert_contains "snapshot is in sync (aggregate: 7.5)" "$_out" "in-sync message printed"
+_out="$(_snap "$_root")"
+assert_equals 0 $? "second refresh exits 0"
+assert_equals 1 "$(/usr/bin/grep -c 'BEGIN scorecard-snapshot' "$_md")" "markers not duplicated on refresh"
+
+test_start "check_stale_exits_1_with_diff"
+sed -i.bak 's/Aggregate score \*\*7\.5/Aggregate score **1.0/' "$_md"
+rm -f "$_md.bak"
+_out="$(_snap "$_root" --check)"
+_rc=$?
+assert_equals 1 "$_rc" "stale check exits 1"
+assert_contains "snapshot is stale (live score: 7.5)" "$_out" "stale message printed"
+assert_contains "-Aggregate score **1.0" "$_out" "unified diff shows the stale line"
+
+echo "RESULTS:$TESTS_RUN:$TESTS_PASSED:$TESTS_FAILED"

--- a/tests/unit/security/test_check_disclosure_key_expiry_branches.sh
+++ b/tests/unit/security/test_check_disclosure_key_expiry_branches.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2015-2026 Sebastien Rousseau
+# shellcheck disable=SC1090,SC1091,SC2034
+#
+# Branch coverage for scripts/security/check-disclosure-key-expiry.sh
+# with a deterministic `gpg` shim. The sibling test
+# (test_check_disclosure_key_expiry.sh) only exercises the real gpg
+# when available; this one drives every exit path — missing key
+# file, gpg absent, import failure, no expiry, warn window, fail
+# window, healthy — without touching a real keyring or the network.
+#
+# AUTO-GENERATED: false (hand-written)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+source "$SCRIPT_DIR/../../framework/assertions.sh"
+source "$SCRIPT_DIR/../../framework/coverage_helpers.sh"
+
+# Route child xtrace to the runner's trace stream even when a probe
+# captures 2>&1 or discards stderr (fd 19: fd 9 is taken by the lock
+# handling in several ops scripts).
+exec 21>&2
+export BASH_XTRACEFD=21
+
+SCRIPT_FILE="$REPO_ROOT/scripts/security/check-disclosure-key-expiry.sh"
+BASH_BIN="$(command -v bash)"
+
+trap cov_teardown_sandbox EXIT
+cov_setup_sandbox
+
+# ── gpg shim ──────────────────────────────────────────────────────────
+# Overrides the sandbox no-op shim. Import writes the `imported: N`
+# marker the script greps for (or not, when GPG_SHIM_IMPORT_FAIL=1);
+# --with-colons prints a `pub:` record whose field 7 is the expiry
+# taken from GPG_SHIM_EXPIRES (0 = no expiry).
+cat >"$DOTFILES_COV_TMPDIR/bin/gpg" <<'SHIM'
+#!/usr/bin/env bash
+case "$*" in
+  *--import*)
+    if [[ "${GPG_SHIM_IMPORT_FAIL:-0}" == "1" ]]; then
+      echo "gpg: no valid OpenPGP data found." >&2
+    else
+      echo "gpg: key 0123456789ABCDEF: public key imported" >&2
+      echo "gpg: Total number processed: 1" >&2
+      echo "gpg: imported: 1" >&2
+    fi
+    exit 0
+    ;;
+  *--with-colons*)
+    printf 'tru::1:1700000000:0:3:1:5\n'
+    printf 'pub:u:255:22:0123456789ABCDEF:1700000000:%s::u:::scESC::::::23::0:\n' \
+      "${GPG_SHIM_EXPIRES:-0}"
+    exit 0
+    ;;
+  *) exit 0 ;;
+esac
+SHIM
+chmod +x "$DOTFILES_COV_TMPDIR/bin/gpg"
+
+_now="$(date -u +%s)"
+_days_from_now() { printf '%s\n' "$((_now + $1 * 86400))"; }
+
+test_start "help_prints_usage_and_exits_zero"
+_out="$("$BASH_BIN" "$SCRIPT_FILE" --help 2>&1)"
+_rc=$?
+assert_equals 0 "$_rc" "--help exits 0"
+assert_contains "check-disclosure-key-expiry" "$_out" "help mentions the script name"
+
+test_start "unknown_flag_exits_2"
+_out="$("$BASH_BIN" "$SCRIPT_FILE" --nope 2>&1)"
+_rc=$?
+assert_equals 2 "$_rc" "unknown flag exits 2"
+assert_contains "Unknown arg: --nope" "$_out" "unknown flag is named"
+
+# Missing key file: symlink the script into a fixture tree so its
+# BASH_SOURCE-relative REPO_ROOT has no docs/security/security-pubkey.asc.
+test_start "missing_public_key_exits_2"
+_fixture="$DOTFILES_COV_TMPDIR/nokey"
+mkdir -p "$_fixture/scripts/security"
+ln -s "$SCRIPT_FILE" "$_fixture/scripts/security/check-disclosure-key-expiry.sh"
+_out="$("$BASH_BIN" "$_fixture/scripts/security/check-disclosure-key-expiry.sh" 2>&1)"
+_rc=$?
+assert_equals 2 "$_rc" "missing .asc exits 2"
+assert_contains "::error::no public key" "$_out" "missing .asc is reported"
+
+# gpg absent: a PATH that carries every tool the script needs except gpg.
+test_start "gpg_missing_warns_and_exits_0"
+_nogpg="$DOTFILES_COV_TMPDIR/nogpg"
+mkdir -p "$_nogpg"
+for _t in dirname mktemp chmod grep awk date cat rm sed; do
+  _p="$(command -v "$_t" 2>/dev/null || true)"
+  [[ -n "$_p" ]] && ln -sf "$_p" "$_nogpg/$_t"
+done
+_out="$(PATH="$_nogpg" "$BASH_BIN" "$SCRIPT_FILE" 2>&1)"
+_rc=$?
+assert_equals 0 "$_rc" "no gpg exits 0"
+assert_contains "gpg not installed" "$_out" "no-gpg warning printed"
+
+test_start "import_failure_exits_2"
+_out="$(GPG_SHIM_IMPORT_FAIL=1 "$BASH_BIN" "$SCRIPT_FILE" 2>&1)"
+_rc=$?
+assert_equals 2 "$_rc" "failed import exits 2"
+assert_contains "gpg import failed" "$_out" "import failure reported"
+assert_contains "no valid OpenPGP data" "$_out" "import.err is echoed"
+
+test_start "no_expiry_warns_and_exits_0"
+_out="$(GPG_SHIM_EXPIRES=0 "$BASH_BIN" "$SCRIPT_FILE" 2>&1)"
+_rc=$?
+assert_equals 0 "$_rc" "no-expiry key exits 0"
+assert_contains "has no expiry" "$_out" "no-expiry warning printed"
+
+test_start "expiry_inside_fail_window_exits_1"
+_out="$(GPG_SHIM_EXPIRES="$(_days_from_now 10)" "$BASH_BIN" "$SCRIPT_FILE" --fail-days 30 --warn-days 90 2>&1)"
+_rc=$?
+assert_equals 1 "$_rc" "inside fail window exits 1"
+assert_contains "::error::Disclosure key expires in" "$_out" "fail annotation printed"
+assert_contains "fail threshold: 30 days" "$_out" "fail threshold echoed"
+
+test_start "expiry_inside_warn_window_exits_0_with_warning"
+_out="$(GPG_SHIM_EXPIRES="$(_days_from_now 60)" "$BASH_BIN" "$SCRIPT_FILE" --warn-days 90 --fail-days 30 2>&1)"
+_rc=$?
+assert_equals 0 "$_rc" "inside warn window exits 0"
+assert_contains "::warning::Disclosure key expires in" "$_out" "warn annotation printed"
+assert_contains "warn threshold: 90 days" "$_out" "warn threshold echoed"
+
+test_start "healthy_expiry_exits_0_without_annotations"
+_out="$(GPG_SHIM_EXPIRES="$(_days_from_now 400)" "$BASH_BIN" "$SCRIPT_FILE" 2>&1)"
+_rc=$?
+assert_equals 0 "$_rc" "healthy key exits 0"
+assert_contains "Disclosure key expires:" "$_out" "expiry summary printed"
+if [[ "$_out" != *"::warning::"* && "$_out" != *"::error::"* ]]; then
+  ((TESTS_PASSED++)) || true
+  printf '%b\n' "  ${GREEN}✓${NC} $CURRENT_TEST: no annotations"
+else
+  ((TESTS_FAILED++)) || true
+  printf '%b\n' "  ${RED}✗${NC} $CURRENT_TEST: unexpected annotation in: $_out"
+fi
+
+echo "RESULTS:$TESTS_RUN:$TESTS_PASSED:$TESTS_FAILED"

--- a/tests/unit/security/test_check_disclosure_key_expiry_branches.sh
+++ b/tests/unit/security/test_check_disclosure_key_expiry_branches.sh
@@ -48,7 +48,8 @@ case "$*" in
     exit 0
     ;;
   *--with-colons*)
-    printf 'tru::1:1700000000:0:3:1:5\n'
+    # A non-`pub:` record first, so the awk `/^pub:/` filter is exercised.
+    printf 'cfg:version:2.4.4\n'
     printf 'pub:u:255:22:0123456789ABCDEF:1700000000:%s::u:::scESC::::::23::0:\n' \
       "${GPG_SHIM_EXPIRES:-0}"
     exit 0

--- a/tests/unit/security/test_security_backup_branches.sh
+++ b/tests/unit/security/test_security_backup_branches.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2015-2026 Sebastien Rousseau
+# shellcheck disable=SC1090,SC1091,SC2034
+#
+# Branch coverage for scripts/security/backup.sh: the success path
+# archives a small sandbox source tree, and the failure path uses a
+# `tar` shim that exits non-zero so the partial archive is removed.
+#
+# AUTO-GENERATED: false (hand-written)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+source "$SCRIPT_DIR/../../framework/assertions.sh"
+source "$SCRIPT_DIR/../../framework/coverage_helpers.sh"
+
+# Route child xtrace to the runner's trace stream even when a probe
+# captures 2>&1 (fd 19: fd 9 is taken by lock handling elsewhere).
+exec 21>&2
+export BASH_XTRACEFD=21
+
+SCRIPT_FILE="$REPO_ROOT/scripts/security/backup.sh"
+BASH_BIN="$(command -v bash)"
+
+trap cov_teardown_sandbox EXIT
+cov_setup_sandbox
+
+_src="$DOTFILES_COV_TMPDIR/src"
+_dest="$DOTFILES_COV_TMPDIR/dest"
+mkdir -p "$_src/sub"
+echo "hello" >"$_src/sub/file.txt"
+
+test_start "backup_writes_timestamped_archive"
+_out="$(DOTFILES_BACKUP_SRC="$_src" DOTFILES_BACKUP_DIR="$_dest" "$BASH_BIN" "$SCRIPT_FILE" 2>&1)"
+_rc=$?
+assert_equals 0 "$_rc" "backup exits 0"
+assert_contains "Backup written" "$_out" "success line printed"
+_archive="$(find "$_dest" -name 'dotfiles-backup-*.tgz' | head -1)"
+assert_not_empty "$_archive" "archive file created"
+assert_contains "sub/file.txt" "$(tar -tzf "$_archive" 2>/dev/null)" "archive lists the source file"
+
+test_start "backup_failure_removes_partial_archive"
+_shim="$DOTFILES_COV_TMPDIR/failtar"
+mkdir -p "$_shim"
+cat >"$_shim/tar" <<'SHIM'
+#!/usr/bin/env bash
+# Simulate tar dying after creating a partial archive.
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -czf) echo partial >"$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+exit 1
+SHIM
+chmod +x "$_shim/tar"
+_dest2="$DOTFILES_COV_TMPDIR/dest2"
+_out="$(PATH="$_shim:$PATH" DOTFILES_BACKUP_SRC="$_src" DOTFILES_BACKUP_DIR="$_dest2" "$BASH_BIN" "$SCRIPT_FILE" 2>&1)"
+_rc=$?
+assert_equals 1 "$_rc" "failed backup exits 1"
+assert_contains "Backup failed" "$_out" "failure reported"
+assert_equals "" "$(find "$_dest2" -name 'dotfiles-backup-*.tgz')" "partial archive removed"
+
+echo "RESULTS:$TESTS_RUN:$TESTS_PASSED:$TESTS_FAILED"

--- a/tests/unit/security/test_security_dns_doh_branches.sh
+++ b/tests/unit/security/test_security_dns_doh_branches.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2015-2026 Sebastien Rousseau
+# shellcheck disable=SC1090,SC1091,SC2034
+#
+# Branch coverage for scripts/security/dns-doh.sh. The platform is
+# pinned through _DOT_PLATFORM_ID and `resolvectl` / `sudo` are PATH
+# shims, so the systemd-resolved arm runs (dry-run and apply) without
+# changing any resolver on the host.
+#
+# AUTO-GENERATED: false (hand-written)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+source "$SCRIPT_DIR/../../framework/assertions.sh"
+source "$SCRIPT_DIR/../../framework/coverage_helpers.sh"
+
+# Route child xtrace to the runner's trace stream even when a probe
+# captures 2>&1 (fd 19: fd 9 is taken by lock handling elsewhere).
+exec 21>&2
+export BASH_XTRACEFD=21
+
+SCRIPT_FILE="$REPO_ROOT/scripts/security/dns-doh.sh"
+BASH_BIN="$(command -v bash)"
+
+trap cov_teardown_sandbox EXIT
+cov_setup_sandbox
+
+_link_real_tools() {
+  local dir="$1" t p
+  shift
+  for t in "$@"; do
+    p="$(command -v "$t" 2>/dev/null || true)"
+    [[ -n "$p" ]] && ln -sf "$p" "$dir/$t"
+  done
+}
+_base="$DOTFILES_COV_TMPDIR/base"
+mkdir -p "$_base"
+_link_real_tools "$_base" bash dirname uname tput cat grep sed awk head tr mkdir date
+
+# resolvectl + sudo shims that record their argv so the apply path
+# can be asserted without touching systemd-resolved.
+_sysd="$DOTFILES_COV_TMPDIR/sysd"
+mkdir -p "$_sysd"
+cat >"$_sysd/resolvectl" <<'SHIM'
+#!/usr/bin/env bash
+printf 'resolvectl %s\n' "$*" >>"${DOH_SHIM_LOG:?}"
+SHIM
+cat >"$_sysd/sudo" <<'SHIM'
+#!/usr/bin/env bash
+printf 'sudo %s\n' "$*" >>"${DOH_SHIM_LOG:?}"
+exec "$@"
+SHIM
+chmod +x "$_sysd/resolvectl" "$_sysd/sudo"
+export DOH_SHIM_LOG="$DOTFILES_COV_TMPDIR/doh.log"
+
+_run() { # <platform> <path> [args]
+  local platform="$1" path="$2"
+  shift 2
+  _DOT_PLATFORM_ID="$platform" PATH="$path" "$BASH_BIN" "$SCRIPT_FILE" "$@" 2>&1
+}
+
+test_start "disabled_by_default_exits_1"
+_out="$(DOTFILES_DOH='' _run linux "$_sysd:$_base")"
+_rc=$?
+assert_equals 1 "$_rc" "opt-in gate exits 1"
+assert_contains "disabled by default" "$_out" "opt-in hint printed"
+assert_contains "DOTFILES_DOH=1" "$_out" "re-run hint printed"
+
+test_start "dry_run_linux_prints_planned_commands"
+: >"$DOH_SHIM_LOG"
+_out="$(_run linux "$_sysd:$_base" --dry-run)"
+_rc=$?
+assert_equals 0 "$_rc" "dry-run exits 0"
+assert_contains "dry-run (no changes will be made)" "$_out" "dry-run mode announced"
+assert_contains "sudo resolvectl dns-over-https on" "$_out" "planned command printed"
+assert_equals "" "$(cat "$DOH_SHIM_LOG")" "dry-run never invokes resolvectl"
+
+test_start "apply_linux_runs_resolvectl_through_sudo"
+: >"$DOH_SHIM_LOG"
+_out="$(DOTFILES_DOH=1 _run linux "$_sysd:$_base")"
+_rc=$?
+assert_equals 0 "$_rc" "apply exits 0"
+assert_contains "systemd-resolved DoH" "$_out" "enable message printed"
+assert_contains "sudo resolvectl dns-over-https on" "$(cat "$DOH_SHIM_LOG")" "DoH toggled via sudo"
+assert_contains "resolvectl dns 1.1.1.1 1.0.0.1" "$(cat "$DOH_SHIM_LOG")" "resolvers set via sudo"
+
+test_start "apply_wsl_without_resolvectl_exits_1"
+_out="$(DOTFILES_DOH=1 _run wsl "$_base")"
+_rc=$?
+assert_equals 1 "$_rc" "missing resolvectl exits 1"
+assert_contains "systemd-resolved" "$_out" "resolved not detected reported"
+
+test_start "macos_points_at_browser_exits_0"
+_out="$(DOTFILES_DOH=1 _run macos "$_base")"
+_rc=$?
+assert_equals 0 "$_rc" "macos exits 0"
+assert_contains "DoH in your browser" "$_out" "browser hint printed"
+
+test_start "unsupported_platform_exits_1"
+_out="$(DOTFILES_DOH=1 _run bsd "$_base")"
+_rc=$?
+assert_equals 1 "$_rc" "unsupported platform exits 1"
+assert_contains "Unsupported OS" "$_out" "unsupported platform reported"
+
+echo "RESULTS:$TESTS_RUN:$TESTS_PASSED:$TESTS_FAILED"

--- a/tests/unit/security/test_security_encryption_check_branches.sh
+++ b/tests/unit/security/test_security_encryption_check_branches.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2015-2026 Sebastien Rousseau
+# shellcheck disable=SC1090,SC1091,SC2034
+#
+# Branch coverage for scripts/security/encryption-check.sh. The
+# platform is pinned through _DOT_PLATFORM_ID (honoured by
+# lib/dot/platform.sh) and the probes (`fdesetup`, `lsblk`, `rg`)
+# are PATH shims, so every arm of the case statement runs on any
+# host without reading real disk-encryption state.
+#
+# AUTO-GENERATED: false (hand-written)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+source "$SCRIPT_DIR/../../framework/assertions.sh"
+source "$SCRIPT_DIR/../../framework/coverage_helpers.sh"
+
+# Route child xtrace to the runner's trace stream even when a probe
+# captures 2>&1 (fd 19: fd 9 is taken by lock handling elsewhere).
+exec 21>&2
+export BASH_XTRACEFD=21
+
+SCRIPT_FILE="$REPO_ROOT/scripts/security/encryption-check.sh"
+BASH_BIN="$(command -v bash)"
+
+trap cov_teardown_sandbox EXIT
+cov_setup_sandbox
+
+# A PATH that carries only the tools ui.sh/platform.sh need, plus
+# whatever shim a case adds. Lets a test remove `fdesetup`, `rg` or
+# `lsblk` from view on hosts that ship them.
+_link_real_tools() {
+  local dir="$1" t p
+  shift
+  for t in "$@"; do
+    p="$(command -v "$t" 2>/dev/null || true)"
+    [[ -n "$p" ]] && ln -sf "$p" "$dir/$t"
+  done
+}
+_base="$DOTFILES_COV_TMPDIR/base"
+mkdir -p "$_base"
+_link_real_tools "$_base" bash dirname uname tput cat grep sed awk head tr mkdir date
+
+_mk_shim() { # <dir> <name> <body>
+  mkdir -p "$1"
+  printf '#!/usr/bin/env bash\n%s\n' "$3" >"$1/$2"
+  chmod +x "$1/$2"
+}
+
+_run() { # <platform> <path> [args]
+  local platform="$1" path="$2"
+  shift 2
+  _DOT_PLATFORM_ID="$platform" PATH="$path" "$BASH_BIN" "$SCRIPT_FILE" "$@" 2>&1
+}
+
+test_start "macos_filevault_on_exits_0"
+_d="$DOTFILES_COV_TMPDIR/fv-on"
+_mk_shim "$_d" fdesetup 'echo "FileVault is On."'
+_out="$(_run macos "$_d:$_base")"
+_rc=$?
+assert_equals 0 "$_rc" "FileVault on exits 0"
+assert_contains "FileVault is On" "$_out" "fdesetup status echoed"
+
+test_start "macos_filevault_off_exits_1"
+_d="$DOTFILES_COV_TMPDIR/fv-off"
+_mk_shim "$_d" fdesetup 'echo "FileVault is Off."'
+_out="$(_run macos "$_d:$_base")"
+_rc=$?
+assert_equals 1 "$_rc" "FileVault off exits 1"
+assert_contains "appears to be off" "$_out" "off warning printed"
+
+test_start "macos_without_fdesetup_exits_1"
+_out="$(_run macos "$_base")"
+_rc=$?
+assert_equals 1 "$_rc" "no fdesetup exits 1"
+assert_contains "not found" "$_out" "missing fdesetup reported"
+
+test_start "linux_luks_detected_via_rg_exits_0"
+_d="$DOTFILES_COV_TMPDIR/luks-rg"
+_mk_shim "$_d" lsblk 'printf "NAME FSTYPE\nsda1 crypto_LUKS\n"'
+_mk_shim "$_d" rg 'exec grep -Ei "${@: -1}"'
+_out="$(_run linux "$_d:$_base")"
+_rc=$?
+assert_equals 0 "$_rc" "LUKS via rg exits 0"
+assert_contains "encrypted block device detected" "$_out" "LUKS reported"
+
+test_start "linux_luks_detected_via_grep_exits_0"
+_d="$DOTFILES_COV_TMPDIR/luks-grep"
+_mk_shim "$_d" lsblk 'printf "NAME FSTYPE\nnvme0n1p2 crypto_LUKS\n"'
+_out="$(_run wsl "$_d:$_base")"
+_rc=$?
+assert_equals 0 "$_rc" "LUKS via grep exits 0"
+assert_contains "encrypted block device detected" "$_out" "LUKS reported without rg"
+
+test_start "linux_no_crypto_volume_exits_1"
+_d="$DOTFILES_COV_TMPDIR/nocrypto"
+_mk_shim "$_d" lsblk 'printf "NAME FSTYPE\nsda1 ext4\n"'
+_mk_shim "$_d" rg 'exec grep -Ei "${@: -1}"'
+_out="$(_run linux "$_d:$_base")"
+_rc=$?
+assert_equals 1 "$_rc" "no crypto volume exits 1"
+assert_contains "no crypto volume detected" "$_out" "warning printed"
+
+test_start "linux_without_lsblk_falls_through_exit_0"
+_out="$(_run linux "$_base")"
+_rc=$?
+assert_equals 0 "$_rc" "no lsblk falls through the case with rc 0"
+assert_contains "Encryption Check" "$_out" "header still printed"
+
+test_start "unsupported_platform_exits_1"
+_out="$(_run bsd "$_base")"
+_rc=$?
+assert_equals 1 "$_rc" "unsupported platform exits 1"
+assert_contains "Unsupported OS" "$_out" "unsupported platform reported"
+
+echo "RESULTS:$TESTS_RUN:$TESTS_PASSED:$TESTS_FAILED"

--- a/tests/unit/tools/test_bin_clipboard_and_wsl.sh
+++ b/tests/unit/tools/test_bin_clipboard_and_wsl.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2015-2026 Sebastien Rousseau
+# shellcheck disable=SC1090,SC1091,SC2034
+#
+# Behaviour tests for the two platform-shim CLIs in dot_local/bin:
+#
+#   cb  — universal clipboard: macOS pbcopy/pbpaste, WSL clip.exe /
+#         powershell.exe, Wayland wl-copy, X11 xclip/xsel, and the
+#         "no backend" error.
+#   win — WSL Windows-interop shim: the non-WSL refusal, the missing
+#         argument usage and wslpath translation of existing paths.
+#
+# Both scripts branch on `uname -s` and on `grep -qi microsoft
+# /proc/version`, neither of which a macOS or Linux CI host can
+# provide for the *other* platform, so this drives them through
+# PATH-shadowed `uname`/`grep` plus fake backends. Every backend
+# records what it received into a log the assertions read back.
+#
+# AUTO-GENERATED: false (hand-written)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+source "$SCRIPT_DIR/../../framework/assertions.sh"
+source "$SCRIPT_DIR/../../framework/coverage_helpers.sh"
+
+# Hand children a copy of the real stderr so their xtrace still reaches
+# the coverage runner even though the probes capture output with 2>&1.
+exec 21>&2
+export BASH_XTRACEFD=21
+
+CB="$REPO_ROOT/defaults/dot_local/bin/executable_cb"
+WIN="$REPO_ROOT/defaults/dot_local/bin/executable_win"
+# Run the scripts under the same bash the harness uses: a PATH stub that
+# resolved to /bin/bash 3.2 would both change behaviour and truncate the
+# xtrace records the coverage runner reads.
+BASH_BIN="$(command -v bash)"
+
+trap cov_teardown_sandbox EXIT
+cov_setup_sandbox
+
+LOG="$DOTFILES_COV_TMPDIR/backend.log"
+: >"$LOG"
+
+# _shim <dir> <name> [body…] — record the call, then run the body.
+_shim() {
+  local dir="$1" name="$2"
+  shift 2
+  mkdir -p "$dir"
+  {
+    echo '#!/usr/bin/env bash'
+    printf 'printf "%s %%s\\n" "$*" >>"%s"\n' "$name" "$LOG"
+    printf 'cat >/dev/null 2>&1 || true\n'
+    printf '%s\n' "$@"
+  } >"$dir/$name"
+  chmod +x "$dir/$name"
+}
+
+# Minimal real tools every branch needs, so PATH can stay tiny.
+BASE="$DOTFILES_COV_TMPDIR/base"
+mkdir -p "$BASE"
+for t in bash cat echo printf tr command; do
+  p="$(command -v "$t" 2>/dev/null || true)"
+  [[ -n "$p" ]] && ln -sf "$p" "$BASE/$t"
+done
+
+# _uname_shim <dir> <value> — `uname -s` answers <value>.
+_uname_shim() {
+  mkdir -p "$1"
+  printf '#!/usr/bin/env bash\necho "%s"\n' "$2" >"$1/uname"
+  chmod +x "$1/uname"
+}
+
+# _grep_shim <dir> <microsoft?> — stands in for the `grep -qi microsoft
+# /proc/version` WSL probe; other greps go to the real binary.
+_grep_shim() {
+  local real
+  real="$(command -v grep)"
+  mkdir -p "$1"
+  cat >"$1/grep" <<EOF
+#!/usr/bin/env bash
+if [[ "\$*" == *microsoft*/proc/version* ]]; then
+  exit ${2}
+fi
+exec "$real" "\$@"
+EOF
+  chmod +x "$1/grep"
+}
+
+_run() { # <PATH> <script> [args…]  (stdin passes through)
+  local path="$1" script="$2"
+  shift 2
+  PATH="$path" "$BASH_BIN" "$script" "$@" 2>&1
+}
+
+# ── cb: macOS ────────────────────────────────────────────────────────
+test_start "cb_macos_copies_stdin_to_pbcopy"
+_d="$DOTFILES_COV_TMPDIR/cb-mac"
+_uname_shim "$_d" Darwin
+_shim "$_d" pbcopy
+: >"$LOG"
+_out="$(printf 'clip me\n' | _run "$_d:$BASE" "$CB")"
+_rc=$?
+assert_equals 0 "$_rc" "cb exits 0 on macOS"
+assert_contains "Copied to macOS clipboard" "$_out" "confirmation printed"
+assert_file_contains "$LOG" "pbcopy" "pbcopy received the copy"
+
+# ── cb: WSL ──────────────────────────────────────────────────────────
+test_start "cb_wsl_copies_via_clip_exe"
+_d="$DOTFILES_COV_TMPDIR/cb-wsl"
+_uname_shim "$_d" Linux
+_grep_shim "$_d" 0
+_shim "$_d" clip.exe
+: >"$LOG"
+_out="$(printf 'to windows\n' | _run "$_d:$BASE" "$CB")"
+_rc=$?
+assert_equals 0 "$_rc" "cb exits 0 under WSL"
+assert_contains "Copied to Windows clipboard (WSL)" "$_out" "WSL confirmation printed"
+assert_file_contains "$LOG" "clip.exe" "clip.exe received the copy"
+
+test_start "cb_wsl_without_interop_fails"
+_d="$DOTFILES_COV_TMPDIR/cb-wsl-bare"
+_uname_shim "$_d" Linux
+_grep_shim "$_d" 0
+_out="$(printf 'x\n' | _run "$_d:$BASE" "$CB")"
+_rc=$?
+assert_equals 1 "$_rc" "missing clip.exe exits 1"
+assert_contains "clip.exe not on PATH" "$_out" "interop failure explained"
+
+# ── cb: Wayland / X11 / none ─────────────────────────────────────────
+test_start "cb_wayland_prefers_wl_copy"
+_d="$DOTFILES_COV_TMPDIR/cb-wl"
+_uname_shim "$_d" Linux
+_grep_shim "$_d" 1
+_shim "$_d" wl-copy
+: >"$LOG"
+_out="$(printf 'wayland\n' | WAYLAND_DISPLAY=wayland-0 _run "$_d:$BASE" "$CB")"
+assert_equals 0 "$?" "cb exits 0 on Wayland"
+assert_contains "Copied to Wayland clipboard" "$_out" "Wayland confirmation printed"
+assert_file_contains "$LOG" "wl-copy" "wl-copy received the copy"
+
+test_start "cb_x11_falls_back_to_xclip_then_xsel"
+_d="$DOTFILES_COV_TMPDIR/cb-x11"
+_uname_shim "$_d" Linux
+_grep_shim "$_d" 1
+_shim "$_d" xclip
+: >"$LOG"
+_out="$(printf 'x11\n' | _run "$_d:$BASE" "$CB")"
+assert_contains "Copied to X11 clipboard" "$_out" "xclip branch taken"
+assert_file_contains "$LOG" "xclip -selection clipboard" "xclip got the selection flag"
+
+_d="$DOTFILES_COV_TMPDIR/cb-xsel"
+_uname_shim "$_d" Linux
+_grep_shim "$_d" 1
+_shim "$_d" xsel
+: >"$LOG"
+_out="$(printf 'xsel\n' | _run "$_d:$BASE" "$CB")"
+assert_contains "Copied to X11 clipboard (xsel)" "$_out" "xsel fallback taken"
+assert_file_contains "$LOG" "xsel -b" "xsel got the clipboard flag"
+
+test_start "cb_without_any_backend_fails"
+_d="$DOTFILES_COV_TMPDIR/cb-none"
+_uname_shim "$_d" Linux
+_grep_shim "$_d" 1
+_out="$(printf 'nope\n' | _run "$_d:$BASE" "$CB")"
+_rc=$?
+assert_equals 1 "$_rc" "no backend exits 1"
+assert_contains "no clipboard backend found" "$_out" "install hint printed"
+
+test_start "cb_unknown_os_is_a_no_op"
+_d="$DOTFILES_COV_TMPDIR/cb-other"
+_uname_shim "$_d" SunOS
+_out="$(printf 'x\n' | _run "$_d:$BASE" "$CB")"
+assert_equals 0 "$?" "unknown OS exits 0"
+assert_equals "" "$_out" "and prints nothing"
+
+# ── win ──────────────────────────────────────────────────────────────
+test_start "win_refuses_outside_wsl"
+_d="$DOTFILES_COV_TMPDIR/win-nonwsl"
+_grep_shim "$_d" 1
+_out="$(_run "$_d:$BASE" "$WIN" notepad.exe)"
+_rc=$?
+assert_equals 1 "$_rc" "non-WSL exits 1"
+assert_contains "only for WSL systems" "$_out" "refusal explained"
+
+test_start "win_translates_existing_paths_and_passes_the_rest"
+_d="$DOTFILES_COV_TMPDIR/win-wsl"
+_grep_shim "$_d" 0
+_shim "$_d" wslpath 'echo "C:\\translated"'
+_shim "$_d" notepad.exe
+_file="$DOTFILES_COV_TMPDIR/real-file.txt"
+: >"$_file"
+: >"$LOG"
+_out="$(_run "$_d:$BASE" "$WIN" notepad.exe "$_file" /flag)"
+_rc=$?
+assert_equals 0 "$_rc" "wsl invocation exits 0"
+assert_file_contains "$LOG" 'wslpath -w' "existing path handed to wslpath"
+assert_file_contains "$LOG" 'notepad.exe C:\translated /flag' "translated path and passthrough arg forwarded"
+
+echo "RESULTS:$TESTS_RUN:$TESTS_PASSED:$TESTS_FAILED"

--- a/tests/unit/tools/test_bin_transcoders_behavior.sh
+++ b/tests/unit/tools/test_bin_transcoders_behavior.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2015-2026 Sebastien Rousseau
+# shellcheck disable=SC1090,SC1091,SC2034
+#
+# Behaviour tests for four small dot_local/bin CLIs:
+#
+#   b64       — base64 transcoder: encode/decode, URL-safe mode and its
+#               padding fix-up, argument vs stdin input, help.
+#   jsonv     — JSON validator: jq path, python3 fallback, --format,
+#               --quiet, unknown option, file vs stdin.
+#   dtags     — Docker Hub tag lister: prerequisite check, usage, and
+#               the buffered sort with a fake registry response.
+#   rec-start — history disabling: nothing to do, backup, already
+#               backed up, and an unwritable history file.
+#
+# Network and clipboard access are impossible here: `curl` is a PATH
+# shim serving canned JSON and every history file lives under the
+# sandbox HOME.
+#
+# AUTO-GENERATED: false (hand-written)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+source "$SCRIPT_DIR/../../framework/assertions.sh"
+source "$SCRIPT_DIR/../../framework/coverage_helpers.sh"
+
+# Hand children a copy of the real stderr so their xtrace still reaches
+# the coverage runner even though the probes capture output with 2>&1.
+exec 21>&2
+export BASH_XTRACEFD=21
+
+BIN="$REPO_ROOT/defaults/dot_local/bin"
+# Same bash as the harness: a /bin/bash 3.2 stub would change behaviour
+# and truncate the xtrace the coverage runner reads.
+BASH_BIN="$(command -v bash)"
+
+trap cov_teardown_sandbox EXIT
+cov_setup_sandbox
+
+_run() { # <script> [args…]
+  local script="$1"
+  shift
+  "$BASH_BIN" "$script" "$@" 2>&1
+}
+
+# ── b64 ──────────────────────────────────────────────────────────────
+B64="$BIN/executable_b64"
+
+test_start "b64_encodes_and_decodes_an_argument"
+_out="$(_run "$B64" "Hello World")"
+assert_equals 0 "$?" "encode exits 0"
+assert_equals "SGVsbG8gV29ybGQ=" "$(printf '%s' "$_out" | tr -d '\n')" "argument encoded"
+_out="$(_run "$B64" --decode "SGVsbG8gV29ybGQ=")"
+assert_equals "Hello World" "$(printf '%s' "$_out" | tr -d '\n')" "argument decoded"
+
+test_start "b64_reads_stdin_when_no_argument_is_given"
+_out="$(printf 'piped' | _run "$B64")"
+assert_equals 0 "$?" "stdin encode exits 0"
+assert_equals "cGlwZWQ=" "$(printf '%s' "$_out" | tr -d '\n')" "stdin encoded"
+
+test_start "b64_url_safe_mode_round_trips_without_padding"
+# 0xFB 0xFF 0xBE encodes to "+/++" in standard base64, so the URL-safe
+# form exercises BOTH substitutions: + → - and / → _.
+_out="$(printf '\373\377\276' | _run "$B64" --url)"
+_enc="$(printf '%s' "$_out" | tr -d '\n')"
+assert_equals "-_--" "$_enc" "URL-safe alphabet used (both + and / mapped)"
+# Decoding re-pads and maps back. A leading `-` in tr's first set is an
+# option to BSD tr, which broke this path on macOS until it was quoted
+# with `--`; assert on the decoded bytes, not just the exit code.
+_out="$(_run "$B64" -d -u "$_enc" | od -An -tx1 | tr -s ' ')"
+assert_equals 0 "$?" "URL-safe decode exits 0 after re-padding"
+assert_contains "fb ff be" "$_out" "URL-safe decode returns the original bytes"
+
+test_start "b64_help_on_demand_and_on_an_empty_tty_less_invocation"
+_out="$(_run "$B64" --help)"
+assert_equals 0 "$?" "--help exits 0"
+assert_contains "Usage: b64 [options] [string]" "$_out" "usage printed"
+assert_contains "Base64 Transcoder" "$_out" "non-tty header printed"
+_out="$(_run "$B64" -e -u --help)"
+assert_contains "URL-safe mode" "$_out" "help still reachable after other flags"
+
+# ── jsonv ────────────────────────────────────────────────────────────
+JSONV="$BIN/executable_jsonv"
+_json="$DOTFILES_COV_TMPDIR/good.json"
+printf '{"a":[1,2],"b":"x"}\n' >"$_json"
+_bad="$DOTFILES_COV_TMPDIR/bad.json"
+printf '{"a":\n' >"$_bad"
+
+test_start "jsonv_validates_a_file_and_reports_the_source"
+_out="$(_run "$JSONV" "$_json")"
+assert_equals 0 "$?" "valid JSON exits 0"
+assert_contains "Valid JSON ($_json)" "$_out" "file named in the report"
+
+test_start "jsonv_rejects_invalid_json"
+_out="$(_run "$JSONV" "$_bad")"
+assert_equals 1 "$?" "invalid JSON exits 1"
+assert_contains "Invalid JSON" "$_out" "invalid report printed"
+
+test_start "jsonv_reads_stdin_and_labels_it"
+_out="$(printf '{"ok":true}' | _run "$JSONV")"
+assert_equals 0 "$?" "stdin validation exits 0"
+assert_contains "Valid JSON (stdin)" "$_out" "stdin labelled"
+
+test_start "jsonv_format_pretty_prints"
+_out="$(_run "$JSONV" --format "$_json")"
+assert_equals 0 "$?" "--format exits 0"
+assert_contains '"a"' "$_out" "formatted body printed"
+assert_contains "Valid JSON" "$_out" "still reports validity"
+
+test_start "jsonv_quiet_suppresses_the_success_line"
+_out="$(_run "$JSONV" --quiet "$_json")"
+assert_equals 0 "$?" "--quiet exits 0"
+assert_equals "" "$_out" "no output in quiet mode"
+
+test_start "jsonv_unknown_option_exits_1"
+_out="$(_run "$JSONV" --nope "$_json")"
+assert_equals 1 "$?" "unknown option exits 1"
+assert_contains "Unknown option: --nope" "$_out" "option named"
+
+test_start "jsonv_falls_back_to_python3_without_jq"
+# PATH without jq — python3 must carry both the validate and the
+# --format branch.
+_nojq="$DOTFILES_COV_TMPDIR/nojq"
+mkdir -p "$_nojq"
+for t in bash cat printf echo python3; do
+  p="$(command -v "$t" 2>/dev/null || true)"
+  [[ -n "$p" ]] && ln -sf "$p" "$_nojq/$t"
+done
+_out="$(PATH="$_nojq" "$BASH_BIN" "$JSONV" "$_json" 2>&1)"
+assert_equals 0 "$?" "python3 fallback validates"
+assert_contains "Valid JSON" "$_out" "fallback reports validity"
+_out="$(PATH="$_nojq" "$BASH_BIN" "$JSONV" --format "$_json" 2>&1)"
+assert_contains '"a"' "$_out" "python3 -m json.tool formatted the document"
+
+test_start "jsonv_without_jq_or_python3_reports_the_missing_prerequisite"
+_bare="$DOTFILES_COV_TMPDIR/bare-jsonv"
+mkdir -p "$_bare"
+for t in bash cat printf echo; do
+  p="$(command -v "$t" 2>/dev/null || true)"
+  [[ -n "$p" ]] && ln -sf "$p" "$_bare/$t"
+done
+_out="$(PATH="$_bare" "$BASH_BIN" "$JSONV" "$_json" 2>&1)"
+_rc=$?
+assert_equals 1 "$_rc" "missing prerequisites exit 1"
+assert_contains "jq or python3 required" "$_out" "prerequisite named"
+
+# ── dtags ────────────────────────────────────────────────────────────
+DTAGS="$BIN/executable_dtags"
+_dt="$DOTFILES_COV_TMPDIR/dtags-bin"
+mkdir -p "$_dt"
+for t in bash cat printf echo sort command; do
+  p="$(command -v "$t" 2>/dev/null || true)"
+  [[ -n "$p" ]] && ln -sf "$p" "$_dt/$t"
+done
+cat >"$_dt/curl" <<'SHIM'
+#!/usr/bin/env bash
+printf '{"results":[{"name":"3.9"},{"name":"3.10"},{"name":"3.11"}]}\n'
+SHIM
+_realjq="$(command -v jq || true)"
+[[ -n "$_realjq" ]] && ln -sf "$_realjq" "$_dt/jq"
+chmod +x "$_dt/curl"
+
+test_start "dtags_lists_sorted_tags_from_the_registry"
+if [[ -n "$_realjq" ]]; then
+  _out="$(PATH="$_dt" "$BASH_BIN" "$DTAGS" python 2>&1)"
+  assert_equals 0 "$?" "dtags exits 0"
+  assert_contains "3.11" "$_out" "tag from the response listed"
+  assert_equals "3.9
+3.10
+3.11" "$_out" "version sort orders 3.9 before 3.10"
+else
+  echo "  SKIP: jq unavailable"
+fi
+
+test_start "dtags_requires_an_image_argument"
+_out="$(PATH="$_dt" "$BASH_BIN" "$DTAGS" 2>&1)"
+assert_equals 1 "$?" "no argument exits 1"
+assert_contains "Usage: dtags <image>" "$_out" "usage printed"
+
+test_start "dtags_reports_a_missing_prerequisite"
+_bare="$DOTFILES_COV_TMPDIR/bare-dtags"
+mkdir -p "$_bare"
+for t in bash cat printf echo sort; do
+  p="$(command -v "$t" 2>/dev/null || true)"
+  [[ -n "$p" ]] && ln -sf "$p" "$_bare/$t"
+done
+_out="$(PATH="$_bare" "$BASH_BIN" "$DTAGS" python 2>&1)"
+_rc=$?
+assert_equals 1 "$_rc" "missing curl exits 1"
+assert_contains "dtags requires curl" "$_out" "missing tool named"
+
+# ── rec-start ────────────────────────────────────────────────────────
+REC="$BIN/executable_rec-start"
+
+test_start "rec_start_reports_when_there_is_nothing_to_disable"
+_h="$DOTFILES_COV_TMPDIR/rec-empty"
+mkdir -p "$_h"
+_out="$(HOME="$_h" HISTFILE="" _run "$REC")"
+assert_equals 0 "$?" "no history files exits 0"
+assert_contains "No history files found" "$_out" "explains there is nothing to do"
+
+test_start "rec_start_backs_up_every_history_file_it_finds"
+_h="$DOTFILES_COV_TMPDIR/rec-full"
+mkdir -p "$_h/.local/share/fish"
+printf 'secret\n' >"$_h/.bash_history"
+printf 'fish\n' >"$_h/.local/share/fish/fish_history"
+printf 'zsh\n' >"$_h/.zsh_history"
+_out="$(HOME="$_h" HISTFILE="$_h/.zsh_history" _run "$REC")"
+_rc=$?
+assert_equals 0 "$_rc" "backup run exits 0"
+assert_contains "Recording mode ON (3 files backed up)" "$_out" "counts every file"
+assert_file_exists "$_h/.zsh_history.bak" "HISTFILE backed up"
+assert_file_exists "$_h/.bash_history.bak" "bash history backed up"
+assert_file_exists "$_h/.local/share/fish/fish_history.bak" "fish history backed up"
+assert_file_not_exists "$_h/.zsh_history" "original moved, not copied"
+
+test_start "rec_start_is_idempotent_and_says_so"
+printf 'again\n' >"$_h/.zsh_history"
+_out="$(HOME="$_h" HISTFILE="$_h/.zsh_history" _run "$REC")"
+_rc=$?
+assert_equals 1 "$_rc" "second run exits 1"
+assert_contains "Already backed up: $_h/.zsh_history" "$_out" "names the file it skipped"
+assert_contains "History already disabled. Run rec-stop first." "$_out" "tells the user what to do"
+
+test_start "rec_start_reports_a_history_file_it_cannot_move"
+_h="$DOTFILES_COV_TMPDIR/rec-ro"
+mkdir -p "$_h/locked"
+printf 'x\n' >"$_h/locked/.zsh_history"
+chmod 555 "$_h/locked"
+_out="$(HOME="$_h" HISTFILE="$_h/locked/.zsh_history" _run "$REC")"
+_rc=$?
+chmod 755 "$_h/locked"
+assert_equals 1 "$_rc" "unmovable history exits 1"
+assert_contains "Failed to back up: $_h/locked/.zsh_history" "$_out" "failure reported"
+
+echo "RESULTS:$TESTS_RUN:$TESTS_PASSED:$TESTS_FAILED"

--- a/tests/unit/tools/test_gl_and_wrappers_behavior.sh
+++ b/tests/unit/tools/test_gl_and_wrappers_behavior.sh
@@ -1,0 +1,260 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2015-2026 Sebastien Rousseau
+# shellcheck disable=SC1090,SC1091,SC2034,SC2016
+#
+# Behaviour tests for the interactive-adjacent tools whose logic can
+# still be checked without a terminal:
+#
+#   gl                    — prerequisite checks, the not-a-repo guard,
+#                           --side mode, and the commit-URL normaliser
+#                           its Ctrl+O binding calls (GitHub, GitLab,
+#                           Bitbucket, SSH and HTTPS remotes).
+#   lolcat-wrap.sh        — colouriser present vs absent, file args vs
+#                           stdin.
+#   install-file-icons.sh — macOS with and without `fileicon`, Linux
+#                           with and without `gsettings`, other OSes.
+#   check-shell-preamble  — the compat shim delegates to tools/ci/.
+#
+# `fzf`, `delta`, `git`, `open`, `lolcat`, `fileicon` and `gsettings`
+# are PATH shims that record what they were asked to do; nothing here
+# opens a browser, touches the desktop settings or needs a TTY.
+#
+# AUTO-GENERATED: false (hand-written)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+source "$SCRIPT_DIR/../../framework/assertions.sh"
+source "$SCRIPT_DIR/../../framework/coverage_helpers.sh"
+
+# Hand children a copy of the real stderr so their xtrace still reaches
+# the coverage runner even though the probes capture output with 2>&1.
+exec 21>&2
+export BASH_XTRACEFD=21
+
+GL="$REPO_ROOT/defaults/dot_local/bin/executable_gl"
+LOLCAT_WRAP="$REPO_ROOT/scripts/tools/lolcat-wrap.sh"
+ICONS="$REPO_ROOT/scripts/theme/install-file-icons.sh"
+PREAMBLE_SHIM="$REPO_ROOT/scripts/ci/check-shell-preamble.sh"
+# Same bash as the harness — a /bin/bash 3.2 stub would truncate the
+# xtrace records the coverage runner reads.
+BASH_BIN="$(command -v bash)"
+
+trap cov_teardown_sandbox EXIT
+cov_setup_sandbox
+
+LOG="$DOTFILES_COV_TMPDIR/tool.log"
+: >"$LOG"
+
+_record_shim() { # <dir> <name> [extra body…]
+  local dir="$1" name="$2"
+  shift 2
+  mkdir -p "$dir"
+  {
+    echo '#!/usr/bin/env bash'
+    printf 'printf "%s %%s\\n" "$*" >>"%s"\n' "$name" "$LOG"
+    printf '%s\n' "$@"
+  } >"$dir/$name"
+  chmod +x "$dir/$name"
+}
+
+_base_tools() { # <dir> — link the real coreutils the scripts need
+  local dir="$1" t p
+  mkdir -p "$dir"
+  for t in bash cat printf echo sed tr cut sort head env dirname basename \
+    uname command ls wc grep; do
+    p="$(command -v "$t" 2>/dev/null || true)"
+    [[ -n "$p" ]] && ln -sf "$p" "$dir/$t"
+  done
+}
+
+BASE="$DOTFILES_COV_TMPDIR/base"
+_base_tools "$BASE"
+
+# ── gl: prerequisites ────────────────────────────────────────────────
+test_start "gl_reports_each_missing_prerequisite"
+_out="$(PATH="$BASE" "$BASH_BIN" "$GL" 2>&1)"
+_rc=$?
+assert_equals 1 "$_rc" "missing fzf exits 1"
+assert_contains "gl requires fzf" "$_out" "names the first missing tool"
+
+_d="$DOTFILES_COV_TMPDIR/gl-nodelta"
+_record_shim "$_d" fzf
+_record_shim "$_d" git
+_out="$(PATH="$_d:$BASE" "$BASH_BIN" "$GL" 2>&1)"
+_rc=$?
+assert_equals 1 "$_rc" "missing delta exits 1"
+assert_contains "gl requires delta" "$_out" "names delta"
+
+test_start "gl_refuses_outside_a_git_work_tree"
+_d="$DOTFILES_COV_TMPDIR/gl-norepo"
+_record_shim "$_d" fzf
+_record_shim "$_d" delta
+_record_shim "$_d" git 'exit 128'
+_out="$(PATH="$_d:$BASE" "$BASH_BIN" "$GL" 2>&1)"
+_rc=$?
+assert_equals 1 "$_rc" "outside a repo exits 1"
+assert_contains "gl: not a git repository" "$_out" "explains the refusal"
+
+# ── gl: --side and the fzf hand-off ──────────────────────────────────
+_glbin="$DOTFILES_COV_TMPDIR/gl-ok"
+_record_shim "$_glbin" delta
+_record_shim "$_glbin" open
+_record_shim "$_glbin" fzf 'printf "DELTA_FEATURES=%s\n" "${DELTA_FEATURES:-unset}"'
+cat >"$_glbin/git" <<EOF
+#!/usr/bin/env bash
+printf 'git %s\n' "\$*" >>"$LOG"
+case "\$*" in
+  "rev-parse --is-inside-work-tree") exit 0 ;;
+  "branch --show-current") echo "main" ;;
+  "config --get branch.main.remote") echo "origin" ;;
+  "remote get-url origin") echo "\${GL_TEST_REMOTE-git@github.com:owner/repo.git}" ;;
+  *) : ;;
+esac
+exit 0
+EOF
+chmod +x "$_glbin/git"
+
+test_start "gl_side_mode_exports_delta_side_by_side"
+_out="$(PATH="$_glbin:$BASE" "$BASH_BIN" "$GL" --side 2>&1)"
+_rc=$?
+assert_equals 0 "$_rc" "gl exits 0 once fzf returns"
+assert_contains "DELTA_FEATURES= side-by-side" "$_out" "--side reaches delta through the environment"
+assert_file_contains "$LOG" "fzf --border" "fzf was invoked with the browser bindings"
+
+test_start "gl_passes_git_log_flags_through_to_the_reload_binding"
+: >"$LOG"
+_out="$(PATH="$_glbin:$BASE" "$BASH_BIN" "$GL" --author=nobody 2>&1)"
+assert_equals 0 "$?" "gl exits 0 with extra git flags"
+assert_file_contains "$LOG" -- "--author=nobody" "the flag is embedded in the reload command"
+
+# ── gl: commit-URL normalisation (the Ctrl+O binding) ────────────────
+# The binding runs `bash -c 'source <gl>; open_commit_url <sha>'`, so
+# drive exactly that: source the script (fzf shim returns at once) and
+# call the function.
+_open_url() { # <remote-url> → the URL handed to `open`
+  : >"$LOG"
+  PATH="$_glbin:$BASE" GL_TEST_REMOTE="$1" "$BASH_BIN" -c \
+    'source "$1" >/dev/null 2>&1; open_commit_url deadbee' _ "$GL" >/dev/null 2>&1
+  grep '^open ' "$LOG" | tail -1
+}
+
+test_start "gl_normalises_a_github_ssh_remote"
+assert_equals "open https://github.com/owner/repo/commit/deadbee" \
+  "$(_open_url 'git@github.com:owner/repo.git')" "SSH remote becomes an https commit URL"
+
+test_start "gl_normalises_an_https_remote"
+assert_equals "open https://github.com/owner/repo/commit/deadbee" \
+  "$(_open_url 'https://github.com/owner/repo.git')" "HTTPS remote keeps its host"
+
+test_start "gl_uses_the_gitlab_commit_path"
+assert_equals "open https://gitlab.com/group/proj/-/commit/deadbee" \
+  "$(_open_url 'git@gitlab.com:group/proj.git')" "GitLab uses the /-/commit/ path"
+
+test_start "gl_uses_the_bitbucket_commit_path"
+assert_equals "open https://bitbucket.org/team/proj/commits/deadbee" \
+  "$(_open_url 'git@bitbucket.org:team/proj.git')" "Bitbucket uses the /commits/ path"
+
+test_start "gl_open_commit_url_is_a_no_op_without_a_commit_or_remote"
+: >"$LOG"
+PATH="$_glbin:$BASE" "$BASH_BIN" -c \
+  'source "$1" >/dev/null 2>&1; open_commit_url ""' _ "$GL" >/dev/null 2>&1
+assert_output_not_contains "open http" cat "$LOG"
+: >"$LOG"
+PATH="$_glbin:$BASE" GL_TEST_REMOTE="" "$BASH_BIN" -c \
+  'source "$1" >/dev/null 2>&1; open_commit_url deadbee' _ "$GL" >/dev/null 2>&1
+assert_output_not_contains "open http" cat "$LOG"
+
+test_start "gl_sourcing_does_not_launch_a_second_picker"
+# The Ctrl+O binding sources this file to reuse open_commit_url; that
+# must not re-enter the picker.
+: >"$LOG"
+PATH="$_glbin:$BASE" "$BASH_BIN" -c \
+  'source "$1" >/dev/null 2>&1; open_commit_url deadbee' _ "$GL" >/dev/null 2>&1
+assert_output_not_contains "fzf " cat "$LOG"
+assert_output_contains "open https://github.com/owner/repo/commit/deadbee" cat "$LOG"
+
+# ── lolcat-wrap.sh ───────────────────────────────────────────────────
+_sample="$DOTFILES_COV_TMPDIR/sample.txt"
+printf 'line one\nline two\n' >"$_sample"
+
+test_start "lolcat_wrap_pipes_files_through_lolcat_when_present"
+_d="$DOTFILES_COV_TMPDIR/lol-yes"
+_record_shim "$_d" lolcat 'sed "s/^/rainbow: /"'
+_out="$(PATH="$_d:$BASE" "$BASH_BIN" "$LOLCAT_WRAP" "$_sample" 2>&1)"
+_rc=$?
+assert_equals 0 "$_rc" "file mode exits 0"
+assert_contains "rainbow: line one" "$_out" "file content went through lolcat"
+
+test_start "lolcat_wrap_pipes_stdin_through_lolcat_when_present"
+_out="$(printf 'piped\n' | PATH="$_d:$BASE" "$BASH_BIN" "$LOLCAT_WRAP" 2>&1)"
+assert_equals 0 "$?" "stdin mode exits 0"
+assert_contains "rainbow: piped" "$_out" "stdin went through lolcat"
+
+test_start "lolcat_wrap_falls_back_to_plain_output"
+_out="$(PATH="$BASE" "$BASH_BIN" "$LOLCAT_WRAP" "$_sample" 2>&1)"
+assert_equals 0 "$?" "plain file mode exits 0"
+assert_equals "line one
+line two" "$_out" "file content passed through untouched"
+_out="$(printf 'plain\n' | PATH="$BASE" "$BASH_BIN" "$LOLCAT_WRAP" 2>&1)"
+assert_equals "plain" "$_out" "stdin passed through untouched"
+
+# ── install-file-icons.sh ────────────────────────────────────────────
+_uname_shim() { # <dir> <value>
+  mkdir -p "$1"
+  printf '#!/usr/bin/env bash\necho "%s"\n' "$2" >"$1/uname"
+  chmod +x "$1/uname"
+}
+
+test_start "install_file_icons_macos_paths"
+_d="$DOTFILES_COV_TMPDIR/icons-mac"
+_uname_shim "$_d" Darwin
+_record_shim "$_d" fileicon
+_out="$(PATH="$_d:$BASE" "$BASH_BIN" "$ICONS" 2>&1)"
+assert_equals 0 "$?" "macOS with fileicon exits 0"
+assert_contains "fileicon set <path>" "$_out" "usage hint printed"
+
+_d="$DOTFILES_COV_TMPDIR/icons-mac-bare"
+_uname_shim "$_d" Darwin
+_out="$(PATH="$_d:$BASE" "$BASH_BIN" "$ICONS" 2>&1)"
+assert_contains "brew install fileicon" "$_out" "install hint printed when fileicon is missing"
+
+test_start "install_file_icons_linux_sets_the_gnome_theme"
+_d="$DOTFILES_COV_TMPDIR/icons-linux"
+_uname_shim "$_d" Linux
+_record_shim "$_d" gsettings
+: >"$LOG"
+_out="$(PATH="$_d:$BASE" DOTFILES_ICON_THEME=Numix "$BASH_BIN" "$ICONS" 2>&1)"
+assert_equals 0 "$?" "Linux with gsettings exits 0"
+assert_contains "Set GNOME icon theme to Numix." "$_out" "confirms the theme it set"
+assert_file_contains "$LOG" "gsettings set org.gnome.desktop.interface icon-theme Numix" \
+  "gsettings received the override theme"
+
+_d="$DOTFILES_COV_TMPDIR/icons-linux-bare"
+_uname_shim "$_d" Linux
+_out="$(PATH="$_d:$BASE" "$BASH_BIN" "$ICONS" 2>&1)"
+assert_contains "gsettings not found" "$_out" "falls back to a DE hint"
+
+test_start "install_file_icons_other_os_is_reported_unsupported"
+_d="$DOTFILES_COV_TMPDIR/icons-other"
+_uname_shim "$_d" FreeBSD
+_out="$(PATH="$_d:$BASE" "$BASH_BIN" "$ICONS" 2>&1)"
+assert_equals 0 "$?" "unsupported OS still exits 0"
+assert_contains "Unsupported OS for icon theming." "$_out" "says so"
+
+# ── scripts/ci/check-shell-preamble.sh (compat shim) ─────────────────
+test_start "check_shell_preamble_shim_delegates_to_tools_ci"
+_good="$DOTFILES_COV_TMPDIR/good-preamble.sh"
+printf '#!/usr/bin/env bash\nset -euo pipefail\necho ok\n' >"$_good"
+_out="$("$BASH_BIN" "$PREAMBLE_SHIM" "$_good" 2>&1)"
+_rc=$?
+assert_equals 0 "$_rc" "compliant file passes through the shim"
+
+_bad="$DOTFILES_COV_TMPDIR/bad-preamble.sh"
+printf '#!/usr/bin/env bash\necho no-strict-mode\n' >"$_bad"
+_out="$("$BASH_BIN" "$PREAMBLE_SHIM" "$_bad" 2>&1)"
+_rc=$?
+assert_equals 1 "$_rc" "non-compliant file is rejected through the shim"
+assert_contains "$_bad" "$_out" "the offending file is named"
+
+echo "RESULTS:$TESTS_RUN:$TESTS_PASSED:$TESTS_FAILED"

--- a/tests/unit/tools/test_tools_emoji_picker_behavior.sh
+++ b/tests/unit/tools/test_tools_emoji_picker_behavior.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2015-2026 Sebastien Rousseau
+# shellcheck disable=SC1090,SC1091,SC2034
+#
+# Behaviour tests for scripts/tools/emoji-picker.sh: the missing-list
+# guard, the fzf picker, the `select` fallback when fzf is absent, the
+# empty-selection exit and each clipboard backend it tries in turn
+# (cb, pbcopy, wl-copy, xclip). `fzf` and every clipboard tool are
+# PATH shims that record what they received, so nothing here needs a
+# terminal or touches the real clipboard.
+#
+# AUTO-GENERATED: false (hand-written)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+source "$SCRIPT_DIR/../../framework/assertions.sh"
+source "$SCRIPT_DIR/../../framework/coverage_helpers.sh"
+
+# Hand children a copy of the real stderr so their xtrace still reaches
+# the coverage runner even though the probes capture output with 2>&1.
+exec 21>&2
+export BASH_XTRACEFD=21
+
+PICKER="$REPO_ROOT/scripts/tools/emoji-picker.sh"
+BASH_BIN="$(command -v bash)"
+
+trap cov_teardown_sandbox EXIT
+cov_setup_sandbox
+
+LOG="$DOTFILES_COV_TMPDIR/clipboard.log"
+: >"$LOG"
+
+# Minimal PATH: the host's own fzf/pbcopy would otherwise decide which
+# branch runs.
+BASE="$DOTFILES_COV_TMPDIR/base"
+mkdir -p "$BASE"
+for _t in bash cat printf echo awk sed tr head command; do
+  _p="$(command -v "$_t" 2>/dev/null || true)"
+  [[ -n "$_p" ]] && ln -sf "$_p" "$BASE/$_t"
+done
+
+_shim() { # <dir> <name> [body…]
+  local dir="$1" name="$2"
+  shift 2
+  mkdir -p "$dir"
+  {
+    echo '#!/usr/bin/env bash'
+    printf 'printf "%s %%s\\n" "$*" >>"%s"\n' "$name" "$LOG"
+    printf 'cat >>"%s" 2>/dev/null || true\n' "$LOG"
+    printf '%s\n' "$@"
+  } >"$dir/$name"
+  chmod +x "$dir/$name"
+}
+
+EMOJI_LIST="$DOTFILES_COV_TMPDIR/emoji.txt"
+printf '🚀 rocket\n🐛 bug\n✨ sparkles\n' >"$EMOJI_LIST"
+
+_pick() { # <PATH> [stdin…]
+  EMOJI_FILE="$EMOJI_LIST" PATH="$1" "$BASH_BIN" "$PICKER" 2>&1
+}
+
+test_start "emoji_picker_requires_an_emoji_list"
+_out="$(EMOJI_FILE="$DOTFILES_COV_TMPDIR/absent.txt" PATH="$BASE" "$BASH_BIN" "$PICKER" 2>&1)"
+_rc=$?
+assert_equals 1 "$_rc" "missing list exits 1"
+assert_contains "Emoji list not found" "$_out" "the missing path is reported"
+
+test_start "emoji_picker_uses_fzf_and_prints_only_the_glyph"
+_d="$DOTFILES_COV_TMPDIR/pick-fzf"
+_shim "$_d" fzf 'echo "🐛 bug"'
+: >"$LOG"
+_out="$(_pick "$_d:$BASE" </dev/null)"
+_rc=$?
+assert_equals 0 "$_rc" "a selection exits 0"
+assert_equals "🐛" "$_out" "only the glyph is printed, not the label"
+assert_file_contains "$LOG" "fzf --prompt=emoji>" "fzf was invoked with the picker prompt"
+
+test_start "emoji_picker_copies_through_cb_when_present"
+_d="$DOTFILES_COV_TMPDIR/pick-cb"
+_shim "$_d" fzf 'echo "✨ sparkles"'
+_shim "$_d" cb
+: >"$LOG"
+_out="$(_pick "$_d:$BASE" </dev/null)"
+assert_equals 0 "$?" "copy path exits 0"
+assert_equals "✨" "$_out" "glyph still printed"
+assert_file_contains "$LOG" "✨" "cb received the glyph"
+
+test_start "emoji_picker_falls_back_through_pbcopy_wl_copy_and_xclip"
+for _backend in pbcopy wl-copy xclip; do
+  _d="$DOTFILES_COV_TMPDIR/pick-$_backend"
+  _shim "$_d" fzf 'echo "🚀 rocket"'
+  _shim "$_d" "$_backend"
+  : >"$LOG"
+  _out="$(_pick "$_d:$BASE" </dev/null)"
+  assert_equals "🚀" "$_out" "glyph printed with $_backend available"
+  assert_file_contains "$LOG" "$_backend" "$_backend was chosen as the clipboard backend"
+done
+
+test_start "emoji_picker_still_prints_without_any_clipboard_tool"
+_d="$DOTFILES_COV_TMPDIR/pick-noclip"
+_shim "$_d" fzf 'echo "🐛 bug"'
+_out="$(_pick "$_d:$BASE" </dev/null)"
+assert_equals 0 "$?" "no clipboard backend still exits 0"
+assert_equals "🐛" "$_out" "glyph printed to stdout"
+
+test_start "emoji_picker_fails_when_nothing_is_selected"
+_d="$DOTFILES_COV_TMPDIR/pick-empty"
+_shim "$_d" fzf 'exit 130'
+_out="$(_pick "$_d:$BASE" </dev/null)"
+_rc=$?
+assert_equals 1 "$_rc" "an aborted picker exits 1"
+assert_equals "" "$_out" "nothing is printed"
+
+test_start "emoji_picker_falls_back_to_select_without_fzf"
+# No fzf on PATH: the `select` menu reads the choice number from stdin.
+_out="$(printf '2\n' | _pick "$BASE")"
+_rc=$?
+assert_equals 0 "$_rc" "select fallback exits 0"
+assert_contains "🐛" "$_out" "the numbered choice resolves to its glyph"
+
+echo "RESULTS:$TESTS_RUN:$TESTS_PASSED:$TESTS_FAILED"


### PR DESCRIPTION
Thirty new test files, 356 test cases, 1,043 assertions. The slice goes from 58.17% to 86.19%.

Writing tests to cover existing behaviour turned up eight real defects, each fixed and each proven by a test that fails against the old code.

## The bugs

1. **A fork bomb in the lazy shell loaders.** They `unset -f` names that are actually *aliases*, so initialising the tool re-expanded the name back into the loader and forked until the process limit was hit. Two sibling loaders also re-sourced their init script on every single call.
2. **URL-safe base64 decoding was broken on every macOS host.** The character translation passed a leading dash, which BSD `tr` parses as an option, so `b64 -d -u` always failed.
3. **`dot ai --style` never found its shipped patterns**, because the fallback probed a path that ignores the chezmoi root layout.
4. **`dot ai` died at end of input** rather than prompting, because a bare read under `errexit` killed the script mid-prompt with no message.
5. **One malformed line aborted the whole fleet drift history** instead of falling back to placeholders.
6. **A documented exit status was dead code** in the version consistency checker: a missing key exited 1 silently, indistinguishable from genuine drift.
7. **A key binding in `gl` spawned a second hidden picker**, because it re-sourced the script and re-ran everything.
8. **The package count was off by one**, because a newline was stripped before counting lines.

## Coverage honesty

98% is not reachable with the current instrumentation and this branch does not pretend otherwise. Of the 422 lines still unhit across the slice, 256 (about 61%) are lines bash never emits a trace record for: function headers, multi-word case labels, and the interiors of multi-line commands such as embedded awk and jq programs. The remaining 166 are genuine branches, concentrated in three files and named in the agent's notes.

No exclusions were added. Two exclusion markers left in the tree by an earlier helper were reverted before the first commit.

## Two seams, both justified

One resolves the double-picker bug above. The other adds a repo-root override matching the pattern two sibling scripts already use, and incidentally fixed a measurement hole: the old fixture symlinked the script into a temporary tree, and because trace paths are resolved after teardown, every line was being discarded as outside the repository.

## Findings reported rather than changed

`dot agents render` never writes its intended title, because the body strips the heading before the retitling step runs. The committed file has the same shape, so fixing it would re-render eleven harness files and belongs in its own change. Current behaviour is pinned by a test. Three smaller issues in the alias manifest and scorecard scripts are documented in the same way.

## Gates

Shellcheck clean at both the error severity CI normally uses and the stricter warning severity the portability job uses. Also shfmt, copyright headers across 966 files, preamble, TLS and chmod checks, command index drift, and version consistency. Every pre-existing test touching a changed source was re-run and passes.

Signed-off-by: Sebastien Rousseau <sebastian.rousseau@gmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GkTMSRzg9EVUd11XZ9bbHC

---

THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co
