### PR TITLE
ci: run the regression-traceability hook, not just define it

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -67,5 +67,18 @@ jobs:
       - name: Run pre-commit (typos hook)
         run: pre-commit run typos --all-files --config config/pre-commit-config.yaml --show-diff-on-failure
 
+      # Local-only until now. The hook is registered in
+      # config/pre-commit-config.yaml but the job ran four hooks by name and
+      # this was not one of them, so it bound only on machines with the hooks
+      # installed — a contributor without them, or a merge made through the
+      # web UI, went straight past it.
+      #
+      # It asserts every file under tests/regression/ carries a
+      # `# Regression for:` header naming what it pins. Verified before
+      # wiring in: all 29 existing files pass, and a file added without a
+      # header exits 1.
+      - name: Run pre-commit (regression-traceability hook)
+        run: pre-commit run regression-traceability --all-files --config config/pre-commit-config.yaml --show-diff-on-failure
+
       - name: Run pre-commit (actionlint hook)
         run: pre-commit run actionlint --all-files --config config/pre-commit-config.yaml --show-diff-on-failure


### PR DESCRIPTION
## Summary

`config/pre-commit-config.yaml` registers **29 hooks**. The Pre-Commit job ran **four** of them by name — `yamllint`, `markdownlint-cli2`, `typos`, `actionlint` — and `regression-traceability` was not among them.

So it bound only on machines with the hooks installed. A contributor without them, or a merge made through the web UI, went straight past it.

## What it enforces

Every file under `tests/regression/` must carry a `# Regression for:` header naming what it pins. From the script's own message:

> regressions pinned years ago without context are forensic dead-ends when they fire

## Verified both directions

- All **29** existing regression files pass, so this starts green rather than red.
- A file added under `tests/regression/` without a header exits **1** with the explanation.

My first attempt at that second check created the file in a temp directory and reported the gate **inert**. The script filters by path, so the probe was never in scope. Re-run from `tests/regression/` it caught it immediately — a reminder that a gate "not firing" is as often a bad test as a bad gate.

## The rest of the unrun hooks

Most are covered by dedicated jobs:

| Hook | Covered by |
|---|---|
| `gitleaks` | secrets scan |
| `shell-preamble-check` | shell lint |
| `manpage-drift`, `command-index-drift`, `completions-drift` | doc-drift |
| `luacheck`, `hadolint`, `checkov` | their own workflows |
| `version-consistency` | doc-drift |

The remainder are generic hygiene — `trailing-whitespace`, `end-of-file-fixer`, the `check-*` family — where local-only enforcement is a reasonable choice.

## One left deliberately

`security-policy-enforcement` runs `scripts/security/enforce-policies.sh`, which exits 1 with `Missing required tools: opa`. Wiring it in means provisioning opa in CI — a larger change than this one, and one that wants its own decision rather than being smuggled in here.

Signed-off-by: Sebastien Rousseau <sebastian.rousseau@gmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GkTMSRzg9EVUd11XZ9bbHC

---

THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co
