### PR TITLE
fix(drift): stop counting the always-run iCloud hook as chezmoi drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 This file documents all notable changes to this project.
 
+## Unreleased
+
+### Fixed
+
+- `dot doctor`, `dot health`, `dot fleet`, the scorecard and the drift dashboard
+  no longer report permanent drift on macOS. The iCloud symlink hook is a
+  `run_before_` script that chezmoi lists as pending on every apply by design,
+  which made plain `chezmoi verify` exit 1 and every `chezmoi status` line
+  count read 1 on a fully synchronised machine. Those callers now pass
+  `--exclude=always`; files, directories, symlinks and `run_once`/`run_onchange`
+  scripts still count as drift.
+
 ## v0.2.520 — 2026-09-10
 
 ### Added

--- a/scripts/diagnostics/doctor.sh
+++ b/scripts/diagnostics/doctor.sh
@@ -372,7 +372,11 @@ fi
 
 # --- State ---
 _section "State"
-if chezmoi verify &>/dev/null; then
+# --exclude=always: a run_before_/run_after_ script (the macOS iCloud hook)
+# is "pending" on every apply by design, so plain `verify` exits 1 forever
+# on a fully synchronised machine. Files, dirs, symlinks and run_once/
+# run_onchange scripts still count.
+if chezmoi verify --exclude=always &>/dev/null; then
   _ok "chezmoi" "synchronized"
 else
   _fail "chezmoi" "drifted (run dot drift)"

--- a/scripts/diagnostics/drift-dashboard.sh
+++ b/scripts/diagnostics/drift-dashboard.sh
@@ -71,7 +71,8 @@ fi
 # Class 1: chezmoi-managed drift
 # -----------------------------------------------------------------------------
 
-cm_status="$(chezmoi status 2>/dev/null || true)"
+# --exclude=always: always-run scripts are pending by design, not drift.
+cm_status="$(chezmoi status --exclude=always 2>/dev/null || true)"
 cm_count=0
 if [[ -n "$cm_status" ]]; then
   cm_count=$(printf '%s\n' "$cm_status" | wc -l | tr -d ' ')

--- a/scripts/diagnostics/health.sh
+++ b/scripts/diagnostics/health.sh
@@ -454,7 +454,8 @@ check_sync_status() {
   # needs warned about via the health dashboard.
   if has_command chezmoi; then
     local status_output
-    status_output=$(chezmoi status 2>/dev/null || echo "")
+    # --exclude=always: always-run scripts are pending by design, not drift.
+    status_output=$(chezmoi status --exclude=always 2>/dev/null || echo "")
     if [[ -z "$status_output" ]]; then
       check "Chezmoi sync" "pass"
     else

--- a/scripts/diagnostics/scorecard.sh
+++ b/scripts/diagnostics/scorecard.sh
@@ -52,7 +52,8 @@ perf_target=$(python3 -c 'import json,sys; j=json.loads(sys.stdin.read()); print
 
 # Drift count
 if command -v chezmoi >/dev/null 2>&1; then
-  drift_count=$(chezmoi status 2>/dev/null | wc -l | tr -d ' ')
+  # --exclude=always: always-run scripts are pending by design, not drift.
+  drift_count=$(chezmoi status --exclude=always 2>/dev/null | wc -l | tr -d ' ')
 else
   drift_count=0
 fi

--- a/scripts/dot/commands/fleet.sh
+++ b/scripts/dot/commands/fleet.sh
@@ -93,7 +93,8 @@ cmd_fleet_status() {
   local drift_status="clean"
   if has_command chezmoi; then
     local drift_output
-    drift_output="$(chezmoi status 2>/dev/null || true)"
+    # --exclude=always: always-run scripts are pending by design, not drift.
+    drift_output="$(chezmoi status --exclude=always 2>/dev/null || true)"
     if [[ -n "$drift_output" ]]; then
       drift_status="drifted"
     fi
@@ -168,7 +169,7 @@ cmd_fleet_drift() {
       fi
 
       local drift_output
-      drift_output="$(chezmoi status 2>/dev/null || true)"
+      drift_output="$(chezmoi status --exclude=always 2>/dev/null || true)"
 
       _fleet_drift_append_history "$drift_output"
 

--- a/tests/unit/diagnostics/test_chezmoi_drift_excludes_always_run_scripts.sh
+++ b/tests/unit/diagnostics/test_chezmoi_drift_excludes_always_run_scripts.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright (c) 2015-2026 Sebastien Rousseau
+# shellcheck disable=SC1090,SC1091,SC2034
+# Every place that turns `chezmoi status`/`verify` into a drift verdict must
+# exclude the `always` entry type. defaults/run_before_macos-icloud-symlinks
+# is pending on every apply by design, so without the flag a synchronised
+# macOS machine reads as drifted forever (v0.2.520 regression).
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+source "$SCRIPT_DIR/../../framework/assertions.sh"
+source "$SCRIPT_DIR/../../framework/coverage_helpers.sh"
+
+trap cov_teardown_sandbox EXIT
+cov_setup_sandbox
+
+test_start "always_run_script_exists_so_the_guard_is_load_bearing"
+assert_file_exists "$REPO_ROOT/defaults/run_before_macos-icloud-symlinks.sh.tmpl" \
+  "the always-run hook this guard exists for is still in the tree"
+
+# file|expected number of chezmoi status/verify calls|expected with --exclude=always
+while IFS='|' read -r rel calls; do
+  test_start "drift_caller_excludes_always_$(basename "$rel" .sh | tr -c 'a-z0-9\n' '_')"
+  f="$REPO_ROOT/$rel"
+  # Comment lines are not calls.
+  total="$(grep -vE '^[[:space:]]*#' "$f" | grep -cE 'chezmoi (status|verify)\b' || true)"
+  excl="$(grep -vE '^[[:space:]]*#' "$f" | grep -cE 'chezmoi (status|verify) --exclude=always\b' || true)"
+  assert_equals "$calls" "$total" "$rel: expected $calls chezmoi status/verify call(s)"
+  assert_equals "$total" "$excl" "$rel: every chezmoi status/verify call passes --exclude=always"
+done <<'LIST'
+scripts/diagnostics/doctor.sh|1
+scripts/diagnostics/health.sh|1
+scripts/diagnostics/scorecard.sh|1
+scripts/diagnostics/drift-dashboard.sh|1
+scripts/dot/commands/fleet.sh|2
+LIST
+
+print_summary

--- a/tests/unit/diagnostics/test_diagnostics_doctor_branches.sh
+++ b/tests/unit/diagnostics/test_diagnostics_doctor_branches.sh
@@ -210,7 +210,9 @@ _bench 10
 _shim chezmoi <<EOF
 #!/usr/bin/env bash
 case "\${1:-}" in
-  verify) exit 0 ;;
+  # Plain verify exits 1 on any machine with an always-run script; doctor
+  # must exclude that entry type or it reports permanent drift.
+  verify) case " \$* " in *" --exclude=always "*) exit 0 ;; *) exit 1 ;; esac ;;
   managed) printf '%s\n' "$S_HOME/.config/zsh/clean.zsh" "$S_HOME/.config/absent.conf" "$S_HOME/other.txt" ;;
 esac
 exit 0
