### PR TITLE
fix(chezmoi): capture local config drift instead of overwriting it

### DIFF
--- a/defaults/.chezmoidata/secrets-patterns.toml
+++ b/defaults/.chezmoidata/secrets-patterns.toml
@@ -62,6 +62,13 @@ defaults = [
 
   # Database connection strings with embedded creds
   "(postgres|mysql|mongodb|redis)://[^:]+:[^@]+@",
+  # Key material pasted into a command line, wherever it appears. Deliberately
+  # unanchored: unlike the rules above, these match a secret being *carried*
+  # by a command rather than a recognisable command shape, so the position in
+  # the line tells us nothing. Carried over from a hand-maintained filter that
+  # predates this file; nothing else here catches a pasted key blob.
+  "BEGIN [A-Z ]*PRIVATE KEY",
+  "ssh-(rsa|ed25519|dss) AAAA",
 ]
 
 # Per-host extension slot — populate in ~/.config/chezmoi/chezmoi.toml under

--- a/defaults/dot_claude/CLAUDE.md
+++ b/defaults/dot_claude/CLAUDE.md
@@ -88,3 +88,37 @@ not quotas**.
   equivalence (prove it, don't assert it).
 - Verification is a step, not a vibe: state what you did to verify and what
   you observed; if you skipped a step, say so.
+
+## Destructive git operations
+
+Rewriting or discarding history is **never** a routine tool call. This applies
+to every repository, not just the one where it was learned.
+
+Covered: `rebase` (incl. `--signoff`, `--autosquash`), `push --force` /
+`--force-with-lease`, `reset --hard`, `stash pop`/`drop`, `checkout --`,
+`clean -fd`, `commit --amend` on anything already pushed, branch deletion.
+
+- **Check the precondition, then the postcondition.** Before: does the path
+  exist exactly as spelled, and did the previous command actually succeed?
+  After: verify the invariant that matters — `%G?` for signatures, file
+  contents for edits, `git stash list` for stashes — **before pushing**, not
+  after being asked.
+- **A rebase does not preserve signatures.** It rewrites every commit and
+  re-signs only if `commit.gpgsign` is set. Never assume it survived; check
+  `git log --format='%G?'` on the rewritten range.
+- **One branch at a time.** Never batch a force-push across several branches.
+- **Never chain a destructive command after an unverified one.** `set -e`
+  semantics do not carry across separate tool calls; a failed `stash push`
+  still lets the following `stash pop` run, and it will pop something else.
+- **Prefer the non-destructive form**: `revert` over `reset --hard`; a fresh
+  branch over rewriting a pushed one; `git stash list` before any `pop`.
+- **Idempotence is not free.** A replacement script run twice can corrupt data.
+  Revert to a known-clean state, confirm the revert actually happened, then
+  apply once.
+- **Recovery**: `git reflog` and the hash printed by a dropped stash
+  (`git stash store <sha>`) can undo most of this — but only if the mistake is
+  noticed, which is why the postcondition check is the rule that matters.
+
+The failure mode to watch for: treating one of these as ordinary, and letting
+the next step proceed as though the previous had succeeded. The damage usually
+looks fine at the time and surfaces much later.

--- a/defaults/dot_gitconfig.tmpl
+++ b/defaults/dot_gitconfig.tmpl
@@ -51,6 +51,15 @@
 	forceSignAnnotated = true
 {{- end }}
 
+# Add a `Signed-off-by` trailer to every commit (DCO). Deliberately outside
+# the signing-key block above: a sign-off is a statement about provenance,
+# not a cryptographic signature, so it applies whether or not a signing key
+# is configured. Repositories that gate on the DCO — this one included —
+# reject commits without it, and adding it after the fact means an amend
+# and a force-push.
+[format]
+	signOff = true
+
 [alias]
 	st = status -sb
 	d = diff


### PR DESCRIPTION
`chezmoi apply` was about to discard three sets of edits made directly in `$HOME` that the source tree had never seen. Each is worth keeping, so this brings them into the source rather than losing them on the next apply.

Found while preparing a routine apply: the dry run stopped on a prompt, and following it up showed five files where the live copy was newer than the source. Two needed nothing. Three are here.

## `.claude/CLAUDE.md`

The live file carried a **"Destructive git operations"** section the source lacked: check the precondition then the postcondition, never assume a rebase preserved signatures, one branch at a time, never chain a destructive command after an unverified one.

Applying would have deleted it. Captured verbatim, 5793 bytes, byte-identical to the live file.

That guidance is not incidental. It is what caught a signature-stripping problem earlier in this same batch of work.

## `dot_gitconfig.tmpl`

The live config set `format.signOff = true`, which adds the `Signed-off-by` trailer that this repository's **Check sign-off** gate requires. The template had no equivalent, so a fresh machine would fail that gate until someone rediscovered the setting, and adding it after the fact means an amend and a force-push.

Placed deliberately **outside** the `$git_signingkey` conditional: a sign-off is a statement about provenance, not a cryptographic signature, so it applies whether or not a signing key is configured.

## `.chezmoidata/secrets-patterns.toml`

The live atuin `history_filter` was a hand-maintained list of ten loose substrings. The templated list is better in every other respect — audited, anchored, centralised, with an `extra` slot for per-machine additions — but two live patterns had no equivalent:

```toml
"BEGIN [A-Z ]*PRIVATE KEY",
"ssh-(rsa|ed25519|dss) AAAA",
```

Both are deliberately **unanchored**, unlike every other rule in the file. The rest match a recognisable command shape; these match a secret being *carried* by a command, where position in the line tells you nothing.

Verified against six cases: four kinds of pasted key material match, while `git status` and `ssh-keygen -t ed25519` correctly do not.

## Not changed

Two other drifted files, `50-logic-functions.sh` and `51-logic-functions-extra.sh`, needed nothing. Their diffs were pure additions with nothing removed, installing the lazy-loader fork-bomb fix from this same batch of work.

Signed-off-by: Sebastien Rousseau <sebastian.rousseau@gmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co
