### PR TITLE
ci(dependabot): stop duplicating the reusable-pin bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,21 @@ updates:
     labels:
       - "dependencies"
       - "security"
+    ignore:
+      # This repo's own reusable workflows are pinned by SHA, so Dependabot
+      # sees each call site as a github-actions dependency and opens a PR
+      # whenever main moves. But .github/workflows/bump-reusable-pins.yml
+      # already owns that job: it runs on every push to main touching a
+      # reusable-*.yml and opens a single PR bumping every stale caller.
+      #
+      # With both active, each merge to main regenerated up to seven
+      # near-identical PRs, which in turn moved main again. Nothing required
+      # them: tools/ci/lint-reusable-pins.sh only enforces that a pin is an
+      # immutable 40-hex SHA, never that it matches main, so a pin that
+      # trails main by a few commits is valid and safe.
+      #
+      # Third-party actions are unaffected and still bumped normally.
+      - dependency-name: "sebastienrousseau/dotfiles/.github/workflows/*"
     groups:
       github-actions-minor-patch:
         patterns:


### PR DESCRIPTION
Two systems were doing the same job, and each merge to main made them produce more work.

This repository's reusable workflows are pinned by SHA, so Dependabot treats every call site as a github-actions dependency and opens a PR whenever main moves. But `.github/workflows/bump-reusable-pins.yml` already owns exactly that: it runs on every push to main touching a `reusable-*.yml` and opens a single PR bumping all stale callers.

With both active, each merge regenerated up to seven near-identical PRs, which moved main again and regenerated them. Seven were open simultaneously while landing a batch of work, on top of the ten already in flight.

## Nothing required them

`tools/ci/lint-reusable-pins.sh` enforces only that a pin is an immutable 40-hex SHA. It never compares against main. A pin trailing main by a few commits passes the lint and is safe, which is the whole point of pinning by SHA rather than by ref.

So the churn bought no correctness, only noise.

## What changes

One `ignore` entry scoped to this repository's own reusable workflow paths. Third-party actions are unaffected and continue to be bumped normally, including security updates.

The bump workflow remains the single owner of these pins, and it is better suited to the job: it triggers on the event that actually invalidates a pin, and it bumps every stale caller in one PR rather than one PR per caller.

## Note on the seven open PRs

They can be closed as superseded. They bump pins to a SHA that is already stale, and the bump workflow will refresh them properly once main settles.

Signed-off-by: Sebastien Rousseau <sebastian.rousseau@gmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GkTMSRzg9EVUd11XZ9bbHC

---

THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co
