### PR TITLE
fix: the reported bugs, and two corrections to what was reported

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@
   first; do not hand-edit AGENTS.md.
 -->
 
+# AGENTS.md — AI Assistant Guidelines
 
 ## Project Overview
 

--- a/docs/manual/03-reference/01-dot-cli.md
+++ b/docs/manual/03-reference/01-dot-cli.md
@@ -360,7 +360,7 @@ dot registry url                  # show the active registry URL
 dot registry set-url <url>        # override the registry URL (HTTPS-only)
 ```
 
-Default registry: `https://sebastienrousseau.github.io/dotfiles/registry.json`. Cache lives at `${XDG_CACHE_HOME:-~/.cache}/dotfiles/registry/index.json` with a 6h TTL. One-off override: `DOTFILES_REGISTRY_URL=<url> dot registry list`.
+Default registry: `https://sebastienrousseau.github.io/dotfiles/registry.json`. Cache lives under `${XDG_CACHE_HOME:-~/.cache}/dotfiles/registry/`, one `index-<digest>.json` per registry URL, with a 6h TTL. One-off override: `DOTFILES_REGISTRY_URL=<url> dot registry list`.
 
 The JSON contract + module-contribution flow live in [`docs/operations/REGISTRY.md`](../../operations/REGISTRY.md).
 

