### PR TITLE
fix(ci): do not let an unrelated apt repo failure veto the install

### DIFF
--- a/tools/ci/install-tools.sh
+++ b/tools/ci/install-tools.sh
@@ -63,8 +63,19 @@ printf 'Installing missing tools: %s\n' "${missing[*]}"
 # ceiling the job timeout can cut short would report "cancelled" — the very
 # symptom this replaces — instead of a readable error.
 apt_install_missing() {
-  sudo timeout 60 apt-get update -qq &&
-    sudo timeout 120 apt-get install -y -qq --no-install-recommends "${missing[@]}"
+  # `apt-get update` exits non-zero when ANY configured repository fails to
+  # fetch — including third-party ones the runner image ships that have
+  # nothing to do with what we install. On 2026-09-09 the Google Chrome repo
+  # was unreachable and took down ten jobs across a PR: apt itself reported
+  # "Some index files failed to download. They have been ignored, or old ones
+  # used instead", so it had a usable index and the packages we want come from
+  # Ubuntu's own repos, but the `&&` vetoed the install anyway.
+  #
+  # So refresh on a best-effort basis and let the *install* decide success.
+  # A genuinely missing package still fails here, loudly, which is the signal
+  # worth acting on.
+  sudo timeout 60 apt-get update -qq || true
+  sudo timeout 120 apt-get install -y -qq --no-install-recommends "${missing[@]}"
 }
 
 for attempt in 1 2 3; do


### PR DESCRIPTION
`apt-get update` exits non-zero when **any** configured repository fails to fetch, including third-party ones the runner image ships that have nothing to do with the packages being installed. The `&&` then skipped the install entirely.

Today the Google Chrome repository was unreachable and this took down ten jobs on a single PR: copyright headers, three shell-lint variants, lua lint, coverage, the perf baseline, reliability, and the unit suite. None of them involve Chrome.

The failure is self-refuting in apt's own output:

```
E: Failed to fetch https://dl.google.com/linux/chrome-stable/deb/dists/stable/main/binary-amd64/Packages.gz
E: Some index files failed to download. They have been ignored, or old ones used instead.
::warning::apt attempt 3/3 failed for: ripgrep shfmt
::error::Failed to install after 3 attempts: ripgrep shfmt
```

apt says it fell back to a usable index. `ripgrep`, `shfmt` and `jq` come from Ubuntu's own repositories, which were fine. The install would have succeeded had it been attempted.

The existing three-attempt retry could not help, because the failing repository was still failing on every attempt. Retrying is the right response to a transient blip; it is the wrong response to a repository that is simply down.

## The change

Refresh on a best-effort basis, then let the *install* decide success:

```bash
sudo timeout 60 apt-get update -qq || true
sudo timeout 120 apt-get install -y -qq --no-install-recommends "${missing[@]}"
```

A genuinely missing or unavailable package still fails here, loudly, which is the signal worth acting on. What no longer fails is a lint job because an unrelated vendor's repository is down.

This preserves everything the script already does well: it still checks what is actually missing before installing anything, still bounds every network call so a hung mirror cannot eat the job budget, and still retries.

Signed-off-by: Sebastien Rousseau <sebastian.rousseau@gmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co
