### PR TITLE
test(completion): keep the evidence when the generator misbehaves

### DIFF
--- a/tests/unit/dot-cli/test_dot_completion.sh
+++ b/tests/unit/dot-cli/test_dot_completion.sh
@@ -12,22 +12,72 @@ REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
 source "$REPO_ROOT/tests/framework/assertions.sh"
 export REPO_ROOT
 
-DOT="$REPO_ROOT/bin/dot"
+# Overridable so the diagnostic path below can be proven to fire against a
+# deliberately broken generator, rather than assumed to work.
+DOT="${DOT:-$REPO_ROOT/bin/dot}"
+
+# ---------------------------------------------------------------------------
+# _emit <shell> — run the generator and keep the evidence.
+#
+# These captures used to be `"$(bash "$DOT" completion X 2>/dev/null || true)"`,
+# which threw away both the exit status and stderr. When this suite failed on
+# a macos-14 runner the only thing recoverable from the log was a truncated
+# "Actual string" — the bash generator normally emits 81 lines and about 40
+# arrived, stopping mid-way through the subcommand `case`. Nothing said
+# whether the generator had crashed, been killed, or written a short result,
+# because the test had discarded all three answers.
+#
+# It is not reproducible locally: 20 consecutive generator runs and 5 suite
+# runs were clean. So rather than guess at a fix, this keeps what the next
+# occurrence needs — status, stderr, and length — and prints it on failure.
+# ---------------------------------------------------------------------------
+_emit() {
+  local shell="$1"
+  _emit_err="$(mktemp)"
+  _emit_rc=0
+  _emit_out="$(bash "$DOT" completion "$shell" 2>"$_emit_err")" || _emit_rc=$?
+  _emit_lines="$(printf '%s\n' "$_emit_out" | wc -l | tr -d ' ')"
+}
+
+# _emit_diag <label> — dump what a failing generator actually did.
+_emit_diag() {
+  printf '        | generator exit status: %s\n' "$_emit_rc"
+  printf '        | stdout: %s line(s), %s byte(s)\n' \
+    "$_emit_lines" "$(printf '%s' "$_emit_out" | wc -c | tr -d ' ')"
+  if [[ -s "$_emit_err" ]]; then
+    printf '        | stderr:\n'
+    sed 's/^/        |   /' "$_emit_err" | head -20
+  else
+    printf '        | stderr: (empty)\n'
+  fi
+  printf '        | last 5 lines of stdout:\n'
+  printf '%s\n' "$_emit_out" | tail -5 | sed 's/^/        |   /'
+  rm -f "$_emit_err"
+}
 
 test_start "completion_module_exists"
 assert_file_exists "$REPO_ROOT/scripts/dot/commands/completion.sh" "completion module should exist"
 
 test_start "completion_bash_emits_complete"
-out="$(bash "$DOT" completion bash 2>/dev/null || true)"
+_emit bash
+out="$_emit_out"
+if [[ "$out" != *"complete -F _dot_completions"* ]]; then _emit_diag; fi
 assert_contains "complete -F _dot_completions" "$out" "bash completion registers the _dot_completions function"
+rm -f "$_emit_err"
 
 test_start "completion_zsh_emits_compdef"
-out="$(bash "$DOT" completion zsh 2>/dev/null || true)"
+_emit zsh
+out="$_emit_out"
+if [[ "$out" != *"#compdef dot"* ]]; then _emit_diag; fi
 assert_contains "#compdef dot" "$out" "zsh completion emits a #compdef header"
+rm -f "$_emit_err"
 
 test_start "completion_fish_emits_complete"
-out="$(bash "$DOT" completion fish 2>/dev/null || true)"
+_emit fish
+out="$_emit_out"
+if [[ "$out" != *"complete -c dot"* ]]; then _emit_diag; fi
 assert_contains "complete -c dot" "$out" "fish completion emits complete -c dot"
+rm -f "$_emit_err"
 
 test_start "completion_nu_emits_extern"
 out="$(bash "$DOT" completion nu 2>/dev/null || true)"


### PR DESCRIPTION
## Summary

`tests/unit/dot-cli/test_dot_completion.sh` crashed twice on macos-14 runners this week — once on #1038, once on `fix/spdx-readme-title` — and both times passed on re-run. Each failure left nothing to diagnose it with.

## What the log held

Only a truncated assertion message. The bash generator emits 81 lines ending in `complete -F _dot_completions dot`; roughly 40 arrived, stopping mid-way through the subcommand `case`:

```
  ✗ completion_bash_emits_complete: bash completion registers the _dot_completions function
    Expected to contain: 'complete -F _dot_completions'
    Actual string:      '# dot bash completion — generated by: dot completion bash
    ...
    fleet)
      COMPREPLY=($(compgen -W "drift namespace" -- "$cur"))
      return 0
      ;;'
```

Whether the generator crashed, was killed, or wrote a short result was unrecoverable, because the test discarded every answer:

```bash
out="$(bash "$DOT" completion bash 2>/dev/null || true)"
```

`2>/dev/null` threw away stderr; `|| true` threw away the exit status.

## This does not guess at a fix

It is not reproducible here. 20 consecutive generator runs returned 81 lines every time, and 5 consecutive suite runs were clean, on macOS 26 under both bash 3.2 and bash 5. Inventing a fix for a failure I cannot observe would be worse than leaving it, so this makes the **next** occurrence self-diagnosing instead.

On failure the test now prints the generator's exit status, its stderr, the stdout byte and line counts, and the tail of what did arrive. On success it prints nothing extra.

## The diagnostic is itself tested

`DOT` is now overridable, which is what makes that possible. Against a stub that prints four lines and exits 1:

```
        | generator exit status: 1
        | stdout: 4 line(s), 71 byte(s)
        | stderr:
        |   something went wrong
        | last 5 lines of stdout:
        |   # dot bash completion
        |   _dot_completions() {
        |     case "$prev" in
        |       fleet)
```

Without that seam the new code would have shipped unexercised — which is the same class of mistake as the one being fixed.

Suite still passes 7/7 across three runs and leaves no temporary files behind.

Signed-off-by: Sebastien Rousseau <sebastian.rousseau@gmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GkTMSRzg9EVUd11XZ9bbHC

---

THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co