--- a/docs/operations/REGISTRY.md
+++ b/docs/operations/REGISTRY.md
@@ -27,7 +27,7 @@ dot registry url                    # show active registry URL
 dot registry set-url <url>          # point at a different registry
 ```
 
-The registry index is cached locally at `${XDG_CACHE_HOME:-~/.cache}/dotfiles/registry/index.json` with a 6 hour TTL. Override the URL one-off via `DOTFILES_REGISTRY_URL=<url> dot registry list`.
+The registry index is cached locally under `${XDG_CACHE_HOME:-~/.cache}/dotfiles/registry/` with a 6 hour TTL, in a file named for the URL it was fetched from (`index-<digest>.json`) so changing the registry URL never serves the previous registry's index. Override the URL one-off via `DOTFILES_REGISTRY_URL=<url> dot registry list`.
 
 ## JSON contract
 

--- a/docs/reference/FEATURE-MATRIX.md
+++ b/docs/reference/FEATURE-MATRIX.md
@@ -608,7 +608,6 @@ accommodated. None is fixed here — `bin/dot`'s command modules and
 | Severity | Where | What |
 |----------|-------|------|
 | High | `scripts/dot/commands/agent.sh` | `dot mode run`, `dot agent checkpoint replay` and `dot agent delegate` all discard the wrapped command's exit code. All three use `if ! "$@"; then exit_code=$?`, where `$?` is the status of the *negated* pipeline and so always `0`. `dot mode run plan false` exits 0; delegate reports `failed (exit 0)`. Fix: `"$@" \|\| exit_code=$?`. |
-| High | `scripts/dot/commands/fleet.sh` | `dot fleet namespace set` rewrites `.chezmoidata.toml` only when a `namespace` key already exists, but reports success either way. The shipped file has no such key, so on a fresh checkout the command is a silent no-op. `dot profile set` handles the same case correctly by appending the key. |
 | Medium | `scripts/dot/commands/registry.sh` | The registry index cache lives at one fixed path and is treated as fresh for six hours regardless of which URL produced it, so changing `DOTFILES_REGISTRY_URL` keeps serving the previous registry's index. |
 | Medium | `scripts/diagnostics/doctor-unified.sh` | `dot doctor --audit` routes to `scripts/ops/health-check.sh`, which is not in the tree; the flag dies with "Script not found". |
 | Medium | `scripts/dot/commands/tools.sh` | `dot tools docs` looks for `docs/TOOLS.md` / `docs/UTILS.md`; both live under `docs/reference/`, so the subcommand reports "TOOLS.md not found" on a complete checkout. |

--- a/docs/reference/FEATURE-MATRIX.md
+++ b/docs/reference/FEATURE-MATRIX.md
@@ -600,10 +600,11 @@ hunted through the table.
 
 ## Findings this matrix produced
 
-Building the coverage turned up defects in the CLI. Each is exercised by the
+Building the coverage turned up defects in the CLI. Each was exercised by the
 row that found it, commented at that row, and reported rather than silently
-accommodated. None is fixed here — `bin/dot`'s command modules and
-`scripts/diagnostics/` belong to other work.
+accommodated. Every one of them has since been fixed and pinned by a
+regression test; what remains below is the one entry that is working as
+designed.
 
 | Severity | Where | What |
 |----------|-------|------|
@@ -611,16 +612,28 @@ accommodated. None is fixed here — `bin/dot`'s command modules and
 
 ### Commands that write into the checkout
 
-Three commands resolve their write target from the location of the sourced
-library rather than from `$HOME`, so a sandboxed `HOME` does not protect a
-working tree from them. The regression rows for these drive a throwaway copy
-of the repo instead, and then assert the checkout is still clean:
+These commands resolve their write target through `lib/dot/utils.sh`'s
+`resolve_source_dir`, which probes the location of the sourced library BEFORE
+`$CHEZMOI_SOURCE_DIR` and `$HOME`. Running `./bin/dot` from a checkout
+therefore writes into that checkout whatever `HOME` says, so a sandboxed
+`HOME` does not protect a working tree from them. The regression rows for
+these drive a throwaway copy of the repo instead, and then assert the checkout
+is still clean:
 
 - `dot profile set` → `defaults/.chezmoidata.toml`
 - `dot fleet namespace set` → `defaults/.chezmoidata.toml`
 - `dot fleet enforce set` → `defaults/dot_config/dotfiles/agent-profiles.json`
 - `dot aliases cheatsheet` (no `--output`) → `docs/ALIASES_CHEATSHEET.md`
-- `dot theme set` → `defaults/.chezmoidata.toml`, **and** the OS appearance
+
+`dot theme set` is NOT one of them, contrary to an earlier note here.
+scripts/theme/switch.sh and bin/dot-theme-sync resolve the data file from
+`$CHEZMOI_SOURCE_DIR`, then `$HOME/.dotfiles`, then
+`$HOME/.local/share/chezmoi`, and refuse with "Dotfiles source not found"
+when none exists — measured by pointing `$HOME/.dotfiles` at a synthetic tree
+while running the checkout's `bin/dot`: the synthetic tree was written and the
+checkout was untouched. It writes the checkout under this harness only because
+the harness points both `CHEZMOI_SOURCE_DIR` and `$HOME/.dotfiles` at it. It
+also drives the real OS appearance, which is why it stays a smoke row.
 
 ## See also
 

--- a/docs/reference/FEATURE-MATRIX.md
+++ b/docs/reference/FEATURE-MATRIX.md
@@ -607,7 +607,6 @@ accommodated. None is fixed here — `bin/dot`'s command modules and
 
 | Severity | Where | What |
 |----------|-------|------|
-| Medium | `scripts/dot/commands/tools.sh` | `dot tools docs` looks for `docs/TOOLS.md` / `docs/UTILS.md`; both live under `docs/reference/`, so the subcommand reports "TOOLS.md not found" on a complete checkout. |
 | Low | `scripts/dot/commands/meta.sh` | A bare `dot keys` falls back to `scripts/diagnostics/keys.sh`, which does not exist, when `docs/KEYS.md` is absent — and `docs/KEYS.md` is not in the tree. |
 | Low | `scripts/lib/secrets_provider.sh` | The `plain-enc` store aborts with `tmp_rec: unbound variable` under `set -u` *after* writing the encrypted file, so `dot secrets set` exits non-zero on a write that in fact succeeded. |
 | Note | `scripts/dot/commands/env-emit.sh` | The `-h\|--help` arm of `dot_env_emit` is unreachable through the CLI: the dispatcher's universal `--help` intercept fires first and renders `dot help env`. Working as designed, but the sub-handler's usage text can only be read in the source. |

--- a/docs/reference/FEATURE-MATRIX.md
+++ b/docs/reference/FEATURE-MATRIX.md
@@ -607,7 +607,6 @@ accommodated. None is fixed here — `bin/dot`'s command modules and
 
 | Severity | Where | What |
 |----------|-------|------|
-| Low | `scripts/dot/commands/meta.sh` | A bare `dot keys` falls back to `scripts/diagnostics/keys.sh`, which does not exist, when `docs/KEYS.md` is absent — and `docs/KEYS.md` is not in the tree. |
 | Low | `scripts/lib/secrets_provider.sh` | The `plain-enc` store aborts with `tmp_rec: unbound variable` under `set -u` *after* writing the encrypted file, so `dot secrets set` exits non-zero on a write that in fact succeeded. |
 | Note | `scripts/dot/commands/env-emit.sh` | The `-h\|--help` arm of `dot_env_emit` is unreachable through the CLI: the dispatcher's universal `--help` intercept fires first and renders `dot help env`. Working as designed, but the sub-handler's usage text can only be read in the source. |
 

--- a/docs/reference/FEATURE-MATRIX.md
+++ b/docs/reference/FEATURE-MATRIX.md
@@ -613,7 +613,6 @@ accommodated. None is fixed here — `bin/dot`'s command modules and
 | Medium | `scripts/diagnostics/doctor-unified.sh` | `dot doctor --audit` routes to `scripts/ops/health-check.sh`, which is not in the tree; the flag dies with "Script not found". |
 | Medium | `scripts/dot/commands/tools.sh` | `dot tools docs` looks for `docs/TOOLS.md` / `docs/UTILS.md`; both live under `docs/reference/`, so the subcommand reports "TOOLS.md not found" on a complete checkout. |
 | Low | `scripts/dot/commands/meta.sh` | A bare `dot keys` falls back to `scripts/diagnostics/keys.sh`, which does not exist, when `docs/KEYS.md` is absent — and `docs/KEYS.md` is not in the tree. |
-| Low | `scripts/theme/switch.sh` | `dot theme set` with no name aborts with `$1: unbound variable` instead of printing usage. The refusal is correct; its presentation is not. |
 | Low | `scripts/lib/secrets_provider.sh` | The `plain-enc` store aborts with `tmp_rec: unbound variable` under `set -u` *after* writing the encrypted file, so `dot secrets set` exits non-zero on a write that in fact succeeded. |
 | Note | `scripts/dot/commands/env-emit.sh` | The `-h\|--help` arm of `dot_env_emit` is unreachable through the CLI: the dispatcher's universal `--help` intercept fires first and renders `dot help env`. Working as designed, but the sub-handler's usage text can only be read in the source. |
 

--- a/docs/reference/FEATURE-MATRIX.md
+++ b/docs/reference/FEATURE-MATRIX.md
@@ -607,7 +607,6 @@ accommodated. None is fixed here — `bin/dot`'s command modules and
 
 | Severity | Where | What |
 |----------|-------|------|
-| Low | `scripts/lib/secrets_provider.sh` | The `plain-enc` store aborts with `tmp_rec: unbound variable` under `set -u` *after* writing the encrypted file, so `dot secrets set` exits non-zero on a write that in fact succeeded. |
 | Note | `scripts/dot/commands/env-emit.sh` | The `-h\|--help` arm of `dot_env_emit` is unreachable through the CLI: the dispatcher's universal `--help` intercept fires first and renders `dot help env`. Working as designed, but the sub-handler's usage text can only be read in the source. |
 
 ### Commands that write into the checkout

--- a/docs/reference/FEATURE-MATRIX.md
+++ b/docs/reference/FEATURE-MATRIX.md
@@ -607,7 +607,6 @@ accommodated. None is fixed here — `bin/dot`'s command modules and
 
 | Severity | Where | What |
 |----------|-------|------|
-| Medium | `scripts/diagnostics/doctor-unified.sh` | `dot doctor --audit` routes to `scripts/ops/health-check.sh`, which is not in the tree; the flag dies with "Script not found". |
 | Medium | `scripts/dot/commands/tools.sh` | `dot tools docs` looks for `docs/TOOLS.md` / `docs/UTILS.md`; both live under `docs/reference/`, so the subcommand reports "TOOLS.md not found" on a complete checkout. |
 | Low | `scripts/dot/commands/meta.sh` | A bare `dot keys` falls back to `scripts/diagnostics/keys.sh`, which does not exist, when `docs/KEYS.md` is absent — and `docs/KEYS.md` is not in the tree. |
 | Low | `scripts/lib/secrets_provider.sh` | The `plain-enc` store aborts with `tmp_rec: unbound variable` under `set -u` *after* writing the encrypted file, so `dot secrets set` exits non-zero on a write that in fact succeeded. |

--- a/docs/reference/FEATURE-MATRIX.md
+++ b/docs/reference/FEATURE-MATRIX.md
@@ -607,7 +607,6 @@ accommodated. None is fixed here — `bin/dot`'s command modules and
 
 | Severity | Where | What |
 |----------|-------|------|
-| Medium | `scripts/dot/commands/registry.sh` | The registry index cache lives at one fixed path and is treated as fresh for six hours regardless of which URL produced it, so changing `DOTFILES_REGISTRY_URL` keeps serving the previous registry's index. |
 | Medium | `scripts/diagnostics/doctor-unified.sh` | `dot doctor --audit` routes to `scripts/ops/health-check.sh`, which is not in the tree; the flag dies with "Script not found". |
 | Medium | `scripts/dot/commands/tools.sh` | `dot tools docs` looks for `docs/TOOLS.md` / `docs/UTILS.md`; both live under `docs/reference/`, so the subcommand reports "TOOLS.md not found" on a complete checkout. |
 | Low | `scripts/dot/commands/meta.sh` | A bare `dot keys` falls back to `scripts/diagnostics/keys.sh`, which does not exist, when `docs/KEYS.md` is absent — and `docs/KEYS.md` is not in the tree. |

--- a/docs/reference/FEATURE-MATRIX.md
+++ b/docs/reference/FEATURE-MATRIX.md
@@ -607,7 +607,6 @@ accommodated. None is fixed here — `bin/dot`'s command modules and
 
 | Severity | Where | What |
 |----------|-------|------|
-| High | `scripts/dot/commands/agent.sh` | `dot mode run`, `dot agent checkpoint replay` and `dot agent delegate` all discard the wrapped command's exit code. All three use `if ! "$@"; then exit_code=$?`, where `$?` is the status of the *negated* pipeline and so always `0`. `dot mode run plan false` exits 0; delegate reports `failed (exit 0)`. Fix: `"$@" \|\| exit_code=$?`. |
 | Medium | `scripts/dot/commands/registry.sh` | The registry index cache lives at one fixed path and is treated as fresh for six hours regardless of which URL produced it, so changing `DOTFILES_REGISTRY_URL` keeps serving the previous registry's index. |
 | Medium | `scripts/diagnostics/doctor-unified.sh` | `dot doctor --audit` routes to `scripts/ops/health-check.sh`, which is not in the tree; the flag dies with "Script not found". |
 | Medium | `scripts/dot/commands/tools.sh` | `dot tools docs` looks for `docs/TOOLS.md` / `docs/UTILS.md`; both live under `docs/reference/`, so the subcommand reports "TOOLS.md not found" on a complete checkout. |

--- a/scripts/diagnostics/doctor-unified.sh
+++ b/scripts/diagnostics/doctor-unified.sh
@@ -20,7 +20,11 @@ target="scripts/diagnostics/doctor.sh"
 for arg in "$@"; do
   case "$arg" in
     --heal | -H) target="scripts/ops/heal.sh" ;;
-    --audit | -a) target="scripts/ops/health-check.sh" ;;
+    # scripts/ops/health-check.sh has never existed in this tree, so
+    # `dot doctor --audit` died with "Script not found" for every user who
+    # tried it. The health dashboard is what that name meant: it is the
+    # audit-shaped diagnostic, and `dot health-check` already aliases it.
+    --audit | -a) target="scripts/diagnostics/health.sh" ;;
     --score | -s) target="scripts/diagnostics/scorecard.sh" ;;
     --smoke | -m) target="scripts/diagnostics/smoke-test.sh" ;;
     --drift | -d) target="scripts/diagnostics/drift-dashboard.sh" ;;

--- a/scripts/dot/commands/agent.sh
+++ b/scripts/dot/commands/agent.sh
@@ -21,6 +21,55 @@ _agent_repo_root() {
   require_source_dir
 }
 
+## _agent_run_bounded <seconds> <command…> — run a command under a wall-clock
+## limit on every platform we ship to.
+##
+## `timeout` is GNU coreutils. Stock macOS has neither it nor `gtimeout`
+## (that one arrives with `brew install coreutils`), so the delegate arm's
+## former `timeout "$t" "$@"` meant the delegated command never ran at all on
+## a clean Mac — it died 127, "command not found". perl is present on both
+## macOS and the CI runners and gives us fork + alarm, which is what timeout(1)
+## does. tests/framework/assertions.sh solves the same problem the same way.
+##
+## Exit codes follow GNU timeout: 124 on expiry, 128+N when signalled,
+## otherwise the command's own status.
+_agent_run_bounded() {
+  local seconds="$1"
+  shift
+  local bin
+  bin="$(type -P timeout || true)"
+  [[ -n "$bin" ]] || bin="$(type -P gtimeout || true)"
+  if [[ -n "$bin" ]]; then
+    "$bin" "$seconds" "$@"
+    return
+  fi
+  if command -v perl >/dev/null 2>&1; then
+    perl -e '
+      my $secs = shift @ARGV;
+      my $pid  = fork();
+      die "dot: fork failed: $!\n" unless defined $pid;
+      if ($pid == 0) {
+        exec { $ARGV[0] } @ARGV;
+        exit 127;
+      }
+      my $timed_out = 0;
+      $SIG{ALRM} = sub { $timed_out = 1; kill("TERM", $pid); kill("KILL", $pid); };
+      alarm($secs);
+      my $reaped;
+      do { $reaped = waitpid($pid, 0); } while ($reaped == -1 && $!{EINTR});
+      my $status = $?;
+      alarm(0);
+      exit(124) if $timed_out;
+      exit($status & 127 ? 128 + ($status & 127) : $status >> 8);
+    ' "$seconds" "$@"
+    return
+  fi
+  # Neither available: running the command is still better than refusing to,
+  # but the lost guarantee is said out loud rather than assumed.
+  ui_warn "Delegate" "no timeout(1) or perl on PATH — running without a time limit"
+  "$@"
+}
+
 _agent_profiles_file() {
   local repo_root
   repo_root="$(_agent_repo_root)"
@@ -393,7 +442,7 @@ EOF
       dot_agent_session_log "delegate_start" "$delegate_profile" "running" "delegate=$delegate_name" "parent=$current_profile" "timeout=$delegate_timeout"
       ui_info "Delegating" "$delegate_name (profile: $delegate_profile, timeout: ${delegate_timeout}s)"
       local exit_code=0
-      if timeout "$delegate_timeout" "$@"; then
+      if _agent_run_bounded "$delegate_timeout" "$@"; then
         dot_agent_session_log "delegate_finish" "$delegate_profile" "ok" "delegate=$delegate_name" "exit_code=$exit_code"
         ui_ok "Delegate" "$delegate_name completed"
       else

--- a/scripts/dot/commands/agents.sh
+++ b/scripts/dot/commands/agents.sh
@@ -193,9 +193,17 @@ cmd_agents() {
 -->
 
 HEADER
-        # Replace the title line so the rendered file declares its
-        # purpose, but pass everything else through unchanged.
-        _agents_body "$claude_md" | sed '1s/^# CLAUDE\.md.*/# AGENTS.md — AI Assistant Guidelines/'
+        # The title is emitted, not substituted. This used to be
+        #
+        #     _agents_body … | sed '1s/^# CLAUDE\.md.*/# AGENTS.md — …/'
+        #
+        # but _agents_body drops the H1 by design (the two files differ
+        # there), so line 1 of its output was never the CLAUDE.md title and
+        # the substitution could not fire: the rendered file carried no title
+        # at all. `check` is unaffected either way — it compares bodies with
+        # the H1 stripped from both sides.
+        printf '# AGENTS.md — AI Assistant Guidelines\n'
+        _agents_body "$claude_md"
         cat <<'FOOTER'
 
 ---

--- a/scripts/dot/commands/fleet.sh
+++ b/scripts/dot/commands/fleet.sh
@@ -301,23 +301,42 @@ cmd_fleet_namespace() {
       validate_name "$new_ns" "namespace"
       local data_file
       data_file="$(resolve_chezmoi_source_dir)/.chezmoidata.toml"
-      if grep -q "^namespace = " "$data_file" 2>/dev/null; then
-        # Atomic write: render into a tempfile + mv so concurrent
-        # `dot fleet namespace set` callers can't corrupt the TOML.
-        # Avoids `sed -i` portability dance (GNU `-i` vs BSD `-i ''`).
-        local _tmp
-        _tmp="$(mktemp "${data_file}.XXXXXX")" || die "Cannot create tempfile"
-        # Explicit if/else instead of A && B || C — the latter (SC2015)
-        # silently runs C when B itself fails, masking real mv errors.
+      [[ -f "$data_file" ]] || die ".chezmoidata.toml not found: $data_file"
+      # Atomic write: render into a tempfile + mv so concurrent
+      # `dot fleet namespace set` callers can't corrupt the TOML.
+      # Avoids `sed -i` portability dance (GNU `-i` vs BSD `-i ''`).
+      local _tmp _rendered=0
+      _tmp="$(mktemp "${data_file}.XXXXXX")" || die "Cannot create tempfile"
+      # Explicit if/else instead of A && B || C — the latter (SC2015)
+      # silently runs C when B itself fails, masking real mv errors.
+      if grep -q "^namespace = " "$data_file"; then
         if sed "s/^namespace = \".*\"/namespace = \"$new_ns\"/" "$data_file" >"$_tmp"; then
-          if ! mv "$_tmp" "$data_file"; then
-            rm -f "$_tmp"
-            die "Failed to commit namespace update"
-          fi
-        else
-          rm -f "$_tmp"
-          die "Failed to render namespace update"
+          _rendered=1
         fi
+      else
+        # No key yet — the shipped .chezmoidata.toml has none, and rewriting
+        # only when one already existed made `set` a silent no-op on a fresh
+        # checkout while still reporting success. Insert it after the first
+        # line: appending at the end would land the key inside whatever
+        # [table] the file happens to end with, which TOML reads as a
+        # different key entirely. `dot profile set` does the same for
+        # `profile`.
+        if awk -v ns="$new_ns" '
+          NR == 1 { print; printf "namespace = \"%s\"\n", ns; inserted = 1; next }
+          { print }
+          END { if (!inserted) printf "namespace = \"%s\"\n", ns }
+        ' "$data_file" >"$_tmp"; then
+          _rendered=1
+        fi
+      fi
+      if [[ "$_rendered" -eq 1 ]]; then
+        if ! mv "$_tmp" "$data_file"; then
+          rm -f "$_tmp"
+          die "Failed to commit namespace update"
+        fi
+      else
+        rm -f "$_tmp"
+        die "Failed to render namespace update"
       fi
       ui_ok "Namespace" "Set to '$new_ns'. Run 'dot sync' to apply."
       _fleet_emit_event "namespace_set" "ok" "namespace=$new_ns"

--- a/scripts/dot/commands/meta.sh
+++ b/scripts/dot/commands/meta.sh
@@ -199,11 +199,33 @@ cmd_keys() {
     return 0
   fi
 
-  if [ -n "$src_dir" ] && [ -f "$src_dir/docs/KEYS.md" ]; then
+  # The keybindings document lives at docs/security/KEYS.md. Probing only
+  # docs/KEYS.md meant every `dot keys` fell through to
+  # scripts/diagnostics/keys.sh, which is not in the tree either, so the
+  # command could only ever report "Keys script not found". The legacy path
+  # stays in the list for trees that predate the move.
+  local keys_doc=""
+  if [ -n "$src_dir" ]; then
+    local candidate
+    for candidate in docs/security/KEYS.md docs/KEYS.md; do
+      if [ -f "$src_dir/$candidate" ]; then
+        keys_doc="$src_dir/$candidate"
+        break
+      fi
+    done
+  fi
+
+  if [ -n "$keys_doc" ]; then
     if [ -n "${1:-}" ]; then
-      rg -i --fixed-strings --context 1 "${1:-}" "$src_dir/docs/KEYS.md" || true
+      # ripgrep is not installed everywhere (the CI runners have none), and
+      # a bare `rg` there printed nothing at all while exiting 0.
+      if has_command rg; then
+        rg -i --fixed-strings --context 1 "${1:-}" "$keys_doc" || true
+      else
+        grep -i -F -C 1 -- "${1:-}" "$keys_doc" || true
+      fi
     else
-      exec cat "$src_dir/docs/KEYS.md"
+      exec cat "$keys_doc"
     fi
   else
     run_script "scripts/diagnostics/keys.sh" "Keys script" "$@"

--- a/scripts/dot/commands/registry.sh
+++ b/scripts/dot/commands/registry.sh
@@ -76,6 +76,38 @@ _registry_cache_dir() {
   printf '%s/dotfiles/registry\n' "${XDG_CACHE_HOME:-$HOME/.cache}"
 }
 
+## The index cache is keyed by URL, not by one fixed path.
+##
+## It used to live at <cache>/index.json for every registry, and be treated as
+## fresh for six hours: a freshness window says nothing about WHICH registry
+## produced the file, so changing DOTFILES_REGISTRY_URL — or running
+## `dot registry set-url` — kept serving the previous registry's index for up
+## to six hours. Keying by URL also means switching back and forth does not
+## re-download.
+##
+## SHA-256 where a hasher exists, POSIX `cksum` otherwise: this is a cache
+## key, not a security boundary, and every index is schema-validated on read.
+_registry_cache_key() {
+  local url="$1" digest=""
+  if command -v shasum >/dev/null 2>&1; then
+    digest="$(printf '%s' "$url" | shasum -a 256 2>/dev/null | awk '{print $1}')"
+  elif command -v sha256sum >/dev/null 2>&1; then
+    digest="$(printf '%s' "$url" | sha256sum 2>/dev/null | awk '{print $1}')"
+  fi
+  if [[ -z "$digest" ]]; then
+    digest="$(printf '%s' "$url" | cksum | awk '{print $1 "-" $2}')"
+  fi
+  printf '%s\n' "${digest:0:32}"
+}
+
+## _registry_cache_file [url] — absolute path of the cached index for a URL
+## (the active one by default). Tests seed the cache through this.
+_registry_cache_file() {
+  local url="${1:-}"
+  [[ -n "$url" ]] || url="$(_registry_url)"
+  printf '%s/index-%s.json\n' "$(_registry_cache_dir)" "$(_registry_cache_key "$url")"
+}
+
 _registry_data_dir() {
   printf '%s/dotfiles/modules\n' "${XDG_DATA_HOME:-$HOME/.local/share}"
 }
@@ -107,7 +139,7 @@ _registry_fetch() {
     return 1
   }
   cache_dir="$(_registry_cache_dir)"
-  cache_file="$cache_dir/index.json"
+  cache_file="$(_registry_cache_file "$url")"
   mkdir -p "$cache_dir"
   # Refresh if older than 6h or missing.
   local now mtime

--- a/scripts/dot/commands/tools.sh
+++ b/scripts/dot/commands/tools.sh
@@ -253,11 +253,17 @@ cmd_tools() {
       exit 1
     fi
   elif [ "$subcommand" = "docs" ]; then
-    if [ -n "$src_dir" ] && [ -f "$src_dir/docs/TOOLS.md" ]; then
-      exec cat "$src_dir/docs/TOOLS.md"
-    elif [ -n "$src_dir" ] && [ -f "$src_dir/docs/UTILS.md" ]; then
-      exec cat "$src_dir/docs/UTILS.md"
-    fi
+    # docs/reference/ first: both documents were moved there, and looking
+    # only in docs/ meant `dot tools docs` answered "TOOLS.md not found" on a
+    # complete checkout. The legacy paths stay in the list so a pre-reorg
+    # tree still resolves.
+    local doc
+    for doc in docs/reference/TOOLS.md docs/reference/UTILS.md \
+      docs/TOOLS.md docs/UTILS.md; do
+      if [ -n "$src_dir" ] && [ -f "$src_dir/$doc" ]; then
+        exec cat "$src_dir/$doc"
+      fi
+    done
     ui_err "Docs" "TOOLS.md not found"
     exit 1
   else

--- a/scripts/lib/secrets_provider.sh
+++ b/scripts/lib/secrets_provider.sh
@@ -96,9 +96,24 @@ dot_secrets_store_plain_enc() {
   dot_secrets_ensure_layout
   tmp_rec="$(umask 077 && mktemp)"
   file="$DOT_SECRETS_STORE_DIR/${key}.age"
-  trap 'rm -f "$tmp_rec"' RETURN
-  age-keygen -y "$DOT_SECRETS_AGE_KEY" >"$tmp_rec"
-  printf "%s" "$value" | age -R "$tmp_rec" -o "$file"
+
+  # No RETURN trap here. A RETURN trap set inside a function also fires when
+  # its CALLER returns, and by then `tmp_rec` — local to this function — is
+  # out of scope: under `set -u` the trap aborted dot_secrets_set with
+  # "tmp_rec: unbound variable" AFTER the encrypted file had been written, so
+  # `dot secrets set` reported failure on a write that had succeeded. Clean up
+  # explicitly on both paths instead.
+  if ! age-keygen -y "$DOT_SECRETS_AGE_KEY" >"$tmp_rec"; then
+    rm -f "$tmp_rec"
+    echo "failed to derive the age recipient from $DOT_SECRETS_AGE_KEY" >&2
+    return 1
+  fi
+  if ! printf "%s" "$value" | age -R "$tmp_rec" -o "$file"; then
+    rm -f "$tmp_rec"
+    echo "failed to encrypt secret: $key" >&2
+    return 1
+  fi
+  rm -f "$tmp_rec"
   chmod 600 "$file" 2>/dev/null || true
 }
 

--- a/scripts/ops/rollback.sh
+++ b/scripts/ops/rollback.sh
@@ -35,6 +35,11 @@ BACKUP_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/dotfiles/backups"
 STATE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/dotfiles"
 ROLLBACK_LOG="$STATE_DIR/rollback.log"
 MAX_BACKUPS=10
+# sysexits.h EX_TEMPFAIL: the command did nothing because another instance
+# holds the lock. Distinct from 1 (the rollback ran and failed) and from 0
+# (the rollback ran and succeeded) — a caller has to be able to tell those
+# three apart.
+EXIT_BUSY=75
 
 # Logging — delegates to shared ui.sh primitives
 ui_init
@@ -525,8 +530,12 @@ main() {
   if command -v flock >/dev/null 2>&1; then
     exec 9>"$LOCK_FILE"
     if ! flock -n 9; then
+      # Losing the lock means this invocation did nothing. Exiting 0 made
+      # "did nothing" indistinguishable from "rolled back" to any caller or
+      # CI step, which is the one thing a recovery tool must never be
+      # ambiguous about. 75 is EX_TEMPFAIL: nothing is wrong, try again.
       ui_warn "Already running" "Another rollback instance is active"
-      exit 0
+      exit "$EXIT_BUSY"
     fi
   fi
 

--- a/scripts/qa/check-feature-matrix.sh
+++ b/scripts/qa/check-feature-matrix.sh
@@ -175,9 +175,13 @@ fi
 # 2. Test coverage
 # ---------------------------------------------------------------------------
 
+# `|| true`: this runs at top level under `set -euo pipefail`, so without it an
+# unmatched glob (or a grep that simply finds nothing) aborts the whole script
+# with grep's status before the emptiness check below can run — exit 2 and not
+# a word about why, instead of the diagnostic that check exists to print.
 # shellcheck disable=SC2086
 grep -ho '^test_fm_[a-z0-9_]*()' $TEST_GLOB 2>/dev/null |
-  sed 's/()//' | sort -u >"$work/defined-tests.txt"
+  sed 's/()//' | sort -u >"$work/defined-tests.txt" || true
 
 if [[ ! -s "$work/defined-tests.txt" ]]; then
   fail "no test functions found in $TEST_GLOB"

--- a/scripts/theme/switch.sh
+++ b/scripts/theme/switch.sh
@@ -200,8 +200,17 @@ is_dark_theme() {
 }
 
 set_theme() {
-  local new_theme="$1"
+  local new_theme="${1:-}"
   if [ -z "$new_theme" ]; then
+    # A picker needs someone to pick. Under DOTFILES_NONINTERACTIVE the
+    # selector cannot run, and ui_pick reports "nothing selected" the same
+    # way it reports a cancel — so answering with a silent success would
+    # make a forgotten argument indistinguishable from a theme change.
+    if [ "${DOTFILES_NONINTERACTIVE:-0}" = "1" ]; then
+      ui_err "Missing theme name" "no interactive picker in a non-interactive session"
+      ui_info "Usage" "dot theme set <name>  (or 'dot theme list' to see them)"
+      return 1
+    fi
     pick_theme
     return
   fi
@@ -252,6 +261,11 @@ pick_theme() {
     else
       ui_info "Theme" "already on $current"
     fi
+  else
+    # Cancelled, or no selector could run. Either way nothing changed, and
+    # saying so beats exiting mute on a command the user asked to be
+    # interactive.
+    ui_info "Theme" "no selection — still on $current"
   fi
 }
 
@@ -403,7 +417,16 @@ case "${1:-}" in
     ;;
   set)
     shift
-    set_theme "$1"
+    # `"${1:-}"`, not `"$1"`: with no theme name the bare positional aborts
+    # the script under `set -u` before set_theme's own empty-string check can
+    # open the picker `dot help theme` promises. Worse, the abort is silent
+    # about its status on bash 3.2 (macOS /bin/bash): when a script dies on an
+    # unbound variable with an EXIT trap installed — switch.sh installs
+    # `trap cleanup EXIT` — 3.2 exits 0, and no handler can recover the status
+    # because `$?` is already 0 when the handler runs. So on a stock Mac this
+    # one missing default turned every `dot theme set` typo into a reported
+    # success. Keep every expansion in this script guarded.
+    set_theme "${1:-}"
     ;;
   toggle)
     toggle_theme

--- a/tests/framework/feature_matrix_lib.sh
+++ b/tests/framework/feature_matrix_lib.sh
@@ -27,19 +27,27 @@
 #   * No network: commands that would egress are recorded "unmeasurable" in
 #     the matrix and covered by a --help smoke test instead.
 #
-# Three commands resolve their WRITE target from the location of the sourced
-# library rather than from $HOME, so a sandboxed HOME does not protect the
-# checkout from them:
+# Some commands resolve their WRITE target through lib/dot/utils.sh's
+# resolve_source_dir, which probes the location of the sourced library BEFORE
+# $CHEZMOI_SOURCE_DIR and $HOME. A sandboxed HOME does not protect the
+# checkout from those:
 #
 #     dot profile set              -> <repo>/defaults/.chezmoidata.toml
 #     dot fleet namespace set      -> <repo>/defaults/.chezmoidata.toml
 #     dot fleet enforce set        -> <repo>/defaults/dot_config/.../agent-profiles.json
-#     dot theme set / toggle / …   -> <repo>/defaults/.chezmoidata.toml (+ the OS appearance)
 #     dot aliases cheatsheet       -> <repo>/docs/ALIASES_CHEATSHEET.md
 #
-# `fm_repo_copy` exists for the first three: it materialises a ~1 MB subset of
-# the repo in the sandbox so the write lands there. `theme set` additionally
-# drives the real OS appearance, so it stays a smoke row.
+# `fm_repo_copy` exists for those: it materialises a ~1 MB subset of the repo
+# in the sandbox so the write lands there.
+#
+# `dot theme set` is NOT in that list, despite an earlier note here saying so.
+# scripts/theme/switch.sh and bin/dot-theme-sync resolve the data file from
+# CHEZMOI_SOURCE_DIR, then $HOME/.dotfiles, then $HOME/.local/share/chezmoi,
+# and refuse when none exists — verified by pointing $HOME/.dotfiles at a
+# synthetic tree while running the checkout's bin/dot: the synthetic tree was
+# written, the checkout was not. It reaches the checkout HERE only because
+# this harness points both CHEZMOI_SOURCE_DIR and $HOME/.dotfiles at it. It
+# also drives the real OS appearance, which is why it stays a smoke row.
 
 [[ "${_DOT_LIB_FEATURE_MATRIX_LOADED:-0}" == "1" ]] && return 0
 _DOT_LIB_FEATURE_MATRIX_LOADED=1

--- a/tests/regression/test_dot_commands_execution.sh
+++ b/tests/regression/test_dot_commands_execution.sh
@@ -55,7 +55,15 @@ mkdir -p "$sandbox/.config" "$sandbox/.local/share" "$sandbox/.cache" \
 ln -s "$REPO_ROOT" "$sandbox/.dotfiles"
 printf '#!/usr/bin/env bash\nexit 0\n' >"$sandbox/bin/chezmoi"
 chmod +x "$sandbox/bin/chezmoi"
-printf '{"version":1,"modules":[]}\n' >"$sandbox/.cache/dotfiles/registry/index.json"
+# Seed the registry index cache so `dot registry …` stays offline. The cache
+# is keyed by the URL it came from, so ask registry.sh where the active URL's
+# index belongs instead of hard-coding a file name.
+registry_cache_file="$(
+  HOME="$sandbox" XDG_CACHE_HOME="$sandbox/.cache" XDG_CONFIG_HOME="$sandbox/.config" \
+    bash -c 'source "$1"; _registry_cache_file' _ \
+    "$REPO_ROOT/scripts/dot/commands/registry.sh"
+)"
+printf '{"version":1,"modules":[]}\n' >"$registry_cache_file"
 export HOME="$sandbox" \
   XDG_CONFIG_HOME="$sandbox/.config" \
   XDG_DATA_HOME="$sandbox/.local/share" \

--- a/tests/regression/test_feature_matrix_agent.sh
+++ b/tests/regression/test_feature_matrix_agent.sh
@@ -381,24 +381,16 @@ test_fm_mode_run_exit_code() {
   # The wrapped command's exit code SHOULD reach the caller, or `dot mode run`
   # cannot be used as a CI wrapper at all.
   #
-  # KNOWN BUG (found by this row, reported; scripts/dot/commands/agent.sh is
-  # not this agent's file to change). All three wrappers use
+  # This row was written while all three wrappers used
   #
   #     if ! "$@"; then exit_code=$?
   #
-  # and inside that branch `$?` is the status of the NEGATED pipeline, which
-  # is always 0 — so the failure code is lost. `dot mode run plan false`
-  # exits 0, and `dot agent delegate` prints "failed (exit 0)". The fix is to
-  # capture before negating:
-  #
-  #     "$@" || exit_code=$?
-  #
-  # The assertion accepts both values so it passes before and after the fix
-  # rather than pinning the bug in place; the row below is what proves the
-  # command actually ran.
+  # where `$?` is the status of the NEGATED pipeline and so always 0 — the
+  # failure code was lost. They now run the command as the `if` condition and
+  # read `$?` in the else branch, so the real status reaches the caller.
   test_start "fm_mode_run_exit_code"
   fm_run mode run plan sh -c "exit 42"
-  fm_expect_rc_in 0 42
+  fm_expect_rc 42
   test_start "fm_mode_run_exit_code_command_was_executed"
   fm_run mode run plan sh -c "printf fm-exit-marker; exit 42"
   fm_expect_out "fm-exit-marker"
@@ -679,32 +671,15 @@ test_fm_agent_delegate() {
   AGENT_PROFILE_CONFIG="$profiles" fm_run agent delegate fm-reviewer echo fm-delegated
   fm_expect_rc 0
 
-  # KNOWN BUG (found by this row, reported; scripts/dot/commands/agent.sh is
-  # not this agent's file to change): the delegate path wraps the command as
-  #
-  #     if ! timeout "$delegate_timeout" "$@"; then
-  #
-  # and `timeout` is GNU coreutils, which stock macOS does not ship — only
-  # `gtimeout`, and only after `brew install coreutils`. So on a clean Mac the
-  # delegated command never runs at all, and (because of the negated-status
-  # bug in the same function) it is announced as "failed (exit 0)". The rest
-  # of the repo handles this properly: tests/framework/assertions.sh defines a
-  # `timeout` shim that falls back to gtimeout, and bench.sh probes for both.
-  #
-  # The row therefore only asserts the command actually ran where a timeout
-  # binary exists; elsewhere it records the environment gap rather than
-  # reporting a red test for a machine the CLI cannot serve.
-  #
-  # `type -P`, not `command -v`: assertions.sh defines a `timeout` shell
-  # FUNCTION as its own fallback, and `command -v` reports that function as
-  # available — but a function is not exported to the `dot` subprocess, which
-  # is where the lookup that matters happens. Only a real executable counts.
+  # This row used to be conditional on a GNU `timeout` existing: the delegate
+  # path wrapped the command as `timeout "$delegate_timeout" "$@"`, and stock
+  # macOS ships neither `timeout` nor `gtimeout`, so the delegated command
+  # never ran there at all. _agent_run_bounded now falls back to perl's
+  # fork+alarm (the same answer tests/framework/assertions.sh gives), so the
+  # command runs — and stays bounded — on every host we support. The unit
+  # file pins the fallbacks with a PATH that has no timeout binary.
   test_start "fm_agent_delegate_runs_under_the_delegate_profile"
-  if [[ -n "$(type -P timeout)" ]]; then
-    fm_expect_out "fm-delegated"
-  else
-    fm_pass "skipped — no GNU timeout; dot agent delegate cannot run its command here"
-  fi
+  fm_expect_out "fm-delegated"
   test_start "fm_agent_delegate_rejects_an_unknown_delegate"
   AGENT_PROFILE_CONFIG="$profiles" fm_run agent delegate zzz-nobody echo x
   fm_expect_rc 1

--- a/tests/regression/test_feature_matrix_agent.sh
+++ b/tests/regression/test_feature_matrix_agent.sh
@@ -102,14 +102,14 @@ test_fm_smoke_sandbox() { fm_smoke sandbox; }
 # ── meta: keys ─────────────────────────────────────────────────────────────
 
 test_fm_keys() {
-  # KNOWN GAP (reported): cmd_keys falls back to scripts/diagnostics/keys.sh,
-  # which does not exist, when docs/KEYS.md is absent — and docs/KEYS.md is
-  # not in the tree, so a bare `dot keys` reports "Keys script not found".
+  # cmd_keys used to probe only docs/KEYS.md and then fall back to
+  # scripts/diagnostics/keys.sh; neither is in the tree, so a bare `dot keys`
+  # could only report "Keys script not found". It reads docs/security/KEYS.md.
   test_start "fm_keys"
   fm_run keys
-  fm_expect_rc_in 0 1
+  fm_expect_rc 0
   test_start "fm_keys_is_routed"
-  fm_expect_any "Keys" "KEYS.md" "keybinding" "not found"
+  fm_expect_out "Keybindings"
 }
 
 test_fm_keys_sign_check() {

--- a/tests/regression/test_feature_matrix_appearance_security.sh
+++ b/tests/regression/test_feature_matrix_appearance_security.sh
@@ -71,42 +71,28 @@ test_fm_theme_current() {
 test_fm_theme_set_missing() {
   # `dot theme set` with no name must not quietly apply a theme.
   #
-  # This row deliberately does NOT assert an exit code, because the exit code
-  # is not a property of the command here — it is a property of the bash
-  # running it. scripts/theme/switch.sh installs `trap cleanup EXIT`, and when
-  # the script aborts under `set -u` the trap's own (successful) last command
-  # replaces the failure status on bash 3.2 but not on bash 5.x:
+  # History: this row used to avoid asserting an exit code, because the code
+  # was a property of the bash running the command rather than of the command.
+  # `set_theme "$1"` aborted on the unset positional under `set -u`, and a
+  # script that dies that way with an EXIT trap installed — switch.sh installs
+  # `trap cleanup EXIT` — exits 0 on bash 3.2 (macOS /bin/bash) and 1 on 5.x.
+  # No handler can recover it: `$?` is already 0 when the handler runs.
   #
-  #     bash 3.2  (macOS runners, /bin/bash)   rc=0
-  #     bash 5.x  (Linux runners)              rc=1
-  #
-  # Measured directly, and with the trap removed both return 1. An earlier
-  # version of this row asserted "must not exit 0" and so passed on Linux and
-  # failed on macOS while the command behaved identically on both — a test of
-  # the runner, not of the CLI.
-  #
-  # Two product findings reported separately, neither fixed here:
-  #   * `dot help theme` documents "interactive picker if omitted", but
-  #     `set_theme "$1"` dies on the unset positional before pick_theme is
-  #     ever reached. `"${1:-}"` would restore the documented behaviour.
-  #   * More seriously, that EXIT trap masks the exit status of ANY failure in
-  #     switch.sh on bash 3.2, so on macOS the script reports success however
-  #     it fails.
-  #
-  # What is contractual on both platforms, and what this row pins: the command
-  # says something rather than failing mute, and it does not change the
-  # configured theme.
+  # Both halves are fixed. `set_theme "${1:-}"` reaches the picker `dot help
+  # theme` documents, so the abort — the only status-losing path on 3.2 — is
+  # gone, and under DOTFILES_NONINTERACTIVE (which the sandbox exports, and
+  # where no picker can run) the command refuses with a usage message and
+  # rc=1 on every shell. tests/unit/theme/test_theme_switch_dispatch.sh pins
+  # the picker path and the bash-3.2 status directly.
   local data="$REPO_ROOT/defaults/.chezmoidata.toml"
   local before
   before="$(sed -n 's/^theme = "\(.*\)"/\1/p' "$data" | head -1)"
 
   test_start "fm_theme_set_missing"
   fm_run theme set
