### PR TITLE
ci: make the wall-clock ratchet runnable, and stop the fuzz shutdown race failing builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -577,6 +577,22 @@ jobs:
           chmod +x benches/*.sh 2>/dev/null || true
           ./benches/benchmark_runner.sh 2>/dev/null || true
 
+      # ADVISORY, deliberately. The ratchet's thresholds
+      # (HELP_GATES_WALL_CLOCK_MS=20000, HELP_GATES_PER_MAX_MS=15000) were
+      # chosen in #1034 when the file was written, and `git log -S` over
+      # .github/ shows no workflow has ever referenced it — so no runner has
+      # ever measured against them. It then moved to benches/ in #1058, which
+      # broke its framework path, and it could not start at all.
+      #
+      # Reporting first is the point: a threshold nothing has measured is not
+      # a threshold, and picking a number now would just be a guess with a
+      # gate attached. Once a few runs have logged real figures here, set the
+      # two variables from them and drop continue-on-error.
+      - name: Help-gate wall-clock ratchet (advisory)
+        continue-on-error: true
+        run: |
+          bash benches/test_help_gates_wall_clock.sh || true
+
       - name: Shell startup benchmark with regression tracking
         id: benchmark
         run: |

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -213,8 +213,52 @@ jobs:
         env:
           FUZZTIME: ${{ inputs.fuzztime || '60s' }}
         run: |
-          go test -run '^$' -fuzz='^${{ matrix.harness }}$' \
-            -fuzztime="$FUZZTIME" ./...
+          set -uo pipefail
+          log="$(mktemp)"
+
+          run_once() {
+            go test -run '^$' -fuzz='^${{ matrix.harness }}$' \
+              -fuzztime="$FUZZTIME" ./... 2>&1 | tee "$log"
+            return "${PIPESTATUS[0]}"
+          }
+
+          # A crasher is recorded as a file under testdata/fuzz/. Its presence
+          # is what separates "the fuzzer found something" from "the fuzzer
+          # finished and then failed to shut down", and only the second is
+          # worth retrying.
+          found_crasher() {
+            [ -d testdata/fuzz ] && [ -n "$(find testdata/fuzz -type f -print -quit 2>/dev/null)" ]
+          }
+
+          if run_once; then
+            exit 0
+          fi
+
+          # `--- FAIL: Fuzz... (60.10s)  context deadline exceeded` against a
+          # 60s budget is the coordinator missing its own shutdown window by
+          # milliseconds after a complete run. Go reports it as a test failure
+          # even though nothing failed. Retry ONCE, and only when there is no
+          # reproducer on disk — a real finding always writes one, so this
+          # cannot hide one.
+          if found_crasher; then
+            echo "::error::${{ matrix.harness }} found a crasher (reproducer written)"
+            exit 1
+          fi
+          if ! grep -q 'context deadline exceeded' "$log"; then
+            echo "::error::${{ matrix.harness }} failed without a reproducer and without a shutdown timeout"
+            exit 1
+          fi
+
+          echo "::warning::${{ matrix.harness }} hit Go's fuzzing shutdown deadline with no reproducer; retrying once"
+          if run_once; then
+            exit 0
+          fi
+          if found_crasher; then
+            echo "::error::${{ matrix.harness }} found a crasher on the retry"
+          else
+            echo "::error::${{ matrix.harness }} failed twice; not a one-off shutdown race"
+          fi
+          exit 1
 
       - name: Upload reproducer corpus if failed
         if: failure()

--- a/benches/test_help_gates_wall_clock.sh
+++ b/benches/test_help_gates_wall_clock.sh
@@ -35,6 +35,23 @@ GATES=(
   tests/regression/test_dot_help_flag_universal.sh
 )
 
+# THESE TWO NUMBERS HAVE NEVER BEEN MEASURED AGAINST.
+#
+# They were written in #1034 alongside this file, and `git log -S
+# test_help_gates_wall_clock -- .github/` returns nothing: no workflow has
+# ever invoked this script, on any runner, ever. It then moved to benches/
+# in #1058, which broke its framework path, so from that point it could not
+# even start.
+#
+# CI now runs it in the Benchmark job as ADVISORY (continue-on-error), so
+# real figures get logged without gating on a guess. Once a few runs have
+# reported, set these from the observed medians with headroom and make it
+# enforcing.
+#
+# For reference, a local run on a machine at load average ~11 measured
+# 120624ms total with test_dot_help_flag_universal.sh at 63646ms — which
+# says more about the load than about the gate, and is exactly why the
+# number needs to come from CI rather than from here.
 THRESHOLD_MS="${HELP_GATES_WALL_CLOCK_MS:-20000}"
 PER_GATE_MAX_MS="${HELP_GATES_PER_MAX_MS:-15000}"
 

--- a/benches/test_help_gates_wall_clock.sh
+++ b/benches/test_help_gates_wall_clock.sh
@@ -23,7 +23,12 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/.." && pwd)}"
-source "$SCRIPT_DIR/../framework/assertions.sh"
+# The assertions framework lives under tests/, not beside this file. benches/
+# is a sibling of tests/, so `$SCRIPT_DIR/../framework` resolves to
+# `<repo>/framework`, which does not exist — this script has been dying on
+# its own second line, and nothing in CI ran it, so nothing said so. Address
+# it from the repository root instead.
+source "$REPO_ROOT/tests/framework/assertions.sh"
 
 GATES=(
   tests/regression/test_dot_subcommand_smoke.sh


### PR DESCRIPTION
## Summary

Three CI defects found while getting #1038 green, each of which was invisible for a different reason.

## 1. The wall-clock ratchet could not start

`docs/operations/PERFORMANCE_BUDGETS.md` describes `benches/test_help_gates_wall_clock.sh` as the **suite-level wall-clock ratchet** — the thing that stops the help gates getting slower. On `main` it dies on its own second line:

```
benches/test_help_gates_wall_clock.sh: line 26: .../benches/../framework/assertions.sh: No such file or directory
```

It sources `$SCRIPT_DIR/../framework/assertions.sh`. That was correct when the file lived under `tests/`, and stopped being correct when #1058 moved it to `benches/` — the same defect as the perf budget gate, in the file next to it.

## 2. Nothing has ever run it — so its thresholds are not measurements

```
$ git log --all -S'test_help_gates_wall_clock' -- .github/
(no output)
```

No workflow has referenced this script on any runner, ever. `HELP_GATES_WALL_CLOCK_MS=20000` and `HELP_GATES_PER_MAX_MS=15000` were written in #1034 alongside the file and nothing has checked them since.

So CI now runs it in the Benchmark job as **advisory** (`continue-on-error`), reporting without gating.

That job is `schedule`/`workflow_dispatch` only — the step does **not** fire on pull requests, and that is deliberate rather than an oversight. PR runners are contended and shared; a wall-clock figure taken there measures the runner's mood as much as the code. The scheduled run is the consistent reference, and it is the one to calibrate from. It also keeps a two-minute gate off every PR.

**It is not made to pass.** A local run measured 120624 ms total with `test_dot_help_flag_universal.sh` at 63646 ms — but on a machine at load average ~11 with an unrelated process at 87% CPU, and the repository's own note in `tools/ci/run-coverage.sh` records 157 s for that same gate on a contended laptop. Any threshold picked from those is a guess with a gate attached.

Making it enforcing is two lines once real figures exist: set the variables from the observed medians with headroom, drop `continue-on-error`. Left to whoever reads the first numbers, because they will have evidence and this PR does not.

The alternative — raising the threshold until it goes green — is precisely what this repository's own gate-integrity tests exist to catch.

## 3. The fuzz job failed on a shutdown race

`FuzzValidateArgs` failed on #1038 with:

```
fuzz: elapsed: 1m0s, execs: 4017481 (0/sec), new interesting: 279
--- FAIL: FuzzValidateArgs (60.10s)
    context deadline exceeded
```

Four million executions, no crasher, and the upload step confirmed it: *"No files were found with the provided path: …/testdata/fuzz/"*. The run completed and missed its own shutdown window by 100 ms; Go reports that as a failure.

Retrying blindly is how a real finding gets buried, so the retry is gated on the signature:

- a reproducer under `testdata/fuzz/` → fail immediately, no retry
- no `context deadline exceeded` in the log → fail immediately, no retry
- otherwise → retry **once**, and fail if it recurs

### Verified against a stubbed `go`

| Scenario | Exit | `go` invocations |
|---|---|---|
| clean pass | 0 | 1 |
| shutdown flake, then pass | 0 | 2 |
| shutdown flake twice | 1 | 2 |
| **real crasher** | **1** | **1 — never retried** |
| any other failure | 1 | 1 |

The crasher row is the one that matters and is asserted hardest.

## Follow-up

`PERFORMANCE_BUDGETS.md` lives on the v0.2.520 branch and calls this file the enforcing ratchet. That line needs the "advisory" qualifier when #1038 lands.

Signed-off-by: Sebastien Rousseau <sebastian.rousseau@gmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GkTMSRzg9EVUd11XZ9bbHC

---

THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co
