### PR TITLE
fix(upgrade): stop dot upgrade hanging on hidden prompts; make its Neovim sync real

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,9 @@ This file documents all notable changes to this project.
   passes `-u` with the user's `init.lua` (honouring `XDG_CONFIG_HOME` and
   `NVIM_APPNAME`) ahead of `-l`, and reports a visible skip when there is no
   config to load.
+- `dot doctor` no longer warns about a missing `cargo-install-update` on a
+  machine that has no `cargo` for it to run through; the check now reports
+  "not needed" there and keeps warning where a Rust toolchain is present.
 
 ## v0.2.519 — 2026-08-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,19 @@ This file documents all notable changes to this project.
   third-party tooling or as "not actually WebAssembly": `docs/ECOSYSTEM.md`,
   `docs/architecture/REPO_LAYOUT.md`, `docs/STRUCTURE.md`,
   `docs/ARCHITECTURE.md`, `docs/reference/TOOLS.md` and `REUSE.toml`.
+- `dot upgrade` no longer hangs on a question nobody can see. Each phase's
+  output is captured to a log, so when `chezmoi update` met a locally edited
+  managed file it asked "has changed since chezmoi last wrote it?" on the
+  terminal's tty while the run looked merely slow. The step runner now closes
+  stdin and passes `--no-tty`, so the prompt fails fast, the step is marked
+  failed, and the surfaced tail names the fix (`chezmoi apply` to choose per
+  file, or `chezmoi update --force`).
+- `dot upgrade`'s Neovim phase actually syncs plugins. `nvim -l` does not
+  load `init.lua`, so `scripts/nvim/headless-upgrade.lua` never found
+  lazy.nvim and logged "skipping plugin update" on every run. The phase now
+  passes `-u` with the user's `init.lua` (honouring `XDG_CONFIG_HOME` and
+  `NVIM_APPNAME`) ahead of `-l`, and reports a visible skip when there is no
+  config to load.
 
 ## v0.2.519 — 2026-08-13
 

--- a/scripts/diagnostics/doctor.sh
+++ b/scripts/diagnostics/doctor.sh
@@ -462,10 +462,15 @@ else
   _fail "fish_plugins" "missing (~/.config/fish/fish_plugins)"
 fi
 
+# Only meaningful when there is a cargo for topgrade to run it through; a
+# machine without a Rust toolchain has nothing to update, so warning about
+# the missing helper there is noise that never goes away.
 if command -v cargo-install-update >/dev/null 2>&1; then
   _ok "cargo-install-update" "$(pretty_path "$(command -v cargo-install-update)")"
-else
+elif command -v cargo >/dev/null 2>&1; then
   _warn "cargo-install-update" "missing (install: cargo install cargo-update)"
+else
+  _ok "cargo-install-update" "not needed (cargo not installed)"
 fi
 
 # --- Symlinks ---

