### PR TITLE
fix(nvim): install markdown-preview's server with upstream's installer, not npm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ This file documents all notable changes to this project.
   count read 1 on a fully synchronised machine. Those callers now pass
   `--exclude=always`; files, directories, symlinks and `run_once`/`run_onchange`
   scripts still count as drift.
+- markdown-preview.nvim no longer blocks `dot upgrade`'s plugin sync. Its build
+  step ran `cd app && npm install`, which rewrote the upstream `app/yarn.lock`
+  on every build and left the checkout dirty, so Lazy refused to update it.
+  The spec now uses upstream's `mkdp#util#install`, which downloads the
+  prebuilt preview server and leaves the checkout untouched.
 
 ## v0.2.520 — 2026-09-10
 

--- a/defaults/dot_config/nvim/lua/plugins/markdown.lua
+++ b/defaults/dot_config/nvim/lua/plugins/markdown.lua
@@ -4,7 +4,13 @@ return {
     "iamcco/markdown-preview.nvim",
     ft = { "markdown" },
     cmd = { "MarkdownPreview", "MarkdownPreviewStop", "MarkdownPreviewToggle" },
-    build = "cd app && npm install",
+    -- Upstream's installer fetches the prebuilt preview server. The previous
+    -- `cd app && npm install` rewrote app/yarn.lock on every build (npm
+    -- resolves against registry.npmjs.org, the lockfile against yarnpkg.com),
+    -- which left the checkout dirty and made Lazy refuse every later update.
+    build = function()
+      vim.fn["mkdp#util#install"]()
+    end,
     init = function()
       vim.g.mkdp_auto_start = 0
       vim.g.mkdp_auto_close = 1


### PR DESCRIPTION
## Summary

`dot upgrade`'s Neovim phase has been logging `[markdown-preview.nvim] Please remove them to update` on every run. Cause: the spec's build step `cd app && npm install` rewrites the plugin's committed `app/yarn.lock` each time (npm resolves against `registry.npmjs.org`, the lockfile pins `registry.yarnpkg.com` URLs and sha1 fields), leaving the checkout dirty, and Lazy refuses to update a dirty plugin.

The spec now uses upstream's documented build, `mkdp#util#install`, which downloads the prebuilt preview server and touches nothing under git.

## Test plan

- [x] `tests/unit/nvim/test_nvim_plugin_markdown.sh`: 4/4.
- [x] `stylua --check` clean; the spec loads under `nvim --headless -u NONE -l`.
- [x] Diagnosed on this machine: `git -C ~/.local/share/nvim/lazy/markdown-preview.nvim diff --stat` shows only `app/yarn.lock`, 78 insertions / 83 deletions, all registry-URL rewrites.
- [ ] After merge and apply: `git -C ~/.local/share/nvim/lazy/markdown-preview.nvim checkout -- app/yarn.lock`, then `dot upgrade` should update the plugin and stay clean on the next run.

Related: copilot.lua and nvim-lint were blocked for a different reason (upstream commits CRLF files marked `text`, so git reports them modified on any checkout). That is fixed locally with a `.git/info/attributes` override in each plugin and needs no repo change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KUnYpCsjBMK1ZKm1KhYypA

---
THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co
