### PR TITLE
fix(rust): stop the toolchain and target dir fighting every project

### DIFF
--- a/defaults/dot_cargo/config.toml.tmpl
+++ b/defaults/dot_cargo/config.toml.tmpl
@@ -26,8 +26,31 @@ bloat = "bloat --release --crates"
 jobs = -1
 # Incremental compilation for faster rebuilds
 incremental = true
-# Build artifacts in /tmp (cleared on reboot)
-target-dir = "/tmp/builds/cargo"
+# NOTE: `target-dir` is deliberately NOT set globally.
+#
+# Cargo takes an exclusive lock on the target directory, so pointing
+# every repo at one shared path makes concurrent builds serialise —
+# a build in one project blocks `cargo test` in another, which looks
+# like a hang rather than contention. Each project now uses its own
+# ./target instead.
+#
+# The shared-target benefit (compiling common dependencies once) is
+# recovered by sccache below, which is content-addressed and so is
+# shared across projects *without* a lock.
+#
+# To override for one build:  CARGO_TARGET_DIR=/tmp/builds/foo cargo build
+# Use sccache as a compilation cache. Content-addressed, so concurrent
+# builds of different projects sharing dependency versions all hit the
+# same cache without blocking each other.
+#
+# Templated on presence rather than set unconditionally: cargo treats a
+# missing rustc-wrapper as a hard error ("could not execute process
+# sccache"), so an unguarded line here would break every build on a
+# machine that has not installed it yet. Re-run `chezmoi apply` after
+# installing sccache to pick it up.
+{{- if lookPath "sccache" }}
+rustc-wrapper = "sccache"
+{{- end }}
 
 {{- if eq .chezmoi.os "darwin" }}
 # macOS: Use Apple's linker for faster linking
@@ -61,6 +84,7 @@ progress.width = 80
 [registries.crates-io]
 protocol = "sparse"
 
-# Uncomment to use sccache for distributed caching
-# [build]
-# rustc-wrapper = "sccache"
+# sccache is configured in the [build] section above. Note it must live
+# there and not in a second [build] table — two tables with the same
+# name is a TOML duplicate-key error, which is why the previous
+# commented-out block here could never have been uncommented as written.

--- a/defaults/dot_config/mise/conf.d/00-dotfiles.toml
+++ b/defaults/dot_config/mise/conf.d/00-dotfiles.toml
@@ -30,8 +30,17 @@ python = ["3.12", "3.11", "3.14"]
 # Go
 go = "latest"
 
-# Rust
-rust = "latest"
+# Rust -- deliberately NOT managed by mise.
+#
+# mise's rust plugin exports RUSTUP_TOOLCHAIN, and that environment
+# variable overrides `rust-toolchain.toml` in every project, silently.
+# A repository pinned to 1.98.0 was being built with 1.97.1: clippy
+# reported an unknown lint for one that only exists in 1.98, and a
+# local "all green" did not mean CI would be green.
+#
+# rustup is installed and ~/.cargo/bin is on PATH, so rustup governs
+# instead and each project's own pin is honoured. Re-adding
+# `rust = "latest"` here brings the override back.
 
 # Ruby
 ruby = "3.3"

--- a/defaults/dot_config/mise/conf.d/00-dotfiles.toml
+++ b/defaults/dot_config/mise/conf.d/00-dotfiles.toml
@@ -68,7 +68,12 @@ codex = "latest"
 # binary and `corralctl` is never on PATH. The github: backend unpacks the
 # release tarball as-is and yields the real `corralctl`. Verified against
 # v0.0.18 assets (corralctl_Darwin_arm64.tar.gz et al).
-"github:sebastienrousseau/corral" = "latest"
+# The repository is now sebastienrousseau/corralctl, and `corralctl sync`
+# (which replaces corral-sync) is not in a tagged release yet. Until v0.0.37
+# ships, ~/.config/mise/config.toml pins a go: build of the branch; switch
+# this back on afterwards as:
+#   "github:sebastienrousseau/corralctl" = "latest"
+# "github:sebastienrousseau/corral" = "latest"
 eza = "latest"
 gping = "latest"
 # pandoc builds the HTML/PDF/EPUB manual. Without it tools/docs/build-manual.sh