-  if [[ -n "$FM_OUT$FM_ERR" ]]; then
-    fm_pass "reported a diagnostic (rc=$FM_RC)"
-  else
-    fm_fail "theme set with no name produced no output at all"
-  fi
+  fm_expect_rc 1
+  test_start "fm_theme_set_missing_reports_usage"
+  fm_expect_any "dot theme set <name>" "Missing theme name"
 
   test_start "fm_theme_set_missing_does_not_apply_a_theme"
   local after

--- a/tests/regression/test_feature_matrix_appearance_security.sh
+++ b/tests/regression/test_feature_matrix_appearance_security.sh
@@ -14,10 +14,10 @@
 # `defaults write`. Those rows carry a --help smoke test and a recorded
 # reason in the matrix rather than a fake pass.
 #
-# `dot theme set` is worth calling out: it resolves the theme file from the
-# location of the sourced library, not from $HOME, so it rewrites
-# defaults/.chezmoidata.toml in the CHECKOUT even under a sandboxed HOME —
-# and then drives the OS appearance. It is never invoked here.
+# `dot theme set` is worth calling out: it resolves the theme file from
+# CHEZMOI_SOURCE_DIR / $HOME/.dotfiles, which this harness aims at the
+# checkout, and it then drives the real OS appearance. It is never invoked
+# here with a theme name for that second reason.
 
 set -u
 

