### PR TITLE
fix(docs): let the README carry its SPDX header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<!-- SPDX-License-Identifier: Apache-2.0 OR MIT -->
 <p align="center">
   <img src="https://cloudcdn.pro/dotfiles/v2/images/logos/dotfiles.svg" alt="Dotfiles logo" width="128" />
 </p>

--- a/tests/regression/test_flesch_readability.sh
+++ b/tests/regression/test_flesch_readability.sh
@@ -30,13 +30,13 @@ USER_DOCS=(
 # Extract prose from markdown (strip code blocks, tables, HTML, links)
 _extract_prose() {
   awk '/^```/{skip=!skip; next} !skip{print}' "$1" | # Remove fenced code blocks
-    sed '/^|/d' |                   # Remove tables
-    sed '/^<[^>]*>$/d' |           # Remove HTML-only lines
-    sed 's/\[[^]]*\]([^)]*)//g' |  # Strip link syntax
-    sed '/^##* /d' |                # Remove headings
-    sed '/^$/d' |                   # Remove blank lines
-    sed '/^---$/d' |                # Remove horizontal rules
-    sed '/^- \[/d'                  # Remove checkbox lines
+    sed '/^|/d' |                                    # Remove tables
+    sed '/^<[^>]*>$/d' |                             # Remove HTML-only lines
+    sed 's/\[[^]]*\]([^)]*)//g' |                    # Strip link syntax
+    sed '/^##* /d' |                                 # Remove headings
+    sed '/^$/d' |                                    # Remove blank lines
+    sed '/^---$/d' |                                 # Remove horizontal rules
+    sed '/^- \[/d'                                   # Remove checkbox lines
 }
 
 # Count words in text
@@ -197,7 +197,7 @@ failures=0
 for doc in "${USER_DOCS[@]}"; do
   filepath="$REPO_ROOT/$doc"
   [[ -f "$filepath" ]] || continue
-  lines=$(wc -l < "$filepath" | tr -d ' ')
+  lines=$(wc -l <"$filepath" | tr -d ' ')
   if [[ "$lines" -lt 20 ]]; then
     printf '    %s: too short (%s lines, min 20)\n' "$doc" "$lines"
     failures=$((failures + 1))
@@ -318,7 +318,7 @@ for doc in "${USER_DOCS[@]}"; do
       fi
     fi
     prev_line="$line"
-  done < "$filepath"
+  done <"$filepath"
 done
 assert_equals "0" "$failures" "code blocks should have context text before them"
 
@@ -384,7 +384,7 @@ for doc in "${USER_DOCS[@]}"; do
       fi
       bullet_count=0
     fi
-  done < "$filepath"
+  done <"$filepath"
   # Check trailing list
   if [[ "$bullet_count" -gt 10 ]]; then
     printf '    %s: bullet list with %d items at end of file\n' "$doc" "$bullet_count"
@@ -409,6 +409,13 @@ for doc in "${USER_DOCS[@]}"; do
     NR == 1 && $0 == "---" { in_frontmatter = 1; next }
     in_frontmatter && $0 == "---" { in_frontmatter = 0; next }
     in_frontmatter { next }
+    # Skip a leading HTML comment block the same way. REPO-STANDARD wants an
+    # SPDX identifier on line 1 of the README, which is an HTML comment in
+    # Markdown; without this the standard and this test are mutually
+    # exclusive. A comment is invisible when rendered, so it does not affect
+    # whether a reader sees a clear title — which is what this asserts.
+    !in_frontmatter && /^[[:space:]]*<!--/ { in_comment = 1 }
+    in_comment { if (/-->/) { in_comment = 0 }; next }
     NF { print; exit }
   ' "$filepath")
   if [[ "$first_content" =~ ^#[[:space:]] || "$first_content" =~ ^\<[phH] ]]; then
@@ -464,7 +471,7 @@ for doc in "${USER_DOCS[@]}"; do
   [[ -f "$filepath" ]] || continue
   doc_slug="${doc//[\/.]/_}"
   test_start "flesch_doc_length_${doc_slug}"
-  lines=$(wc -l < "$filepath" | tr -d ' ')
+  lines=$(wc -l <"$filepath" | tr -d ' ')
   if [[ "$lines" -ge 20 ]]; then
     ((TESTS_PASSED++)) || true
     printf '%b\n' "  ${GREEN}✓${NC} $CURRENT_TEST: $lines lines"


### PR DESCRIPTION
REPO-STANDARD category 1 requires an SPDX identifier on line 1 of the README. In Markdown that is an HTML comment, and `tests/regression/test_flesch_readability.sh` asserted the first non-empty line must be a heading. The two were mutually exclusive, so the header was dropped to keep the suite green and the standard recorded as unsatisfiable here.

It is satisfiable. The test already skipped YAML frontmatter for exactly this reason: site metadata should not count against a document having a clear title. An HTML comment is the same case and a stronger one, since it renders to nothing at all.

## The change

The title check now skips a leading HTML comment block the same way it skips frontmatter, and the identifier is back on README line 1.

## Deliberately narrow

The assertion still fails on a document that genuinely lacks a title. Verified by replacing the README with an SPDX comment followed by prose and no heading, which correctly reported "missing clear title". Widening it into a pass-anything check would have been the easy wrong fix, and would have quietly removed a real gate from 24 documents.

## Nothing was machine-unreadable before

REUSE compliance was already satisfied through the tree-wide annotation in `REUSE.toml`. What changes is that a reader viewing README.md outside the repository now sees the grant.

Verified: readability suite 92/92, docs accuracy 71/71 with every declared assertion reached, markdownlint clean over 261 files, shellcheck at warning severity and shfmt clean.

Signed-off-by: Sebastien Rousseau <sebastian.rousseau@gmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co