--- a/defaults/dot_config/shell/Brewfile.cli
+++ b/defaults/dot_config/shell/Brewfile.cli
@@ -56,6 +56,7 @@ brew "shfmt"
 # -----------------------------------------------------------------------------
 brew "uv"                    # Fast Python package manager
 brew "rustup"
+brew "sccache"                # Shared compilation cache; see ~/.cargo/config.toml
 brew "go"
 
 # -----------------------------------------------------------------------------

--- a/defaults/dot_config/zsh/rc.d/35-rust-target.zsh.tmpl
+++ b/defaults/dot_config/zsh/rc.d/35-rust-target.zsh.tmpl
@@ -1,0 +1,53 @@
+# Rust: per-project target dirs, all visible under /tmp/builds
+#
+# A single shared `target-dir` makes every repo serialise, because cargo
+# takes an exclusive lock on it — a build in one project blocks a test
+# run in another, which looks like a hang rather than contention. So
+# ~/.cargo/config.toml no longer sets one.
+#
+# To keep build output out of the repos *and* browsable in one place,
+# each project's ./target is a symlink into /tmp/builds/<name>.
+#
+# A symlink rather than CARGO_TARGET_DIR on purpose: an environment
+# variable only applies to this shell, so rust-analyzer, cargo-fuzz and
+# build scripts would still use ./target and rebuild everything a second
+# time. Every tool follows a symlink.
+
+# Point the current project's ./target at /tmp/builds/<name>.
+# Usage: rust-target-tmp [name]   (defaults to the repo/directory name)
+rust-target-tmp() {
+  local root name dest
+  root=$(command git rev-parse --show-toplevel 2>/dev/null) || root=$PWD
+  if [[ ! -f "$root/Cargo.toml" ]]; then
+    print -u2 "rust-target-tmp: no Cargo.toml in $root"
+    return 1
+  fi
+  name=${1:-${root:t}}
+  dest="/tmp/builds/$name"
+
+  if [[ -e "$root/target" && ! -L "$root/target" ]]; then
+    print -u2 "rust-target-tmp: $root/target exists and is a real directory."
+    print -u2 "  Remove it first:  rm -rf ${root:q}/target"
+    return 1
+  fi
+
+  mkdir -p "$dest"
+  ln -sfn "$dest" "$root/target"
+  print "target -> $dest"
+}
+
+# Recreate the symlink if /tmp was cleared on reboot but the link
+# survives in the repo. Cheap: one stat per cd into a cargo project.
+_rust_target_relink() {
+  [[ -L target && ! -e target ]] || return 0
+  local dest
+  dest=$(readlink target)
+  [[ $dest == /tmp/builds/* ]] && mkdir -p "$dest"
+}
+autoload -Uz add-zsh-hook 2>/dev/null && add-zsh-hook chpwd _rust_target_relink
+
+# List what is currently occupying /tmp/builds, largest first.
+rust-target-usage() {
+  [[ -d /tmp/builds ]] || { print "no /tmp/builds yet"; return 0 }
+  du -sh /tmp/builds/*(/N) 2>/dev/null | sort -rh
+}

--- a/install/provision/run_onchange_10-linux-packages.sh.tmpl
+++ b/install/provision/run_onchange_10-linux-packages.sh.tmpl
@@ -105,7 +105,7 @@ if command -v apt-get >/dev/null; then
     $sudo_cmd apt-get install -y gh || log_info "Skipping GitHub CLI install (apt)."
   fi
 
-  optional_packages=(terraform terraform-docs tflint trivy packer vagrant ansible)
+  optional_packages=(terraform terraform-docs tflint trivy packer vagrant ansible sccache)
   install_optional=()
   for pkg in "${optional_packages[@]}"; do
     if apt-cache show "$pkg" >/dev/null 2>&1; then
@@ -128,7 +128,7 @@ elif command -v dnf >/dev/null; then
   )
   $sudo_cmd dnf install -y "${packages[@]}"
 
-  optional_packages=(terraform terraform-docs tflint trivy packer vagrant ansible)
+  optional_packages=(terraform terraform-docs tflint trivy packer vagrant ansible sccache)
   install_optional=()
   for pkg in "${optional_packages[@]}"; do
     if dnf list --available "$pkg" >/dev/null 2>&1; then
@@ -152,7 +152,7 @@ elif command -v pacman >/dev/null; then
   )
   $sudo_cmd pacman -S --needed --noconfirm "${packages[@]}"
 
-  optional_packages=(terraform terraform-docs tflint trivy packer vagrant ansible)
+  optional_packages=(terraform terraform-docs tflint trivy packer vagrant ansible sccache)
   install_optional=()
   for pkg in "${optional_packages[@]}"; do
     if pacman -Si "$pkg" >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

Two settings in the managed config were overriding what each repository asks for, and both failed quietly. This was uncommitted work sitting in the checkout; it is captured here rather than left one power cut away from gone.

## The toolchain override

mise was pinned to `rust = "latest"`. mise's rust plugin exports `RUSTUP_TOOLCHAIN`, and that environment variable takes precedence over `rust-toolchain.toml` in **every** project — silently.

A repository pinned to 1.98.0 was being built with 1.97.1. The symptom was clippy reporting an unknown lint for one that only exists in 1.98, which reads as a broken lint rather than a wrong compiler, and it meant a local "all green" said nothing about what CI would do.

Rust is left to rustup, which honours each project's own pin. Both provisioners already install rustup, so nothing is lost. Re-adding `rust = "latest"` brings the override back, and the comment in the file says so.

## The shared target directory

`~/.cargo/config.toml` set one global `target-dir`. Cargo takes an **exclusive lock** on it, so every repository pointing at the same path serialises: a build in one project blocks `cargo test` in another. Cargo prints nothing while it waits, so it reads as a hang rather than contention.

Each project uses its own `./target` again. The reason the shared directory existed — compiling common dependencies once — is recovered by sccache, which is content-addressed and therefore shared across projects *without* a lock.

### sccache needed care

A missing sccache is not a warning. Cargo fails the build outright with `could not execute process sccache`, so an unguarded `rustc-wrapper` would break every build on a machine that has not installed it.

- The setting is templated on `lookPath "sccache"` rather than written unconditionally. Verified both ways: with sccache on `PATH` the line is emitted and the rendered TOML parses; with `PATH` stripped of it, zero `rustc-wrapper` lines are emitted.
- It is declared where rustup already is — `Brewfile.cli` for macOS, and the three optional package lists in the Linux provisioner, which probe availability per distro and skip what is not carried.

## Keeping build output out of the repositories

`35-rust-target.zsh.tmpl` gets the original benefit back without the lock: `rust-target-tmp` symlinks a project's `./target` at `/tmp/builds/<name>`.

A symlink rather than `CARGO_TARGET_DIR` is deliberate. An environment variable applies only to the shell that set it, so rust-analyzer, cargo-fuzz and build scripts would still use `./target` and rebuild everything a second time. Every tool follows a symlink.

A `chpwd` hook recreates the destination when `/tmp` is cleared on reboot, and `rust-target-usage` shows what is occupying it. It refuses to act when `./target` is a real directory rather than silently deleting it.

## One correction

The commented-out sccache block at the bottom of the cargo config could never have been uncommented as written — it opened a second `[build]` table, and two tables of the same name is a TOML duplicate-key error.

## Second commit is unrelated

`chore(mise): park the corral entry` shares a file with the above and nothing else. The repository was renamed `corral` → `corralctl` and `corralctl sync` is not in a tagged release, so the `github:` backend installs a binary without the subcommand. Commented out with the exact line to restore once v0.0.37 ships. Split into its own commit so it can be reviewed — or reverted — on its own.

## Verification

- Cargo template renders and the result parses as TOML, both with and without sccache on `PATH`
- zsh fragment renders and passes `zsh -n`
- Shell preamble lint clean

Signed-off-by: Sebastien Rousseau <sebastian.rousseau@gmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GkTMSRzg9EVUd11XZ9bbHC

---

THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co