--- a/tests/regression/test_feature_matrix_diagnostics.sh
+++ b/tests/regression/test_feature_matrix_diagnostics.sh
@@ -76,17 +76,20 @@ test_fm_doctor_heal() {
 }
 
 test_fm_doctor_audit() {
-  # KNOWN BUG (reported, not fixed here — scripts/diagnostics is another
-  # agent's file): doctor-unified.sh maps --audit to scripts/ops/health-check.sh,
-  # which does not exist in the tree, so the flag currently dies with
-  # "Script not found". The assertion below passes both before and after that
-  # is fixed: what is pinned is that --audit is RECOGNISED as a flag and
-  # routed somewhere, not that the target happens to be missing today.
+  # --audit used to map to scripts/ops/health-check.sh, which has never been
+  # in the tree, so the flag died with "Script not found". It now routes to
+  # the health dashboard — the audit-shaped diagnostic the name meant.
   test_start "fm_doctor_audit"
   fm_run doctor --audit
   fm_expect_rc_in 0 1
   test_start "fm_doctor_audit_is_routed"
-  fm_expect_any "Script not found" "Health" "health" "audit"
+  fm_expect_any "Health" "health"
+  test_start "fm_doctor_audit_target_exists"
+  if [[ "$FM_OUT$FM_ERR" == *"Script not found"* ]]; then
+    fm_fail "--audit routes to a script that is not in the tree"
+  else
+    fm_pass "the target resolved"
+  fi
 }
 
 test_fm_doctor_json() {

--- a/tests/regression/test_feature_matrix_fleet_registry.sh
+++ b/tests/regression/test_feature_matrix_fleet_registry.sh
@@ -165,31 +165,32 @@ test_fm_fleet_namespace_set() {
   repo="$(fm_repo_copy)"
   local data="$repo/defaults/.chezmoidata.toml"
 
-  # KNOWN BUG (found by this row, reported; scripts/dot/commands/fleet.sh is
-  # not this agent's file to change). cmd_fleet_namespace's `set` arm is
-  #
-  #     if grep -q "^namespace = " "$data_file"; then …rewrite… fi
-  #     ui_ok "Namespace" "Set to '$new_ns'…"
-  #
-  # so when the key is absent it writes NOTHING and still reports success.
-  # The shipped defaults/.chezmoidata.toml has no top-level `namespace` key,
-  # so on a fresh checkout `dot fleet namespace set X` is a silent no-op.
-  # `dot profile set` handles the same case correctly, by appending the key.
+  # The case a fresh checkout is actually in: no top-level `namespace` key.
+  # cmd_fleet_namespace used to rewrite only when the key was already there
+  # while reporting success either way, so `dot fleet namespace set X` was a
+  # silent no-op on the shipped file. It now inserts the key, as `dot profile
+  # set` does for `profile`.
   test_start "fm_fleet_namespace_set_reports_success_without_the_key"
   grep -q '^namespace = ' "$data" && sed -i.bak '/^namespace = /d' "$data"
   fm_run_bin "$repo/bin/dot" fleet namespace set fm-engineering
   fm_expect_rc 0
+  test_start "fm_fleet_namespace_set_writes_the_missing_key"
+  if grep -q '^namespace = "fm-engineering"' "$data"; then
+    fm_pass "key inserted at the top level"
+  else
+    fm_fail "namespace set reported success without writing the key"
+  fi
 
-  # The working path: with the key present, the value must be rewritten.
-  printf 'namespace = "default"\n' >>"$data"
+  # The rewrite path: with the key present (the row above just inserted it),
+  # the value must be replaced in place rather than duplicated.
   test_start "fm_fleet_namespace_set"
   fm_run_bin "$repo/bin/dot" fleet namespace set fm-engineering
   fm_expect_rc 0
   test_start "fm_fleet_namespace_set_persists"
-  if grep -q 'namespace = "fm-engineering"' "$data"; then
-    fm_pass "written to the copy"
+  if [[ "$(grep -c '^namespace = "fm-engineering"' "$data")" == "1" ]]; then
+    fm_pass "written to the copy, exactly once"
   else
-    fm_fail "namespace not persisted even with the key present"
+    fm_fail "namespace not persisted exactly once: $(grep -c '^namespace = ' "$data") key(s)"
   fi
   test_start "fm_fleet_namespace_set_is_visible_to_show"
   fm_run_bin "$repo/bin/dot" fleet namespace

--- a/tests/regression/test_feature_matrix_fleet_registry.sh
+++ b/tests/regression/test_feature_matrix_fleet_registry.sh
@@ -483,24 +483,13 @@ JSON
   printf '%s\n' "$dir/index.json"
 }
 
-# The registry cache lives at one fixed path and is considered fresh for six
-# hours REGARDLESS of which URL it came from, so a row that points
-# DOTFILES_REGISTRY_URL at a different index still reads the previous one
-# unless the cache is dropped first. (Worth knowing outside the tests too: a
-# user who changes their registry URL keeps serving the old index for up to
-# six hours.)
+# The index cache is keyed by URL and kept for six hours, so a row that wants
+# a fresh fetch from the same URL has to drop it first. (Pointing
+# DOTFILES_REGISTRY_URL somewhere else no longer serves the previous
+# registry's index — that was a reported bug, now fixed and pinned by
+# tests/unit/dot-cli/test_dot_registry_cache_per_url.sh.)
 fm_registry_clear_cache() {
-  rm -f "$XDG_CACHE_HOME/dotfiles/registry/index.json"
-}
-
-# The registry cache lives at one fixed path and is considered fresh for six
-# hours REGARDLESS of which URL it came from, so a row that points
-# DOTFILES_REGISTRY_URL at a different index still reads the previous one
-# unless the cache is dropped first. (Worth knowing outside the tests too: a
-# user who changes their registry URL keeps serving the old index for up to
-# six hours.)
-fm_registry_clear_cache() {
-  rm -f "$XDG_CACHE_HOME/dotfiles/registry/index.json"
+  rm -f "$XDG_CACHE_HOME"/dotfiles/registry/index-*.json
 }
 
 fm_registry_url() {

--- a/tests/regression/test_feature_matrix_secrets.sh
+++ b/tests/regression/test_feature_matrix_secrets.sh
@@ -127,12 +127,11 @@ test_fm_secrets_set() {
   fi
   test_start "fm_secrets_set"
   fm_run secrets set FM_DEMO_KEY fm-demo-value
-  # KNOWN BUG (reported): the plain-enc store aborts with
-  # "tmp_rec: unbound variable" under `set -u` after it has already written
-  # the encrypted file, so `set` exits non-zero even though the secret is
-  # stored. The round trip below is the real assertion; this row only pins
-  # that the command does not silently claim success while storing nothing.
-  fm_expect_rc_in 0 1
+  # The plain-enc store used to abort with "tmp_rec: unbound variable" under
+  # `set -u` after it had already written the encrypted file, so `set` exited
+  # non-zero on a write that had in fact succeeded. A successful store now
+  # reports success.
+  fm_expect_rc 0
   test_start "fm_secrets_set_indexes_the_key"
   fm_run secrets list
   fm_expect_out "FM_DEMO_KEY"

--- a/tests/regression/test_feature_matrix_tools.sh
+++ b/tests/regression/test_feature_matrix_tools.sh
@@ -234,16 +234,14 @@ test_fm_tools() {
 }
 
 test_fm_tools_docs() {
-  # KNOWN BUG (reported, not fixed here — scripts/dot/commands is shared):
-  # cmd_tools looks for <src>/docs/TOOLS.md and <src>/docs/UTILS.md, but both
-  # live under docs/reference/, so `dot tools docs` reports "TOOLS.md not
-  # found" on a complete checkout. The assertion pins that the subcommand is
-  # routed and names the document either way.
+  # cmd_tools used to look only in <src>/docs/; both documents live under
+  # docs/reference/, so `dot tools docs` reported "TOOLS.md not found" on a
+  # complete checkout. The reference location is probed first now.
   test_start "fm_tools_docs"
   fm_run tools docs
-  fm_expect_rc_in 0 1
+  fm_expect_rc 0
   test_start "fm_tools_docs_names_the_document"
-  fm_expect_any "TOOLS.md" "Tools"
+  fm_expect_out "Integrated tools organized by role"
 }
 
 test_fm_smoke_tools_install() { fm_smoke tools; }

--- a/tests/unit/auto/test_auto_cmd_registry.sh
+++ b/tests/unit/auto/test_auto_cmd_registry.sh
@@ -34,10 +34,15 @@ fi
 # Point the fetcher at the in-repo sample registry and seed the cache
 # so list/search/info stay offline. The smoke also exercises
 # _registry_url's DOTFILES_REGISTRY_URL branch.
+#
+# The cache is keyed by URL (a fixed index.json would be served for whichever
+# registry was fetched first), so ask the module itself where this URL's
+# index belongs rather than hard-coding the file name.
 LOCAL_REGISTRY="file://$REPO_ROOT/docs/registry.json"
 export DOTFILES_REGISTRY_URL="$LOCAL_REGISTRY"
-mkdir -p "$XDG_CACHE_HOME/dotfiles/registry"
-cp "$REPO_ROOT/docs/registry.json" "$XDG_CACHE_HOME/dotfiles/registry/index.json"
+REGISTRY_CACHE_FILE="$(bash -c 'source "$1"; _registry_cache_file' _ "$SCRIPT_FILE")"
+mkdir -p "$(dirname "$REGISTRY_CACHE_FILE")"
+cp "$REPO_ROOT/docs/registry.json" "$REGISTRY_CACHE_FILE"
 
 for sub in "--help" "url" "list"; do
   test_start "dot_registry_$(echo "$sub" | tr -d -- '-')"
@@ -116,7 +121,15 @@ registry_tmp="$DOTFILES_COV_TMPDIR/registry-deep"
 mkdir -p "$registry_tmp/config/dotfiles" \
   "$registry_tmp/cache/dotfiles/registry" \
   "$registry_tmp/bin"
-cat >"$registry_tmp/cache/dotfiles/registry/index.json" <<'JSON'
+# Seeded at the cache path this URL maps to — the cache is keyed by URL.
+REGISTRY_DEEP_CACHE="$(
+  HOME="$registry_tmp/home" \
+    XDG_CONFIG_HOME="$registry_tmp/config" \
+    XDG_CACHE_HOME="$registry_tmp/cache" \
+    DOTFILES_REGISTRY_URL="" \
+    bash -c 'source "$1"; _registry_cache_file' _ "$SCRIPT_FILE"
+)"
+cat >"$REGISTRY_DEEP_CACHE" <<'JSON'
 {
   "version": 1,
   "updated": "2026-07-22T12:00:00Z",
@@ -215,7 +228,7 @@ chmod +x "$registry_tmp/bin/curl"
   cmd_registry --help
   cmd_registry not-a-real-subcommand
 
-  rm -f "$registry_tmp/cache/dotfiles/registry/index.json"
+  rm -f "$registry_tmp"/cache/dotfiles/registry/index-*.json
   DOTFILES_REGISTRY_URL="https://registry.example/index.json" _registry_fetch
 ) >/dev/null || true
 assert_file_contains "$registry_tmp/config/dotfiles/registry.toml" \

--- a/tests/unit/auto/test_auto_dot_driver.sh
+++ b/tests/unit/auto/test_auto_dot_driver.sh
@@ -210,7 +210,14 @@ declare -a PROBES=(
   "fleet_drift_h   fleet drift history"
   "fleet_drift_p   fleet drift predict"
   "fleet_drift_c   fleet drift check"
-  "fleet_ns_set    fleet namespace set engineering"
+  # NOT `fleet namespace set`: that arm writes .chezmoidata.toml, and its
+  # target is resolved from the location of the sourced library rather than
+  # from $HOME, so a sandboxed HOME does not keep it out of the checkout. It
+  # was harmless here only for as long as the arm was a silent no-op when the
+  # file had no `namespace` key — the bug fixed in
+  # scripts/dot/commands/fleet.sh. The set arm is covered against a fake
+  # source tree by tests/unit/dot-cli/test_dot_fleet_namespace_enforce_apply.sh.
+  "fleet_ns_show   fleet namespace show"
   # ── manual subcommand probes ──
   "manual_help     manual --help"
   "manual_open     manual open"

--- a/tests/unit/diagnostics/test_diagnostics_doctor_unified_dispatch.sh
+++ b/tests/unit/diagnostics/test_diagnostics_doctor_unified_dispatch.sh
@@ -38,8 +38,8 @@ mkdir -p "$TMP/du-home"
 # while still proving doctor-unified reached its exec.
 DU_BIN="$TMP/du-bin"
 mkdir -p "$DU_BIN"
-for _t in cat env printf sed grep tr head dirname basename mktemp rm uname \
-  locale tput wc awk; do
+for _t in cat env printf sed grep tr head tail dirname basename mktemp rm uname \
+  locale tput wc awk date cut sort stat; do
   _p="$(command -v "$_t" 2>/dev/null || true)"
   [[ -n "$_p" ]] && ln -sf "$_p" "$DU_BIN/$_t"
 done
@@ -54,6 +54,28 @@ _run_du() {
       env BASH_XTRACEFD=21 PATH="$DU_BIN" HOME="$TMP/du-home" DOTFILES_ACCESSIBILITY=1 \
         "$BASH" "$DU_FILE" "$@" </dev/null 2>&1
   )" || DU_RC=$?
+}
+
+# _du_expect_out <label> <needle…> — assert on the target's output only.
+# After `exec` the exit status belongs to the target, not to
+# doctor-unified.sh, so a status assertion there would be testing the
+# diagnostic (and the runner it found) rather than the routing.
+_du_expect_out() {
+  local label="$1"
+  shift
+  local needle problems=""
+  for needle in "$@"; do
+    [[ "$DU_OUT" == *"$needle"* ]] || problems="${problems}\n      missing: $needle"
+  done
+  test_start "$label"
+  if [[ -z "$problems" ]]; then
+    ((TESTS_PASSED++)) || true
+    printf '%b\n' "  ${GREEN}✓${NC} $CURRENT_TEST (target rc=$DU_RC)"
+  else
+    ((TESTS_FAILED++)) || true
+    printf '%b\n' "  ${RED}✗${NC} $CURRENT_TEST$problems"
+    printf '%s\n' "$DU_OUT" | tail -20 | sed 's/^/      /'
+  fi
 }
 
 _du_expect() {
@@ -76,30 +98,54 @@ _du_expect() {
 }
 
 # =======================================================================
-# 1. `--audit` maps to scripts/ops/health-check.sh, which the repo does
-#    not ship: that is the missing-target guard.
+# 1. Every flag maps to a script that is actually in the tree.
+#
+#    Regression: `--audit` mapped to scripts/ops/health-check.sh, which
+#    has never existed here, so the flag died with "Script not found" for
+#    every user who tried it — a routing table nobody had checked against
+#    the filesystem. Read the targets out of the case arms rather than
+#    listing them here, so a new flag is covered the day it is added.
+# =======================================================================
+test_start "every_flag_target_exists_in_the_tree"
+_missing=""
+_targets=0
+while IFS= read -r _target; do
+  [[ -n "$_target" ]] || continue
+  _targets=$((_targets + 1))
+  [[ -f "$REPO_ROOT/$_target" ]] || _missing="$_missing $_target"
+done < <(sed -n 's/^[[:space:]]*--[a-z]*[^)]*)[[:space:]]*target="\([^"]*\)".*/\1/p' "$DU_FILE")
+if [[ "$_targets" -ge 6 && -z "$_missing" ]]; then
+  ((TESTS_PASSED++)) || true
+  printf '%b\n' "  ${GREEN}✓${NC} $CURRENT_TEST ($_targets targets)"
+else
+  ((TESTS_FAILED++)) || true
+  printf '%b\n' "  ${RED}✗${NC} $CURRENT_TEST: parsed $_targets target(s), missing:$_missing"
+fi
+
+# =======================================================================
+# 2. `--audit` reaches the health dashboard rather than a missing file.
 # =======================================================================
 _run_du --audit
-_du_expect "audit_flag_reports_missing_target" 1 \
-  "Script not found" "scripts/ops/health-check.sh"
+_du_expect_out "audit_flag_execs_the_health_dashboard" "Dotfiles Health Dashboard"
 
 _run_du -a
-_du_expect "audit_short_flag_reports_missing_target" 1 "scripts/ops/health-check.sh"
+_du_expect_out "audit_short_flag_execs_the_health_dashboard" "Dotfiles Health Dashboard"
 
 # =======================================================================
-# 2. Every other flag arm runs in a single pass. The loop visits each
-#    case arm in argv order, so ending on --audit keeps the exec away
-#    from a real diagnostic while still proving the mappings ran.
+# 3. Every other flag arm runs in a single pass. The loop visits each
+#    case arm in argv order, so ending on --audit keeps the exec on the
+#    cheapest of the targets while still proving the mappings ran.
 # =======================================================================
 _run_du --heal --score --smoke --drift --benchmark --json --ai extra-arg --audit
-_du_expect "all_flag_arms_are_visited_last_one_wins" 1 \
-  "Script not found" "scripts/ops/health-check.sh"
+# --json rides along in this pass, so the target renders JSON rather than the
+# dashboard banner; assert on a check name, which both forms carry.
+_du_expect_out "all_flag_arms_are_visited_last_one_wins" "Chezmoi installed"
 
 _run_du -H -s -m -d -b -j -A -a
-_du_expect "short_flag_arms_are_visited" 1 "scripts/ops/health-check.sh"
+_du_expect_out "short_flag_arms_are_visited" "Chezmoi installed"
 
 # =======================================================================
-# 3. A resolvable target is exec'd. `--benchmark` picks tests/benchmark.sh,
+# 4. A second resolvable target. `--benchmark` picks tests/benchmark.sh,
 #    which is the cheapest of the six and needs no fixture.
 #
 #    The assertion is on the banner the target prints, not on the exit

--- a/tests/unit/dot-cli/test_dot_agent_checkpoint.sh
+++ b/tests/unit/dot-cli/test_dot_agent_checkpoint.sh
@@ -174,4 +174,63 @@ AGENT_PROFILE_CONFIG="$STRICT_PROFILES" meta agent delegate lint-checker bash -c
 assert_equals 4 "$RC" "rc"
 assert_contains "failed (exit 4)" "$OUT" "failure line"
 
+# ── delegate without GNU timeout ────────────────────────────────────────
+# Regression: the arm was `if timeout "$delegate_timeout" "$@"`. `timeout` is
+# GNU coreutils; stock macOS ships neither it nor `gtimeout` (that arrives
+# only with `brew install coreutils`), so on a clean Mac the delegated command
+# never ran at all — `dot agent delegate` is unusable on the platform this
+# repo primarily targets. $NOTIME is a curated bin dir with everything the
+# command needs and no timeout binary of either name.
+NOTIME="$DOTFILES_COV_TMPDIR/no-timeout-bin"
+mkdir -p "$NOTIME"
+for _t in bash sh env jq sed awk grep cat date mkdir rm mv cp mktemp dirname \
+  basename head tail tr cut sort uniq wc uname tput stty ls find chmod touch \
+  comm realpath readlink id hostname sleep perl; do
+  _p="$(command -v "$_t" 2>/dev/null || true)"
+  [[ -n "$_p" ]] && ln -sf "$_p" "$NOTIME/$_t"
+done
+test_start "delegate_bin_dir_has_no_timeout"
+assert_file_not_exists "$NOTIME/timeout" "the curated PATH must not contain timeout"
+assert_file_not_exists "$NOTIME/gtimeout" "the curated PATH must not contain gtimeout"
+
+test_start "delegate_runs_the_command_without_a_timeout_binary"
+PATH="$NOTIME" AGENT_PROFILE_CONFIG="$STRICT_PROFILES" \
+  meta agent delegate lint-checker bash -c 'printf "delegated-ran\n"'
+assert_equals 0 "$RC" "rc"
+assert_contains "delegated-ran" "$OUT" "the delegated command ran"
+assert_contains "completed" "$OUT" "success line"
+
+test_start "delegate_propagates_failure_without_a_timeout_binary"
+PATH="$NOTIME" AGENT_PROFILE_CONFIG="$STRICT_PROFILES" \
+  meta agent delegate lint-checker bash -c 'exit 4'
+assert_equals 4 "$RC" "rc"
+assert_contains "failed (exit 4)" "$OUT" "the command's own status survives the fallback"
+
+test_start "delegate_enforces_the_limit_without_a_timeout_binary"
+# The fallback must still bound the command, not merely run it. 124 is GNU
+# timeout's expiry status, which the perl fallback reproduces.
+FAST="$DOTFILES_COV_TMPDIR/fast-profiles.json"
+jq '.rbac.enforcement = "strict" | .delegation.enabled = true
+    | .profiles.ask.canDelegate = true
+    | .delegation.allowedDelegates["lint-checker"].timeout = 1' \
+  "$REAL_PROFILES" >"$FAST"
+PATH="$NOTIME" AGENT_PROFILE_CONFIG="$FAST" \
+  meta agent delegate lint-checker bash -c 'sleep 20'
+assert_equals 124 "$RC" "an over-running delegate is killed and reported as 124"
+
+test_start "delegate_runs_unbounded_only_as_a_last_resort"
+# No timeout binary AND no perl: the command must still run, and the lost
+# guarantee must be announced rather than assumed.
+NOPERL="$DOTFILES_COV_TMPDIR/no-perl-bin"
+mkdir -p "$NOPERL"
+for _f in "$NOTIME"/*; do
+  [[ "$(basename "$_f")" == "perl" ]] && continue
+  ln -sf "$(readlink "$_f")" "$NOPERL/$(basename "$_f")"
+done
+PATH="$NOPERL" AGENT_PROFILE_CONFIG="$STRICT_PROFILES" \
+  meta agent delegate lint-checker bash -c 'printf "unbounded-ran\n"'
+assert_equals 0 "$RC" "rc"
+assert_contains "unbounded-ran" "$OUT" "the delegated command still ran"
+assert_contains "without a time limit" "$OUT$ERR" "the missing bound is announced"
+
 echo "RESULTS:$TESTS_RUN:$TESTS_PASSED:$TESTS_FAILED"

--- a/tests/unit/dot-cli/test_dot_commands_agents_render.sh
+++ b/tests/unit/dot-cli/test_dot_commands_agents_render.sh
@@ -132,13 +132,24 @@ done
 assert_contains "rendered → $_root/AGENTS.md" "$_out" "AGENTS.md render reported"
 
 test_start "agents_render_propagates_the_claude_body"
-# NOTE: render pipes the body through
-# `sed '1s/^# CLAUDE\.md.*/# AGENTS.md — AI Assistant Guidelines/'`,
-# but `_agents_body` has already dropped that H1, so the substitution
-# never fires and the rendered file carries no title of its own — the
-# committed AGENTS.md shows the same shape. Pinned as current
-# behaviour; changing it would re-render every harness file.
-assert_output_not_contains "# AGENTS.md — AI Assistant Guidelines" cat "$_root/AGENTS.md"
+# Regression: render used to pipe the body through
+# `sed '1s/^# CLAUDE\.md.*/# AGENTS.md — AI Assistant Guidelines/'`, but
+# `_agents_body` drops the H1 by design, so line 1 was never the CLAUDE.md
+# title, the substitution never fired, and the rendered file carried no title
+# at all. The title is printed directly now.
+assert_file_contains "$_root/AGENTS.md" "# AGENTS.md — AI Assistant Guidelines" \
+  "the rendered file declares its own title"
+test_start "agents_render_puts_the_title_before_the_body"
+_title_line="$(grep -n '^# AGENTS\.md' "$_root/AGENTS.md" | head -1 | cut -d: -f1)"
+_body_line="$(grep -n '^## Conventions' "$_root/AGENTS.md" | head -1 | cut -d: -f1)"
+if [[ -n "$_title_line" && -n "$_body_line" && "$_title_line" -lt "$_body_line" ]]; then
+  ((TESTS_PASSED++)) || true
+  printf '%b\n' "  ${GREEN}✓${NC} $CURRENT_TEST (title on line $_title_line)"
+else
+  ((TESTS_FAILED++)) || true
+  printf '%b\n' "  ${RED}✗${NC} $CURRENT_TEST: title=$_title_line body=$_body_line"
+fi
+test_start "agents_render_propagates_the_claude_body"
 assert_file_contains "$_root/AGENTS.md" "## Conventions" "the first body heading survives"
 assert_file_contains "$_root/AGENTS.md" "Conventional commits." "the CLAUDE.md body is carried over"
 assert_file_contains "$_root/AGENTS.md" "Canonical source: CLAUDE.md" "the do-not-edit header is present"

--- a/tests/unit/dot-cli/test_dot_commands_meta.sh
+++ b/tests/unit/dot-cli/test_dot_commands_meta.sh
@@ -168,6 +168,42 @@ else
 fi
 rm -rf "$_up_sb"
 
+# ── dot keys ─────────────────────────────────────────────────────────
+# Regression: cmd_keys probed <src>/docs/KEYS.md and, when that was absent,
+# fell back to scripts/diagnostics/keys.sh. The keybindings document lives at
+# docs/security/KEYS.md and the fallback script is not in the tree at all, so
+# a bare `dot keys` could only ever answer "Keys script not found".
+_keys_out="$DOTFILES_COV_TMPDIR/keys.out"
+
+test_start "keys_prints_the_keybindings_document"
+_keys_rc=0
+bash "$META_FILE" keys >"$_keys_out" 2>&1 || _keys_rc=$?
+assert_equals "0" "$_keys_rc" "a bare 'dot keys' exits 0 on a complete checkout"
+assert_file_contains "$_keys_out" "# Keybindings" "the document is printed"
+assert_output_not_contains "Keys script not found" "cat '$_keys_out'"
+
+test_start "keys_with_a_query_searches_the_document"
+_keys_rc=0
+bash "$META_FILE" keys "Reload config" >"$_keys_out" 2>&1 || _keys_rc=$?
+assert_equals "0" "$_keys_rc" "a query exits 0"
+assert_file_contains "$_keys_out" "Reload config" "the matching line is shown"
+
+test_start "keys_search_works_without_ripgrep"
+# The CI runners have no ripgrep, and a bare `rg` there printed nothing while
+# exiting 0. $KEYS_BIN is a curated PATH with grep but no rg.
+KEYS_BIN="$DOTFILES_COV_TMPDIR/keys-bin"
+mkdir -p "$KEYS_BIN"
+for _t in bash sh cat env printf sed grep tr head tail dirname basename \
+  mktemp rm uname locale tput wc awk date cut sort realpath readlink; do
+  _p="$(command -v "$_t" 2>/dev/null || true)"
+  [[ -n "$_p" ]] && ln -sf "$_p" "$KEYS_BIN/$_t"
+done
+assert_file_not_exists "$KEYS_BIN/rg" "the curated PATH must not contain ripgrep"
+_keys_rc=0
+PATH="$KEYS_BIN" bash "$META_FILE" keys "Reload config" >"$_keys_out" 2>&1 || _keys_rc=$?
+assert_equals "0" "$_keys_rc" "the search exits 0 without ripgrep"
+assert_file_contains "$_keys_out" "Reload config" "grep answers when rg is absent"
+
 echo ""
 echo "Meta commands tests completed."
 # Slice 3 (#883): exercise the script under sandbox for line coverage

--- a/tests/unit/dot-cli/test_dot_commands_tools.sh
+++ b/tests/unit/dot-cli/test_dot_commands_tools.sh
@@ -260,6 +260,56 @@ assert_dir_exists "$tools_tmp/work/demo_project" "tools deep branches created sa
   bash "$TOOLS_FILE" tools install node >/dev/null
 ) || true
 
+# ── tools docs ───────────────────────────────────────────────────────
+# Regression: cmd_tools looked for <src>/docs/TOOLS.md and <src>/docs/UTILS.md.
+# Both documents live under docs/reference/, so `dot tools docs` answered
+# "TOOLS.md not found" on a complete checkout — the subcommand could not work
+# for anyone. The reference location is probed first, the legacy one after,
+# so a pre-reorg checkout still resolves.
+test_start "tools_docs_prints_the_tools_document"
+_docs_out="$DOTFILES_COV_TMPDIR/tools-docs.out"
+_docs_rc=0
+bash "$TOOLS_FILE" tools docs >"$_docs_out" 2>&1 || _docs_rc=$?
+assert_equals "0" "$_docs_rc" "tools docs exits 0 on a complete checkout"
+assert_file_contains "$_docs_out" "Integrated tools organized by role" \
+  "the body of docs/reference/TOOLS.md is printed"
+assert_output_not_contains "TOOLS.md not found" "cat '$_docs_out'"
+
+test_start "tools_docs_falls_back_to_the_legacy_location"
+# A tree that only has the pre-reorg docs/TOOLS.md must still resolve.
+_legacy="$DOTFILES_COV_TMPDIR/legacy-repo"
+mkdir -p "$_legacy/docs" "$_legacy/lib/dot"
+printf 'legacy-tools-doc\n' >"$_legacy/docs/TOOLS.md"
+_docs_rc=0
+(
+  set +e
+  # shellcheck disable=SC1090
+  source "$REPO_ROOT/lib/dot/utils.sh"
+  # shellcheck disable=SC1090
+  set -- tools
+  source "$TOOLS_FILE" >/dev/null 2>&1
+  _DOT_SOURCE_DIR_CACHE="$_legacy"
+  cmd_tools docs
+) >"$_docs_out" 2>&1 || _docs_rc=$?
+assert_file_contains "$_docs_out" "legacy-tools-doc" "the legacy docs/TOOLS.md is still found"
+
+test_start "tools_docs_reports_a_tree_with_neither_document"
+_bare="$DOTFILES_COV_TMPDIR/bare-repo"
+mkdir -p "$_bare/docs"
+_docs_rc=0
+(
+  set +e
+  # shellcheck disable=SC1090
+  source "$REPO_ROOT/lib/dot/utils.sh"
+  set -- tools
+  # shellcheck disable=SC1090
+  source "$TOOLS_FILE" >/dev/null 2>&1
+  _DOT_SOURCE_DIR_CACHE="$_bare"
+  cmd_tools docs
+) >"$_docs_out" 2>&1 || _docs_rc=$?
+assert_equals "1" "$_docs_rc" "a tree with no tools document fails"
+assert_file_contains "$_docs_out" "TOOLS.md not found" "the missing document is named"
+
 # Slice 3 (#883): exercise the script under sandbox for line coverage
 cov_exercise_script "$TOOLS_FILE"
 

--- a/tests/unit/dot-cli/test_dot_fleet_namespace_enforce_apply.sh
+++ b/tests/unit/dot-cli/test_dot_fleet_namespace_enforce_apply.sh
@@ -174,6 +174,11 @@ assert_contains "Invalid namespace" "$out" "validation message"
 assert_file_contains "$DATA" 'namespace = "lab"' "data file untouched"
 
 test_start "fleet_namespace_set_without_existing_key"
+# Regression: the `set` arm only rewrote the file when a `namespace = ` key
+# was already there, yet reported success either way — and the shipped
+# defaults/.chezmoidata.toml has no such key, so on a fresh checkout the
+# command was a silent no-op. It must append the key, as `dot profile set`
+# does for `profile`.
 write_data <<'TOML'
 node_id = "node-a"
 TOML
@@ -181,7 +186,20 @@ out="$(fleet namespace set fresh 2>&1)"
 rc=$?
 assert_equals 0 "$rc" "set without a namespace line still succeeds"
 assert_contains "Set to 'fresh'" "$out" "confirmation message"
-assert_equals "" "$(grep '^namespace' "$DATA")" "no namespace line is invented"
+assert_file_contains "$DATA" 'namespace = "fresh"' "the missing key is appended, not skipped"
+assert_equals "1" "$(grep -c '^namespace = ' "$DATA")" "exactly one namespace key is written"
+assert_file_contains "$DATA" 'node_id = "node-a"' "the rest of the file survives"
+
+test_start "fleet_namespace_set_without_existing_key_is_visible_to_show"
+out="$(fleet namespace show 2>&1)"
+assert_contains "fresh" "$out" "the appended namespace is the active one"
+
+test_start "fleet_namespace_set_appends_idempotently"
+out="$(fleet namespace set fresher 2>&1)"
+rc=$?
+assert_equals 0 "$rc" "a second set exits 0"
+assert_file_contains "$DATA" 'namespace = "fresher"' "the appended key is rewritten in place"
+assert_equals "1" "$(grep -c '^namespace = ' "$DATA")" "no duplicate key is appended"
 
 write_data <<'TOML'
 namespace = "team"

--- a/tests/unit/dot-cli/test_dot_registry_cache_per_url.sh
+++ b/tests/unit/dot-cli/test_dot_registry_cache_per_url.sh
@@ -143,4 +143,27 @@ assert_equals "2" "$(printf '%s\n' "$paths" | sort -u | wc -l | tr -d ' ')" \
   "two URLs must map to two cache files"
 assert_output_not_contains "/index.json" "printf '%s' '$paths'"
 
+test_start "the_cache_key_falls_back_to_cksum_without_a_sha256_tool"
+# Not every host has shasum or sha256sum (busybox images, trimmed containers).
+# The key must still be stable and per-URL there — it is a cache key, not a
+# security boundary.
+NOSHA="$DOTFILES_COV_TMPDIR/no-sha-bin"
+mkdir -p "$NOSHA"
+for _t in bash sh cat env printf sed grep awk tr head tail cut sort wc \
+  mktemp rm mkdir dirname basename date uname cksum stat curl jq tput stty; do
+  _p="$(command -v "$_t" 2>/dev/null || true)"
+  [[ -n "$_p" ]] && ln -sf "$_p" "$NOSHA/$_t"
+done
+assert_file_not_exists "$NOSHA/shasum" "the curated PATH must not contain shasum"
+assert_file_not_exists "$NOSHA/sha256sum" "the curated PATH must not contain sha256sum"
+keys="$(PATH="$NOSHA" bash -c '
+  source "$1"
+  _registry_cache_key "$2"
+  _registry_cache_key "$3"
+  _registry_cache_key "$2"
+' _ "$REGISTRY_SH" "$URL_A" "$URL_B")"
+assert_equals "3" "$(printf '%s\n' "$keys" | grep -c .)" "three keys printed"
+assert_equals "2" "$(printf '%s\n' "$keys" | sort -u | wc -l | tr -d ' ')" \
+  "two URLs, two keys, and the same URL keys the same way twice"
+
 echo "RESULTS:$TESTS_RUN:$TESTS_PASSED:$TESTS_FAILED"

--- a/tests/unit/dot-cli/test_dot_registry_cache_per_url.sh
+++ b/tests/unit/dot-cli/test_dot_registry_cache_per_url.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright (c) 2015-2026 Sebastien Rousseau
+# shellcheck disable=SC1090,SC1091,SC2034
+#
+# The registry index cache must be keyed by the URL it came from.
+#
+# It used to live at <cache>/index.json for every registry and be treated as
+# fresh for six hours, so pointing DOTFILES_REGISTRY_URL at a different index
+# (or running `dot registry set-url`) kept serving the previous registry's
+# modules until the TTL expired. Nothing about the six-hour window says which
+# registry produced the file.
+#
+# curl is shimmed to copy a local fixture, so no test here touches the
+# network; every index is served from a file the test wrote.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+source "$SCRIPT_DIR/../../framework/assertions.sh"
+source "$SCRIPT_DIR/../../framework/coverage_helpers.sh"
+
+REGISTRY_SH="$REPO_ROOT/scripts/dot/commands/registry.sh"
+
+trap cov_teardown_sandbox EXIT
+cov_setup_sandbox
+# XDG_RUNTIME_DIR belongs inside the sandbox too: leaving it unset sends any
+# lock or socket a command opens to a machine-global /tmp path shared with
+# every other test process the runner has in flight.
+export XDG_RUNTIME_DIR="$DOTFILES_COV_TMPDIR/run"
+mkdir -p "$XDG_RUNTIME_DIR"
+
+WORK="$DOTFILES_COV_TMPDIR/registry-cache"
+BIN="$DOTFILES_COV_TMPDIR/bin"
+mkdir -p "$WORK"
+
+test_start "registry_module_exists"
+assert_file_exists "$REGISTRY_SH" "scripts/dot/commands/registry.sh must exist"
+
+if ! command -v jq >/dev/null 2>&1; then
+  test_start "registry_cache_per_url"
+  ((TESTS_PASSED++)) || true
+  printf '%b\n' "  ${GREEN}✓${NC} $CURRENT_TEST: skipped — jq not installed"
+  echo "RESULTS:$TESTS_RUN:$TESTS_PASSED:$TESTS_FAILED"
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Two registries, each valid against _registry_validate_index's schema.
+# ---------------------------------------------------------------------------
+_fixture() {
+  local path="$1" module="$2"
+  cat >"$path" <<JSON
+{
+  "version": 1,
+  "modules": [
+    {
+      "name": "$module",
+      "description": "fixture module $module",
+      "tags": ["fixture"],
+      "version": "1.0.0",
+      "archive_url": "https://example.com/$module-1.0.0.tar.gz",
+      "sha256": "$(printf 'a%.0s' $(seq 1 64))"
+    }
+  ]
+}
+JSON
+}
+_fixture "$WORK/alpha.json" "alpha-module"
+_fixture "$WORK/beta.json" "beta-module"
+
+# curl shim: serves whichever fixture $FAKE_CURL_SOURCE names, and records
+# every call so "was this a cache hit?" is answerable.
+CURL_LOG="$WORK/curl.log"
+cat >"$BIN/curl" <<SHIM
+#!/usr/bin/env bash
+out=""
+url=""
+while (( \$# )); do
+  case "\$1" in
+    -o)
+      out="\$2"
+      shift 2
+      ;;
+    -*) shift ;;
+    *)
+      url="\$1"
+      shift
+      ;;
+  esac
+done
+printf '%s\n' "\$url" >>"$CURL_LOG"
+[[ -n "\$out" ]] && cp "\$FAKE_CURL_SOURCE" "\$out"
+exit 0
+SHIM
+chmod +x "$BIN/curl"
+: >"$CURL_LOG"
+
+# fetch <url> <fixture> — run _registry_fetch for a URL and print the module
+# name the returned index contains.
+fetch() {
+  local url="$1" source_file="$2"
+  DOTFILES_REGISTRY_URL="$url" FAKE_CURL_SOURCE="$source_file" \
+    PATH="$BIN:$PATH" \
+    bash -c '
+      source "$1"
+      index="$(_registry_fetch)" || exit $?
+      jq -r ".modules[0].name" "$index"
+    ' _ "$REGISTRY_SH" 2>/dev/null
+}
+
+URL_A="https://alpha.example/registry.json"
+URL_B="https://beta.example/registry.json"
+
+test_start "the_first_fetch_populates_the_cache"
+got="$(fetch "$URL_A" "$WORK/alpha.json")"
+assert_equals "alpha-module" "$got" "the first registry's index is served"
+assert_equals "1" "$(wc -l <"$CURL_LOG" | tr -d ' ')" "one fetch so far"
+
+test_start "a_second_fetch_of_the_same_url_is_served_from_the_cache"
+got="$(fetch "$URL_A" "$WORK/alpha.json")"
+assert_equals "alpha-module" "$got" "the cached index is reused"
+assert_equals "1" "$(wc -l <"$CURL_LOG" | tr -d ' ')" "no second fetch inside the TTL"
+
+test_start "changing_the_registry_url_does_not_serve_the_previous_index"
+got="$(fetch "$URL_B" "$WORK/beta.json")"
+assert_equals "beta-module" "$got" "the new registry's index is served, not the cached one"
+assert_equals "2" "$(wc -l <"$CURL_LOG" | tr -d ' ')" "the new URL is actually fetched"
+
+test_start "switching_back_reuses_the_first_registrys_cache"
+got="$(fetch "$URL_A" "$WORK/beta.json")"
+assert_equals "alpha-module" "$got" "each URL keeps its own cached index"
+assert_equals "2" "$(wc -l <"$CURL_LOG" | tr -d ' ')" "no refetch when switching back inside the TTL"
+
+test_start "each_url_has_its_own_cache_file"
+paths="$(DOTFILES_REGISTRY_URL="" PATH="$BIN:$PATH" bash -c '
+  source "$1"
+  _registry_cache_file "$2"
+  _registry_cache_file "$3"
+' _ "$REGISTRY_SH" "$URL_A" "$URL_B")"
+assert_equals "2" "$(printf '%s\n' "$paths" | sort -u | wc -l | tr -d ' ')" \
+  "two URLs must map to two cache files"
+assert_output_not_contains "/index.json" "printf '%s' '$paths'"
+
+echo "RESULTS:$TESTS_RUN:$TESTS_PASSED:$TESTS_FAILED"

--- a/tests/unit/dot-cli/test_registry_failure_paths.sh
+++ b/tests/unit/dot-cli/test_registry_failure_paths.sh
@@ -201,24 +201,37 @@ assert_not_equals "0" "$rc" "an unreachable index with no cache fails"
 assert_file_contains "$ERR" "could not fetch" "the error names the fetch"
 
 test_start "stale_cache_is_used_when_the_fetch_fails"
-# Prime the cache from a good index, age it past the 6h TTL, then point the
-# registry at a URL that cannot be fetched.
-export DOTFILES_REGISTRY_URL="file://$GOOD_INDEX"
+# Prime the cache from a good index, age it past the 6h TTL, then make THAT
+# URL unfetchable. Same URL throughout: the cache is keyed by URL, so the
+# fallback is "the registry you asked for is unreachable, here is the copy we
+# have of it" — never another registry's index.
+export DOTFILES_REGISTRY_URL="file://$WORK/vanishing.json"
+cp "$GOOD_INDEX" "$WORK/vanishing.json"
 clear_cache
 run list >/dev/null
-cache_file="$(_registry_cache_dir)/index.json"
+cache_file="$(_registry_cache_file)"
 assert_file_exists "$cache_file" "the index was cached"
 touch -t 202001010000 "$cache_file"
-export DOTFILES_REGISTRY_URL="file://$WORK/does-not-exist.json"
+rm -f "$WORK/vanishing.json"
 rc="$(run list)"
 assert_equals "0" "$rc" "a stale cache still serves the listing"
 assert_file_contains "$ERR" "using stale cache" "the fallback is announced on stderr"
 assert_file_contains "$OUT" "good-module" "the stale index contents are shown"
 
+test_start "a_different_url_does_not_borrow_that_stale_cache"
+# The cache above is still on disk and still stale. A different registry URL
+# that cannot be fetched must fail rather than serve it — the whole point of
+# keying the cache by URL.
+export DOTFILES_REGISTRY_URL="file://$WORK/does-not-exist.json"
+rc="$(run list)"
+assert_not_equals "0" "$rc" "another registry's stale cache is not served"
+assert_file_contains "$ERR" "could not fetch" "the unreachable URL is reported"
+
 test_start "corrupt_cache_is_discarded_and_refetched"
 export DOTFILES_REGISTRY_URL="file://$GOOD_INDEX"
 clear_cache
 run list >/dev/null
+cache_file="$(_registry_cache_file)"
 printf 'not json at all\n' >"$cache_file"
 rc="$(run list)"
 assert_equals "0" "$rc" "a cache that fails validation is replaced, not served"

--- a/tests/unit/functions/test_secrets_provider_behavior.sh
+++ b/tests/unit/functions/test_secrets_provider_behavior.sh
@@ -167,6 +167,77 @@ dot_secrets_get "some-key" 2>/dev/null
 # rc=3 (provider returned empty). "No provider configured" is rc=2.
 assert_equals "2" "$?" "dot_secrets_get with no provider should return exit code 2 (rc=1 was the pre-N6 behavior)"
 
+# ──────────────────────────────────────────────────────────────────────────────
+# 12. plain-enc: a successful write must report success
+#
+# Regression: dot_secrets_store_plain_enc set `trap 'rm -f "$tmp_rec"' RETURN`
+# on a variable local to itself. A RETURN trap set inside a function fires
+# again when its CALLER returns — dot_secrets_set — by which point tmp_rec is
+# out of scope, so under `set -u` the whole call aborted with
+# "tmp_rec: unbound variable" AFTER the encrypted file had been written.
+# `dot secrets set` exited non-zero on a write that had in fact succeeded, and
+# the key never reached the index because index_add came after the store.
+#
+# Run in a child shell with `set -euo pipefail` — this file runs with `set +e`,
+# which is exactly the condition that hides the bug.
+# ──────────────────────────────────────────────────────────────────────────────
+test_start "secrets_set_plain_enc_reports_a_successful_write"
+_PLAIN_TMP="$(portable_mktemp_dir)"
+mkdir -p "$_PLAIN_TMP/bin"
+cat >"$_PLAIN_TMP/bin/age-keygen" <<'SHIM'
+#!/usr/bin/env bash
+[[ "${1:-}" == "-y" ]] && printf 'age1testrecipient\n'
+exit 0
+SHIM
+cat >"$_PLAIN_TMP/bin/age" <<'SHIM'
+#!/usr/bin/env bash
+out=""
+while (($#)); do
+  case "$1" in
+    -o)
+      out="$2"
+      shift 2
+      ;;
+    *) shift ;;
+  esac
+done
+if [[ -n "$out" ]]; then
+  cat >"$out"
+else
+  cat >/dev/null
+fi
+exit 0
+SHIM
+chmod +x "$_PLAIN_TMP/bin/age-keygen" "$_PLAIN_TMP/bin/age"
+printf 'AGE-SECRET-KEY-TEST\n' >"$_PLAIN_TMP/key.txt"
+
+mkdir -p "$_PLAIN_TMP/tmp"
+_plain_out="$(
+  PATH="$_PLAIN_TMP/bin:$PATH" \
+    TMPDIR="$_PLAIN_TMP/tmp" \
+    DOTFILES_SECRETS_PROVIDER=plain-enc \
+    DOT_SECRETS_HOME="$_PLAIN_TMP/secrets" \
+    DOT_SECRETS_STORE_DIR="$_PLAIN_TMP/secrets/store" \
+    DOT_SECRETS_INDEX_FILE="$_PLAIN_TMP/secrets/index.txt" \
+    DOT_SECRETS_AGE_KEY="$_PLAIN_TMP/key.txt" \
+    bash -c 'set -euo pipefail; source "$1"; dot_secrets_set PLAIN_KEY plain-value' \
+    _ "$SECRETS_FILE" 2>&1
+)"
+_plain_rc=$?
+assert_equals "0" "$_plain_rc" "a successful plain-enc write must exit 0"
+assert_output_not_contains "unbound variable" "printf '%s' \"\$_plain_out\""
+assert_file_exists "$_PLAIN_TMP/secrets/store/PLAIN_KEY.age" "the encrypted file is written"
+assert_file_contains "$_PLAIN_TMP/secrets/index.txt" "PLAIN_KEY" \
+  "the key reaches the index, which only happens if the store call returned"
+
+test_start "secrets_set_plain_enc_leaves_no_recipient_file_behind"
+# The recipient file the store writes is a temporary; dropping the RETURN
+# trap must not mean dropping the cleanup. TMPDIR was private to the child,
+# so anything left there is ours.
+_leftover="$(find "$_PLAIN_TMP/tmp" -type f 2>/dev/null | wc -l | tr -d ' ')"
+assert_equals "0" "$_leftover" "the temporary recipient file is removed"
+rm -rf "$_PLAIN_TMP"
+
 # Cleanup
 rm -rf "$_TMP_SECRETS"
 mock_cleanup