@@ -467,7 +469,9 @@ EOF
 _shim chezmoi <<EOF
 #!/usr/bin/env bash
 case "\${1:-}" in
-  verify) exit 0 ;;
+  # Plain verify exits 1 on any machine with an always-run script; doctor
+  # must exclude that entry type or it reports permanent drift.
+  verify) case " \$* " in *" --exclude=always "*) exit 0 ;; *) exit 1 ;; esac ;;
   managed) printf '%s\n' "$S_HOME/.config/zsh/ghost.zsh" ;;
 esac
 exit 0


### PR DESCRIPTION
## Summary

Follow-up to #1038. The new macOS iCloud symlink hook is a `run_before_` script, which chezmoi lists as pending on **every** apply by design. Side effect: on a fully synchronised Mac, `chezmoi verify` exits 1 and `chezmoi status` prints one line, so:

- `dot doctor` reported `chezmoi drifted (run dot drift)` permanently,
- `dot health` failed its "Chezmoi sync" check,
- the scorecard, the drift dashboard and `dot fleet` status each counted one phantom drift signal.

Every call that turns `chezmoi status`/`verify` into a drift verdict now passes `--exclude=always`. That entry type is exactly the always-run scripts; files, directories, symlinks and `run_once`/`run_onchange` scripts still count as drift. `dot status` and `dot drift` stay raw pass-throughs.

## Test plan

- [x] `tests/unit/diagnostics/test_diagnostics_doctor_branches.sh`: the chezmoi shim's `verify` now exits 1 unless `--exclude=always` is passed. The healthy scenario fails against the previous `doctor.sh` (3 assertions) and passes after.
- [x] New `tests/unit/diagnostics/test_chezmoi_drift_excludes_always_run_scripts.sh`: asserts every drift caller passes the flag and that the always-run hook still exists (so the guard stays load-bearing). Fails 5/11 against the previous files, 11/11 after.
- [x] Existing tests for health, scorecard, drift dashboard, fleet and the dot driver: 12 files, all green.
- [x] On this machine after `dot upgrade` to v0.2.520: `dot doctor` went from `✗ chezmoi drifted` to `✓ synchronized`; `dot health` Chezmoi sync OK.
- [x] shellcheck (CI flags), shfmt, typos, gitleaks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KUnYpCsjBMK1ZKm1KhYypA

---
THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co
