### PR TITLE
ci: enforce the examples-coverage gate that nothing was running

### DIFF
--- a/.github/workflows/reliability-gate.yml
+++ b/.github/workflows/reliability-gate.yml
@@ -82,6 +82,21 @@ jobs:
       - name: Validate executable examples
         run: bash ./scripts/qa/validate-examples.sh
 
+      # validate-examples.sh checks the examples that EXIST still run.
+      # examples-coverage.sh checks every command HAS one — a different
+      # question, and until now nobody was asking it in CI.
+      #
+      # `git log -S examples-coverage -- .github/` was empty: no workflow has
+      # ever invoked it. Its unit test points REPO_ROOT at synthetic fixture
+      # trees, so it exercises the script's logic and never the repository's
+      # actual coverage. A new `dot` command with no example would have gone
+      # in green.
+      #
+      # It reports 162/162 against a 100% threshold today, so this starts
+      # enforcing rather than starting red.
+      - name: Every command has an example
+        run: bash ./scripts/qa/examples-coverage.sh
+
   # Coverage contract for the `dot` CLI: every routable command, flag,
   # environment variable and config key has a row in
   # docs/reference/FEATURE-MATRIX.md naming the regression test, benchmark,


### PR DESCRIPTION
## Summary

`scripts/qa/examples-coverage.sh` asserts that every feature domain and every public `dot` command has an example. It reports **162/162 against a 100% threshold** — and no workflow has ever invoked it:

```
$ git log --all -S'examples-coverage' -- .github/
(no output)
```

## Why it was invisible

The **Examples Contract** job runs `validate-examples.sh`, which answers a different question: do the examples that *exist* still execute? Whether every command *has* one was going unasked.

The unit test does not close the gap either. `test_qa_examples_coverage_matrix.sh` points `REPO_ROOT` at synthetic fixture trees, so it exercises the script's logic and never the repository's own coverage. A new `dot` command shipped without an example would have gone in green.

## How it was found

By sweeping `benches/` and `scripts/qa/` for scripts that no workflow and no Makefile target references — the same pattern that turned up the perf budget gate and the wall-clock ratchet, both of which had also never run.

Five candidates came out of that sweep. Four are accounted for:

| Script | Status |
|---|---|
| `check-version-consistency.sh` | Executed by the perf budget gate (v0.2.520 branch), which requires exit 0 |
| `docs-coverage.sh` | Same |
| `traceability-coverage.sh` | Same |
| `coverage-baseline.sh` | Reports counts only — not a gate |
| **`examples-coverage.sh`** | **Nothing ran it** |

## Verified in both directions

Passing today, so this starts enforcing rather than starting red:

```
Examples coverage: 162/162 (100.00%)
PASS: every feature domain and every public command has an example.
```

And against a tree with two examples removed, it genuinely fails:

```
Missing coverage for: domain:ai-patterns domain:cli-utilities
FAIL: examples coverage 88.24% is below the 100% threshold.
exit=1
```

A gate that has never been observed to fail is not a gate, so both halves were checked before wiring it in.

Signed-off-by: Sebastien Rousseau <sebastian.rousseau@gmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GkTMSRzg9EVUd11XZ9bbHC

---

THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co