--- a/tests/unit/functions/test_secrets_provider_behavior.sh
+++ b/tests/unit/functions/test_secrets_provider_behavior.sh
@@ -230,6 +230,30 @@ assert_file_exists "$_PLAIN_TMP/secrets/store/PLAIN_KEY.age" "the encrypted file
 assert_file_contains "$_PLAIN_TMP/secrets/index.txt" "PLAIN_KEY" \
   "the key reaches the index, which only happens if the store call returned"
 
+test_start "secrets_set_plain_enc_reports_a_failing_encryption"
+# The trap that used to clean up also swallowed nothing useful: with it gone,
+# a failing age-keygen or age must be reported rather than assumed to work,
+# or a failed encryption would look exactly like a stored secret.
+cat >"$_PLAIN_TMP/bin/age" <<'SHIM'
+#!/usr/bin/env bash
+exit 3
+SHIM
+chmod +x "$_PLAIN_TMP/bin/age"
+_fail_out="$(
+  PATH="$_PLAIN_TMP/bin:$PATH" \
+    TMPDIR="$_PLAIN_TMP/tmp" \
+    DOTFILES_SECRETS_PROVIDER=plain-enc \
+    DOT_SECRETS_HOME="$_PLAIN_TMP/secrets" \
+    DOT_SECRETS_STORE_DIR="$_PLAIN_TMP/secrets/store" \
+    DOT_SECRETS_INDEX_FILE="$_PLAIN_TMP/secrets/index.txt" \
+    DOT_SECRETS_AGE_KEY="$_PLAIN_TMP/key.txt" \
+    bash -c 'set -euo pipefail; source "$1"; dot_secrets_set FAIL_KEY v' \
+    _ "$SECRETS_FILE" 2>&1
+)"
+_fail_rc=$?
+assert_not_equals "0" "$_fail_rc" "a failing age must not report success"
+assert_output_not_contains "FAIL_KEY" "cat '$_PLAIN_TMP/secrets/index.txt'"
+
 test_start "secrets_set_plain_enc_leaves_no_recipient_file_behind"
 # The recipient file the store writes is a temporary; dropping the RETURN
 # trap must not mean dropping the cleanup. TMPDIR was private to the child,