--- a/scripts/dot/commands/meta.sh
+++ b/scripts/dot/commands/meta.sh
@@ -70,7 +70,13 @@ cmd_upgrade() {
     [[ "${1:-}" == "--" ]] && shift
     local log="$log_dir/$id.log" rc=0
     ui_step "$id" "$label" run "$running"
-    "$@" >"$log" 2>&1 || rc=$?
+    # stdin is closed on purpose. Output is captured to a log, so a phase
+    # that prompts (chezmoi's "X has changed since chezmoi last wrote it?",
+    # a git credential helper, nvim waiting on a keypress) would otherwise
+    # block on the terminal with its question invisible — the 2026-09-12
+    # "chezmoi update seems very slow" report. With no stdin the prompt
+    # fails fast, the step is marked failed, and the tail below says why.
+    "$@" >"$log" 2>&1 </dev/null || rc=$?
     if [[ "$rc" -eq 0 ]]; then
       ui_step "$id" "" ok "$(_upgrade_last_line "$log")"
     else
@@ -89,14 +95,27 @@ cmd_upgrade() {
     _upgrade_step nix-gc "Nix GC" "collecting…" -- nix-collect-garbage -d
   fi
 
-  _upgrade_step dotfiles "Dotfiles" "chezmoi update…" -- chezmoi update
+  # --no-tty: chezmoi otherwise opens /dev/tty directly for its
+  # overwrite prompt, bypassing the closed stdin above and hanging.
+  _upgrade_step dotfiles "Dotfiles" "chezmoi update…" -- chezmoi update --no-tty
 
   if has_command nvim; then
     # scripts/nvim/headless-upgrade.lua runs Lazy sync AND waits for
     # Mason's async install queue to drain, so ensure_installed installs
     # (codelldb, debugpy, delve, etc.) aren't aborted by an early quitall.
-    _upgrade_step nvim "Neovim plugins" "Lazy sync + Mason drain…" -- \
-      nvim --headless -l "$src_dir/scripts/nvim/headless-upgrade.lua"
+    #
+    # `nvim -l` does NOT load the user's init.lua, so without an explicit
+    # -u the script found no lazy.nvim and logged "skipping plugin update"
+    # on every run — the upgrade step was a silent no-op. Point -u at the
+    # config nvim would load itself (honouring XDG_CONFIG_HOME and
+    # NVIM_APPNAME) and skip visibly when there is none to load.
+    local nvim_init="${XDG_CONFIG_HOME:-$HOME/.config}/${NVIM_APPNAME:-nvim}/init.lua"
+    if [ -f "$nvim_init" ]; then
+      _upgrade_step nvim "Neovim plugins" "Lazy sync + Mason drain…" -- \
+        nvim --headless -u "$nvim_init" -l "$src_dir/scripts/nvim/headless-upgrade.lua"
+    else
+      ui_step nvim "Neovim plugins" skip "no init.lua at $nvim_init"
+    fi
   fi
 
   if [ "${DOTFILES_FONTS:-}" = "1" ] &&
@@ -117,6 +136,9 @@ cmd_upgrade() {
     while ((i < n)); do
       ui_err "${fail_labels[$i]}" "log tail:"
       tail -n 15 "${fail_logs[$i]}" | sed 's/^/    /'
+      if grep -q 'has changed since chezmoi last wrote it' "${fail_logs[$i]}"; then
+        ui_info "Hint" "a managed file was edited locally — run 'chezmoi apply' to choose per file, or 'chezmoi update --force' to overwrite"
+      fi
       ((i++)) || true
     done
     ui_info "Logs" "$log_dir"

--- a/tests/regression/test_feature_matrix_fleet_registry.sh
+++ b/tests/regression/test_feature_matrix_fleet_registry.sh
@@ -1043,7 +1043,13 @@ test_fm_manual_offline_missing() {
   test_start "fm_manual_offline_missing_names_the_path"
   fm_expect_any "offline copy not found" "dotfiles.pdf"
   test_start "fm_manual_local_missing"
-  fm_run manual text --local
+  # --local resolves the build under the dispatcher's own source tree, so
+  # against the real checkout this depends on whether the developer has run
+  # tools/docs/build-manual.sh. Drive it through the sandbox repo copy, which
+  # carries no _build/, so the "missing" case is the one under test.
+  local repo
+  repo="$(fm_repo_copy)"
+  fm_run_bin "$repo/bin/dot" manual text --local
   fm_expect_rc 1
   test_start "fm_manual_local_missing_points_at_the_builder"
   fm_expect_any "local build not found" "build-manual.sh"

--- a/tests/unit/diagnostics/test_diagnostics_doctor_branches.sh
+++ b/tests/unit/diagnostics/test_diagnostics_doctor_branches.sh
@@ -315,7 +315,7 @@ _new_scenario s2
 _uname Linux
 _zsh "9 9"
 _tool pueue pueued batcat wasmtime age hyperfine \
-  mise zoxide atuin fzf direnv pyenv pwsh \
+  mise zoxide atuin fzf direnv pyenv pwsh cargo \
   lscpu lspci free wlr-randr dpkg wslpath
 _bench 9999
 _linux_os_release
@@ -572,8 +572,8 @@ _expect "s5_unknown_os_fallback" \
   "DE: n/a" "[FAIL] zsh" "[WARN] fish" "[FAIL] starship" "[WARN] nu" \
   "[FAIL] rg" "[OK] nix" "optional (not installed)" "[FAIL] age" "[WARN] claude" \
   "[FAIL] chezmoi" "[FAIL] .zshrc" "[FAIL] dot" "[WARN] antigravity" \
-  "[FAIL] fish_plugins" "[WARN] cargo-install-update" "[OK] symlinks" \
-  "[WARN] portability" "[OK] shell caches" "[OK] PATH length" \
+  "[FAIL] fish_plugins" "[OK] cargo-install-update" "not needed (cargo not installed)" \
+  "[OK] symlinks" "[WARN] portability" "[OK] shell caches" "[OK] PATH length" \
   "[WARN] hyperfine" "Run 'dot heal' to repair."
 
 # =======================================================================

--- a/tests/unit/dot-cli/test_dot_commands_manual_formats.sh
+++ b/tests/unit/dot-cli/test_dot_commands_manual_formats.sh
@@ -148,7 +148,17 @@ assert_equals 1 "$_rc" "a missing offline copy exits 1"
 assert_contains "offline copy not found at $OFFLINE/dotfiles.epub" "$_out" "the expected path is named"
 
 test_start "manual_local_build_is_reported_when_absent"
-_out="$(_manual pdf --local)"
+# --local resolves the source dir from lib/'s own location, so on a machine
+# that has run tools/docs/build-manual.sh the build under this repo exists and
+# the "absent" case never happens (utils.sh resets its source-dir cache on
+# load, so it cannot be pinned from the environment). Run the command through
+# a stand-in tree that borrows lib/ and scripts/ but has no _build/, so the
+# assertion is about the code path and not about the developer's checkout.
+_no_build="$DOTFILES_COV_TMPDIR/no-build-repo"
+mkdir -p "$_no_build"
+ln -s "$REPO_ROOT/lib" "$_no_build/lib"
+ln -s "$REPO_ROOT/scripts" "$_no_build/scripts"
+_out="$(MANUAL="$_no_build/scripts/dot/commands/manual.sh" _manual pdf --local)"
 _rc=$?
 assert_equals 1 "$_rc" "a missing local build exits 1"
 assert_contains "local build not found" "$_out" "the missing build is reported"

--- a/tests/unit/dot-cli/test_dot_commands_meta.sh
+++ b/tests/unit/dot-cli/test_dot_commands_meta.sh
@@ -166,6 +166,100 @@ else
   printf '%b\n' "  ${RED}✗${NC} $CURRENT_TEST: failure handling wrong"
   printf '%s\n' "$_up_out2" | sed 's/^/      /'
 fi
+
+# ── cmd_upgrade must never block on a prompt it has hidden ───────────
+# Regression for the 2026-09-12 "chezmoi update seems very slow" report.
+# Each phase's output is captured to a log, so a phase that asks a
+# question (chezmoi's "X has changed since chezmoi last wrote it?") sat
+# waiting on the terminal with the question invisible. The step runner
+# now closes stdin and chezmoi gets --no-tty, so the prompt fails fast
+# and the tail explains what to do instead. Same harness as above, plus
+# a fake XDG_CONFIG_HOME so the nvim phase is driven by the fixture and
+# not by whatever the host has under ~/.config.
+_up_run() {
+  XDG_CONFIG_HOME="$1" PATH="$_up_sb/bin:$PATH" bash -c '
+    set -uo pipefail
+    require_source_dir() { printf "%s\n" "'"$_up_sb"'/src"; }
+    has_command() { command -v "$1" >/dev/null 2>&1; }
+    source "'"$REPO_ROOT"'/lib/dot/ui.sh"
+    eval "$(sed -n "/^_upgrade_last_line()/,/^}/p;/^cmd_upgrade()/,/^}\$/p" "'"$REPO_ROOT"'/scripts/dot/commands/meta.sh")"
+    cmd_upgrade
+  ' 2>&1
+}
+mkdir -p "$_up_sb/xdg/nvim" "$_up_sb/xdg-empty"
+: >"$_up_sb/xdg/nvim/init.lua"
+cat >"$_up_sb/bin/chezmoi" <<STUB
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >"$_up_sb/chezmoi.args"
+# /dev/fd/0 -ef /dev/null is true only when stdin really is /dev/null,
+# not for a pipe, a file or a tty.
+if [ /dev/fd/0 -ef /dev/null ]; then echo CLOSED; else echo OPEN; fi >"$_up_sb/chezmoi.stdin"
+STUB
+cat >"$_up_sb/bin/nvim" <<STUB
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >"$_up_sb/nvim.args"
+STUB
+chmod +x "$_up_sb/bin"/*
+
+test_start "upgrade_runs_steps_with_stdin_closed_and_chezmoi_no_tty"
+_up_out3="$(_up_run "$_up_sb/xdg")"
+if grep -q -- '--no-tty' "$_up_sb/chezmoi.args" 2>/dev/null &&
+  grep -qx 'CLOSED' "$_up_sb/chezmoi.stdin" 2>/dev/null; then
+  ((TESTS_PASSED++)) || true
+  printf '%b\n' "  ${GREEN}✓${NC} $CURRENT_TEST: chezmoi gets --no-tty and no stdin"
+else
+  ((TESTS_FAILED++)) || true
+  printf '%b\n' "  ${RED}✗${NC} $CURRENT_TEST: args=[$(cat "$_up_sb/chezmoi.args" 2>/dev/null)] stdin=[$(cat "$_up_sb/chezmoi.stdin" 2>/dev/null)]"
+  printf '%s\n' "$_up_out3" | sed 's/^/      /'
+fi
+
+# `nvim -l` skips init.lua, so the headless upgrade script found no
+# lazy.nvim and logged "skipping plugin update" on every run — the phase
+# was a silent no-op. -u must point at the user's init.lua and come
+# BEFORE -l, because -l ends nvim's option processing.
+test_start "upgrade_nvim_loads_user_init_before_script"
+_nv_args="$(cat "$_up_sb/nvim.args" 2>/dev/null || true)"
+case "$_nv_args" in
+  *"--headless -u $_up_sb/xdg/nvim/init.lua -l "*headless-upgrade.lua)
+    ((TESTS_PASSED++)) || true
+    printf '%b\n' "  ${GREEN}✓${NC} $CURRENT_TEST: -u init.lua precedes -l"
+    ;;
+  *)
+    ((TESTS_FAILED++)) || true
+    printf '%b\n' "  ${RED}✗${NC} $CURRENT_TEST: nvim args=[$_nv_args]"
+    ;;
+esac
+
+test_start "upgrade_nvim_skips_visibly_when_no_init"
+rm -f "$_up_sb/nvim.args"
+_up_out4="$(_up_run "$_up_sb/xdg-empty")"
+if [[ ! -e "$_up_sb/nvim.args" ]] &&
+  printf '%s\n' "$_up_out4" | grep -q 'Neovim plugins' &&
+  printf '%s\n' "$_up_out4" | grep -q 'no init.lua'; then
+  ((TESTS_PASSED++)) || true
+  printf '%b\n' "  ${GREEN}✓${NC} $CURRENT_TEST: step reported as skipped, nvim not run"
+else
+  ((TESTS_FAILED++)) || true
+  printf '%b\n' "  ${RED}✗${NC} $CURRENT_TEST: expected a visible skip without invoking nvim"
+  printf '%s\n' "$_up_out4" | sed 's/^/      /'
+fi
+
+test_start "upgrade_chezmoi_overwrite_prompt_surfaces_hint"
+cat >"$_up_sb/bin/chezmoi" <<'STUB'
+#!/usr/bin/env bash
+echo ".npmrc has changed since chezmoi last wrote it (diff/overwrite/all-overwrite/skip/quit)? chezmoi: .npmrc: EOF" >&2
+exit 1
+STUB
+_up_out5="$(_up_run "$_up_sb/xdg")"
+if printf '%s\n' "$_up_out5" | grep -q 'has changed since chezmoi last wrote it' &&
+  printf '%s\n' "$_up_out5" | grep -q "chezmoi update --force"; then
+  ((TESTS_PASSED++)) || true
+  printf '%b\n' "  ${GREEN}✓${NC} $CURRENT_TEST: prompt failure explained with a fix"
+else
+  ((TESTS_FAILED++)) || true
+  printf '%b\n' "  ${RED}✗${NC} $CURRENT_TEST: hint missing"
+  printf '%s\n' "$_up_out5" | sed 's/^/      /'
+fi
 rm -rf "$_up_sb"
 
 # ── dot keys ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Three fixes found while running `dot upgrade` on a workstation whose `~/.npmrc` carried a token the chezmoi source did not.

- **`dot upgrade` no longer hangs on a question nobody can see.** Each phase captures stdout/stderr to a log, so when `chezmoi update` met a locally edited managed file it asked `has changed since chezmoi last wrote it?` on the terminal's tty and waited, while the run looked merely slow. The step runner now closes stdin and passes `--no-tty`; the prompt fails fast with EOF, the step is marked failed, and the surfaced tail carries a hint (`chezmoi apply` to choose per file, or `chezmoi update --force`).
- **The Neovim phase actually syncs plugins.** `nvim -l` does not load `init.lua`, so `scripts/nvim/headless-upgrade.lua` never found lazy.nvim and logged "skipping plugin update" on every run. The phase now passes `-u` with the user's `init.lua` (honouring `XDG_CONFIG_HOME` and `NVIM_APPNAME`) ahead of `-l`, and reports a visible skip when there is no config.
- **`dot doctor` stops warning about `cargo-install-update` without cargo.** The helper is only meaningful when there is a cargo for topgrade to run it through; the check now reports "not needed" there and keeps warning where a Rust toolchain exists.

Also fixes two pre-existing fragile tests: both "local manual build is absent" assertions depended on the developer never having run `tools/docs/build-manual.sh`. They now run against a tree with no `_build/`.

## Test plan

- [x] `tests/unit/dot-cli/test_dot_commands_meta.sh`: four new `cmd_upgrade` tests (`--no-tty` + `/dev/null` stdin, `-u` before `-l`, visible skip without `init.lua`, prompt hint). All four fail against the previous `meta.sh`, pass after.
- [x] `tests/unit/diagnostics/test_diagnostics_doctor_branches.sh`: drift scenario gets a `cargo` shim so WARN stays covered; FreeBSD fallback expects the "not needed" OK line. Fails against the previous `doctor.sh`.
- [x] Full unit + regression suite: 10291/10294; the 3 failures were coverage-exercise tests hitting their 60 s timeout under a load average above 90, and each passes when re-run alone.
- [x] Real `dot upgrade` run: Neovim phase now produces a full Lazy sync log; the chezmoi phase fails fast with the reason shown instead of hanging.
- [x] shellcheck (CI flags), shfmt, gitleaks, typos clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KUnYpCsjBMK1ZKm1KhYypA


---
THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co
