### PR TITLE
fix(ci): a crasher is a NEW file, not any file under testdata/fuzz

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -222,12 +222,24 @@ jobs:
             return "${PIPESTATUS[0]}"
           }
 
-          # A crasher is recorded as a file under testdata/fuzz/. Its presence
-          # is what separates "the fuzzer found something" from "the fuzzer
-          # finished and then failed to shut down", and only the second is
-          # worth retrying.
+          # A crasher is a file Go WRITES under testdata/fuzz/ during the run.
+          #
+          # The first version of this checked whether testdata/fuzz contained
+          # any file at all, which is wrong: dot-ui ships a committed seed
+          # corpus at testdata/fuzz/FuzzStepApply/, and dot-ai-tui three more
+          # under FuzzHighlight/. For any harness in those modules the check
+          # was true before the fuzzer had run a single execution, so a
+          # shutdown race was reported as "found a crasher" and the retry it
+          # was meant to gate never fired. dot-mcp has no committed corpus,
+          # which is why this passed testing and only showed up on dot-ui.
+          #
+          # Compare a snapshot instead. A crasher is a NEW path, not any path.
+          corpus_before="$(find testdata/fuzz -type f 2>/dev/null | sort || true)"
+
           found_crasher() {
-            [ -d testdata/fuzz ] && [ -n "$(find testdata/fuzz -type f -print -quit 2>/dev/null)" ]
+            local after
+            after="$(find testdata/fuzz -type f 2>/dev/null | sort || true)"
+            [ -n "$(comm -13 <(printf '%s\n' "$corpus_before") <(printf '%s\n' "$after"))" ]
           }
 
           if run_once; then

--- a/defaults/dot_claude/CLAUDE.md
+++ b/defaults/dot_claude/CLAUDE.md
@@ -122,3 +122,38 @@ Covered: `rebase` (incl. `--signoff`, `--autosquash`), `push --force` /
 The failure mode to watch for: treating one of these as ordinary, and letting
 the next step proceed as though the previous had succeeded. The damage usually
 looks fine at the time and surfaces much later.
+
+## Commercialization lens
+
+Treat every repo/product as a business, not a hobby — act as a Strategic
+Technical Co-Founder. Open source is top-of-funnel (adoption, community),
+never the business model itself. Filter product/architecture/roadmap/docs
+work through five pillars:
+
+1. **What** — crisp problem + solution; keep the architecture modular enough
+   to cleanly split a free/open core from future proprietary features (SSO,
+   audit logs, billing hooks, analytics).
+2. **Why us** — leverage our domain expertise and proprietary assets; pick
+   stacks that build a technical moat and maximise execution speed.
+3. **Why now** — market timing, tech shifts, regulatory changes, urgent pain;
+   prioritise immediate-gap features; optimise for speed-to-market.
+4. **Why this investment** — time/effort/compute/capital are scarce; justify
+   ROI before complex code or heavy refactors, and **advise against work that
+   doesn't drive acquisition, de-risking, or commercialisation.** This pillar
+   is anti-over-engineering, not a licence to add scope.
+5. **Expected returns** — map to a concrete monetisation strategy (open-core,
+   dual licence, managed SaaS, enterprise support, gated premium); lay the
+   foundations (scalable auth, API metering, enterprise-ready security) early
+   where cheap, not speculatively.
+
+Behaviours: strategic pushback when a request lacks commercial utility or
+distracts from the core goal (ask how it fits the pillars); architectural
+foresight (interfaces/plugins/feature flags for future upsell); value-driven
+docs framing What + Why-now for both OSS contributors and enterprise
+buyers/investors; briefly validate major solutions against pillars 1 and 5.
+
+This is a filter, not an override: it never trumps the Working-discipline and
+Anti-rationalization rules above. Never fake, gate, or over-build a feature
+just to look sellable, and never monetise in a way that breaks a product's
+core trust (e.g. telemetry or lock-in in a local-first/keyless tool). If a
+project's pillars 4/5 are undefined, prompt to clarify rather than assume.


### PR DESCRIPTION
## Summary

The retry guard added in #1080 misclassified its first real case. On #1038, `FuzzReadItems` hit Go's shutdown race and was reported as a crasher:

```
fuzz: elapsed: 1m0s, execs: 3440195 (0/sec), new interesting: 97 (total: 102)
--- FAIL: FuzzReadItems (60.36s)
    context deadline exceeded
##[error]FuzzReadItems found a crasher (reproducer written)
```

Three and a half million executions, `context deadline exceeded`, and **no crasher was found**.

## Cause

The guard asked whether `testdata/fuzz` contained *any* file:

```bash
[ -d testdata/fuzz ] && [ -n "$(find testdata/fuzz -type f -print -quit 2>/dev/null)" ]
```

`dot-ui` ships a **committed seed corpus** at `testdata/fuzz/FuzzStepApply/`, and `dot-ai-tui` has three more under `FuzzHighlight/`. For any harness in those modules the answer was yes before the fuzzer had run a single execution — so a shutdown race was labelled a crasher, and the retry it was supposed to gate never fired.

It now snapshots the corpus before the run and compares. **A crasher is a NEW path, not any path.**

## Why the original testing missed it

The stub I verified #1080 against created `testdata/` only in the crasher scenario, so it never modelled a module that *ships* one. `dot-mcp` has no committed corpus — which is exactly why `FuzzValidateArgs`, the harness that prompted #1080 in the first place, behaved correctly and hid the bug.

## Re-tested with the corpus modelled

| Scenario | Exit | `go` runs | |
|---|---|---|---|
| flake + seed corpus | 0 | 2 | **was rc=1, 1 run** |
| flake, no corpus | 0 | 2 | |
| **real crasher + seed corpus** | **1** | **1** | never retried |
| **real crasher, no corpus** | **1** | **1** | never retried |
| clean pass + seed corpus | 0 | 1 | |
| flake twice | 1 | 2 | |

The crasher rows are the ones that matter: a genuine finding still fails immediately and is never retried, with or without a corpus present.

Signed-off-by: Sebastien Rousseau <sebastian.rousseau@gmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GkTMSRzg9EVUd11XZ9bbHC

---

THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co