--- a/tests/unit/misc/test_qa_check_feature_matrix.sh
+++ b/tests/unit/misc/test_qa_check_feature_matrix.sh
@@ -89,6 +89,26 @@ assert_exit_code 1 "cd '$scratch' && REPO_ROOT='$scratch' bash '$scratch/scripts
 
 rm -rf "$scratch"
 
+# 5. No test functions at all: the gate's own diagnostic must be the one that
+#    fires. Regression: the `grep … | sed | sort` that fills defined-tests.txt
+#    runs at top level under `set -euo pipefail`, so an unmatched glob aborted
+#    the script with grep's status (2) before the emptiness check below it
+#    could run. The gate still refused to pass, so the property held — but the
+#    message a maintainer needs was dead code, and the exit status was 2 where
+#    every other drift class exits 1.
+test_start "check_feature_matrix_reports_a_tree_with_no_test_functions"
+scratch_no_tests="$(fm_gate_scratch)"
+rm -f "$scratch_no_tests"/tests/regression/test_feature_matrix_*.sh
+gate_out="$(mktemp -t fmgate-out.XXXXXX)"
+gate_rc=0
+(cd "$scratch_no_tests" && REPO_ROOT="$scratch_no_tests" \
+  bash "$scratch_no_tests/scripts/qa/check-feature-matrix.sh" --quiet) \
+  >"$gate_out" 2>&1 || gate_rc=$?
+assert_equals "1" "$gate_rc" "a tree with no matrix test files fails the gate with the drift status"
+assert_file_contains "$gate_out" "no test functions found" \
+  "the gate says WHY it failed instead of dying on the glob"
+rm -rf "$scratch_no_tests" "$gate_out"
+
 test_start "check_feature_matrix_left_the_checkout_clean"
 assert_exit_code 0 "bash '$GATE' --quiet"
 

--- a/tests/unit/ops/test_ops_rollback_dispatch.sh
+++ b/tests/unit/ops/test_ops_rollback_dispatch.sh
@@ -345,7 +345,11 @@ _rb_shim flock <<'EOF'
 exit 1
 EOF
 _run_rb status
-_rb_expect "flock_held_by_another_instance_exits_0" 0 "Already running" "NOT:Dotfiles Rollback Status"
+# Regression: this arm used to `exit 0`, which made "another instance holds
+# the lock, so I did nothing" indistinguishable from "the rollback ran and
+# succeeded" to any caller or CI step. 75 is EX_TEMPFAIL — nothing is wrong,
+# try again — and is distinct from 1, which means the rollback ran and failed.
+_rb_expect "flock_held_by_another_instance_reports_busy" 75 "Already running" "NOT:Dotfiles Rollback Status"
 
 # =======================================================================
 # 9. ~/.dotfiles resolution fallbacks: readlink-only, then neither tool.

--- a/tests/unit/qa/test_qa_feature_matrix_drift.sh
+++ b/tests/unit/qa/test_qa_feature_matrix_drift.sh
@@ -191,18 +191,25 @@ assert_contains "phantom" "$(fm_run "$fx" --quiet 2>&1)" \
 
 # ── 6. No regression suite defines any matrix test function ────────────────
 #
-# The gate carries a `fail "no test functions found"` arm for this, but it
-# cannot be reached: the `grep … $TEST_GLOB | sed | sort` pipeline that fills
-# defined-tests.txt runs at the top level under `set -euo pipefail`, so an
-# unmatched glob aborts the script with grep's own status (2) before the
-# emptiness check runs. The gate still refuses to pass, which is the property
-# that matters, so this asserts what actually happens rather than pretending
-# the arm is live.
+# The gate's `fail "no test functions found"` arm used to be unreachable: the
+# `grep … $TEST_GLOB | sed | sort` pipeline that fills defined-tests.txt runs
+# at the top level under `set -euo pipefail`, so an unmatched glob aborted the
+# script with grep's own status (2) before the emptiness check could run. It
+# refused to pass, which was the property that mattered, but it said nothing —
+# a bare exit 2 where a diagnostic was written and waiting.
+#
+# The pipeline now tolerates finding nothing, so the arm is live. Both halves
+# are asserted: the status, and the sentence, because the point of the fix is
+# that someone reading CI can tell what happened.
 fx="$(fm_fresh)"
 rm -f "$fx"/tests/regression/test_feature_matrix_*.sh
 test_start "feature_matrix_refuses_an_empty_regression_tier"
-assert_equals "2" "$(fm_rc "$fx" --quiet)" \
-  "an empty regression tier should abort the gate, not pass it"
+assert_equals "1" "$(fm_rc "$fx" --quiet)" \
+  "an empty regression tier should fail the gate through its own check"
+
+test_start "feature_matrix_empty_regression_tier_is_diagnosed"
+assert_contains "no test functions found" "$(fm_run "$fx" --quiet 2>&1)" \
+  "the refusal should name what it could not find"
 
 # ── 7. A named function that is defined but never invoked ──────────────────
 fx="$(fm_fresh)"

--- a/tests/unit/theme/test_theme_switch_dispatch.sh
+++ b/tests/unit/theme/test_theme_switch_dispatch.sh
@@ -303,10 +303,26 @@ assert_file_contains "$OUT" "already on bloom-dark" "re-picking the active famil
 assert_empty "$(last_sync)" "no theme is applied"
 
 test_start "cancelling_the_picker_applies_nothing"
+set_theme_to bloom-dark
 : >"$SYNC_CALLS"
 rc="$(FAKE_PICK="" FAKE_PICK_RC=1 switch)"
 assert_equals "0" "$rc" "a cancelled pick still exits 0"
 assert_empty "$(last_sync)" "cancelling applies nothing"
+assert_file_contains "$OUT" "no selection" "a cancelled pick says the theme is unchanged"
+
+test_start "set_with_no_name_refuses_in_a_non_interactive_session"
+# ui_pick reports "no selector could run" exactly as it reports a cancel, so
+# without this guard a forgotten argument would exit 0 having done nothing —
+# the same "did nothing looks like success" failure the picker fix is about.
+: >"$SYNC_CALLS"
+rc=0
+CHEZMOI_SOURCE_DIR="$SRC" DOTFILES_WALLPAPER_DIR="$WALLPAPERS" \
+  DOTFILES_NONINTERACTIVE=1 PATH="$BIN:/usr/bin:/bin" \
+  "$REAL_BASH" "$SCRIPT_FILE" set </dev/null >"$OUT" 2>"$ERR" || rc=$?
+cat "$ERR" >&2
+assert_equals "1" "$rc" "a non-interactive 'set' with no name fails"
+assert_file_contains "$OUT" "dot theme set <name>" "the usage is printed"
+assert_empty "$(last_sync)" "nothing is applied"
 
 test_start "set_with_an_empty_name_opens_the_picker"
 set_theme_to bloom-dark
@@ -314,6 +330,57 @@ set_theme_to bloom-dark
 rc="$(FAKE_PICK="○  maui                                 Custom" switch set "")"
 assert_equals "0" "$rc" "set with an empty name exits 0"
 assert_equals "maui-dark" "$(last_sync)" "an empty name falls through to the interactive picker"
+
+test_start "set_with_no_name_at_all_opens_the_picker"
+# Regression: the dispatcher's `set` arm called `set_theme "$1"` after the
+# shift, so with no theme name the script died on the unset positional under
+# `set -u` — before set_theme's own empty-string check could open the picker
+# that `dot help theme` documents ("Set theme (interactive if no name)").
+set_theme_to bloom-dark
+: >"$SYNC_CALLS"
+rc="$(FAKE_PICK="○  maui                                 Custom" switch set)"
+assert_equals "0" "$rc" "set with no name exits 0"
+assert_equals "maui-dark" "$(last_sync)" "no name falls through to the interactive picker"
+assert_output_not_contains "unbound variable" "cat '$ERR'"
+
+test_start "set_with_no_name_keeps_its_status_honest_on_the_system_bash"
+# The same abort was also a reporting bug, and a macOS-only one. On bash 3.2
+# — still /bin/bash on macOS — a script that aborts under `set -u` while an
+# EXIT trap is installed exits 0, not 1: the status is already gone by the
+# time the handler runs, so no handler can restore it. switch.sh installs
+# `trap cleanup EXIT`, so `dot theme set` announced "$1: unbound variable"
+# and then reported success to its caller. Measured on this repo:
+#
+#     /bin/bash (3.2)   rc=0 + "unbound variable" on stderr
+#     bash 5.x          rc=1 + "unbound variable" on stderr
+#
+# There is no unguarded expansion left in switch.sh, so the abort — and with
+# it the only status-losing path on 3.2 — cannot happen. What this pins on
+# both shells: rc=0 must mean the command actually did its work.
+if [[ -x /bin/bash ]]; then
+  set_theme_to bloom-dark
+  : >"$SYNC_CALLS"
+  rc=0
+  CHEZMOI_SOURCE_DIR="$SRC" \
+    DOTFILES_WALLPAPER_DIR="$WALLPAPERS" \
+    FAKE_PICK="○  maui                                 Custom" \
+    PATH="$BIN:/usr/bin:/bin" \
+    /bin/bash "$SCRIPT_FILE" set </dev/null >"$OUT" 2>"$ERR" || rc=$?
+  cat "$ERR" >&2
+  assert_equals "0" "$rc" "set with no name exits 0 under the system bash"
+  assert_equals "maui-dark" "$(last_sync)" "the exit status matches what was applied"
+  assert_output_not_contains "unbound variable" "cat '$ERR'"
+
+  # The EXIT trap must not mask an ordinary failure either.
+  rc=0
+  CHEZMOI_SOURCE_DIR="$SRC" DOTFILES_WALLPAPER_DIR="$WALLPAPERS" \
+    PATH="$BIN:/usr/bin:/bin" \
+    /bin/bash "$SCRIPT_FILE" definitely-not-a-theme </dev/null >"$OUT" 2>"$ERR" || rc=$?
+  cat "$ERR" >&2
+  assert_equals "1" "$rc" "an unknown argument still fails under the system bash"
+else
+  _fail "/bin/bash not found"
+fi
 
 test_start "a_theme_absent_from_themes_toml_falls_back_to_suffix_stripping"
 # get_theme_family cannot read a family for an unlisted theme, so it strips


### PR DESCRIPTION
Fixes twelve documented defects, each with a regression test proven to fail against the unfixed code first. Two of the reported findings turned out to be wrong, and correcting them was more valuable than fixing them.

## Two corrections

**`dot theme set` does not write into your checkout.** That was reported and repeated several times. Measured: it resolves via the environment variable, then `$HOME/.dotfiles`, so it respects a sandboxed home. It only touched the checkout under the test harness because the harness aimed both at it. The claim *is* true of `dot profile set`, `fleet namespace set`, `fleet enforce set` and `aliases cheatsheet`, which use a library resolver that probes its own location first. Verified by watching `profile set` rewrite a checkout. The matrix was corrected rather than a non-bug "fixed".

**The exit-status masking has a different mechanism than reported.** It was attributed to the trap handler beginning with a conditional. A no-op trap masks identically. On bash 3.2 a script dying on an unbound variable with *any* EXIT trap installed exits 0, because the status is already 0 when the handler runs and no handler can restore it. Explicit exits, `set -e` and pipeline failures are not masked.

## Fixed

- **`dot theme set`** aborted on the unset positional before reaching its documented picker, and that same site was the only status-losing path in the file. Both resolved by one guard.
- **`dot fleet namespace set`** rewrote only when the key already existed, and reported success regardless. The key is now inserted, positioned so the file stays valid TOML.
- **`dot agent delegate`** required GNU `timeout`, absent on stock macOS, so the delegated command never ran. Now falls back through `gtimeout`, then a perl alarm preserving exit semantics, then unbounded with a warning.
- **The registry index cache** was keyed by path, so changing the registry URL kept serving the previous index for six hours. Now keyed by a digest of the URL.
- **`dot doctor --audit`** routed to a script not in the tree. A new test parses every target out of the dispatch arms and asserts each file exists.
- **`dot tools docs`** looked in the wrong directory.
- **`dot keys`** had a missing fallback script, and an unconditional `rg` call that was silently empty on ripgrep-less runners.
- **The `plain-enc` secrets store** aborted after a successful write: a RETURN trap set inside a function fired again on the caller's return, where its local was out of scope.
- **`dot agents render`** never wrote its title. Re-rendering turned out to be a one-line change, not the eleven-file churn that was feared.
- **An unreachable diagnostic** in the feature-matrix gate, where a pipeline under `errexit` aborted before the emptiness check.
- **Losing the rollback lock race exited 0**, making "did nothing" indistinguishable from "succeeded". Now exits 75.

## A landmine found while fixing

A test documented as "strictly read-only" probes `fleet namespace set`, which was safe *only because of the no-op bug being fixed*. Fixing it made that test mutate the checkout. Caught, the file restored and verified clean, and the probe switched to a read-only form. A sandboxed home does not protect the working tree from that family of commands.

## Left alone deliberately

Four other scripts share the exit-0-on-lock-contention shape; changing four more command contracts did not belong here. And a separate unbound-array abort in the theme sync binary on macOS, found while reproducing one of the above.
Signed-off-by: Sebastien Rousseau <sebastian.rousseau@gmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co
